### PR TITLE
fix(quality): resolve lint debt and migrate remaining <img> usage

### DIFF
--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 import { createSupabaseBrowserClient } from '@/lib/supabase/browser-client';
-import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 
 export function LoginForm({ redirect }: { redirect: string }) {
@@ -11,7 +10,6 @@ export function LoginForm({ redirect }: { redirect: string }) {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [shake, setShake] = useState(false);
-  const router = useRouter();
 
   const supabase = createSupabaseBrowserClient();
 
@@ -20,7 +18,7 @@ export function LoginForm({ redirect }: { redirect: string }) {
     setError('');
     setLoading(true);
 
-    const { data, error } = await supabase.auth.signInWithPassword({
+    const { error } = await supabase.auth.signInWithPassword({
       email,
       password,
     });

--- a/app/api/ai/seo/generate-bulk/route.ts
+++ b/app/api/ai/seo/generate-bulk/route.ts
@@ -35,6 +35,17 @@ interface BulkItem {
   image?: string;
 }
 
+interface DestinationRow {
+  id: string;
+  name: string | null;
+  slug: string | null;
+  image: string | null;
+  description: string | null;
+  seo_title: string | null;
+  seo_description: string | null;
+  target_keyword: string | null;
+}
+
 export async function POST(request: NextRequest) {
   const auth = await getEditorAuth(request);
   if (!auth) return apiUnauthorized();
@@ -103,11 +114,15 @@ export async function POST(request: NextRequest) {
   ]);
 
   // Destinations (table may not exist in all environments)
-  let destinationsRes: { data: any[] | null; error: any } = { data: null, error: null };
+  let destinationsRes: { data: DestinationRow[] | null; error: { message: string } | null } = { data: null, error: null };
   try {
-    destinationsRes = await supabase
+    const { data, error } = await supabase
       .from('destinations')
       .select('id, name, slug, image, description, seo_title, seo_description, target_keyword');
+    destinationsRes = {
+      data: (data as DestinationRow[] | null) ?? null,
+      error: error ? { message: error.message } : null,
+    };
   } catch (e) {
     log.warn('Destinations table may not exist', { error: e instanceof Error ? e.message : String(e) });
   }
@@ -330,7 +345,7 @@ export async function POST(request: NextRequest) {
               after: { ...result.object, score: scoreAfter },
             },
           });
-        } catch (_err) {
+        } catch {
           processed++;
           send({
             type: 'item_error',

--- a/app/api/seo/score/route.ts
+++ b/app/api/seo/score/route.ts
@@ -358,9 +358,6 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     const d4Calc = calcD4Conversion({ image, description, amenities, inclusions, slug });
     const d4Score = d4Calc.score;
 
-    // D5 Competitive: always 0 until real GSC integration
-    const d5Score = 0;
-
     // Build check message details grouped by dimension
     const metaDetails = scorerResult.checks
       .filter((c) => c.dimension === 'meta' && !c.pass)

--- a/app/dashboard/[websiteId]/blog/[postId]/page.tsx
+++ b/app/dashboard/[websiteId]/blog/[postId]/page.tsx
@@ -59,7 +59,10 @@ export default function BlogEditorPage() {
 
   const { status: autoSaveStatus, saveNow } = useAutosave({
     data: post,
-    onSave: handleSave as any,
+    onSave: async (data) => {
+      if (!data) return;
+      await handleSave(data);
+    },
     debounceMs: 2000,
     enabled: !!post,
   });

--- a/app/dashboard/[websiteId]/contenido/page.tsx
+++ b/app/dashboard/[websiteId]/contenido/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import Image from 'next/image';
 import { createSupabaseBrowserClient } from '@/lib/supabase/browser-client';
 import { SeoHotelWorkflow } from '@/components/admin/seo-hotel-workflow';
 import { SeoActivityWorkflow } from '@/components/admin/seo-activity-workflow';
@@ -751,7 +752,14 @@ export default function ContenidoPage() {
                     <td className="px-3 py-2">
                       <div className="flex items-center gap-2 min-w-[240px]">
                         {row.image ? (
-                          <img src={row.image} alt="" className="w-8 h-8 rounded object-cover" />
+                          <Image
+                            src={row.image}
+                            alt=""
+                            width={32}
+                            height={32}
+                            unoptimized
+                            className="w-8 h-8 rounded object-cover"
+                          />
                         ) : (
                           <div className="w-8 h-8 rounded bg-[var(--studio-border)]" />
                         )}

--- a/app/dashboard/[websiteId]/layout.tsx
+++ b/app/dashboard/[websiteId]/layout.tsx
@@ -44,7 +44,9 @@ export default function WebsiteLayout({
       }
 
       if (!active) return;
-      setWebsiteName((website.content as any)?.siteName || website.subdomain);
+      const websiteContent = website.content as { siteName?: unknown } | null;
+      const siteName = typeof websiteContent?.siteName === 'string' ? websiteContent.siteName : '';
+      setWebsiteName(siteName || website.subdomain);
     }
 
     loadLayoutData();

--- a/app/dashboard/[websiteId]/settings/page.tsx
+++ b/app/dashboard/[websiteId]/settings/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase/browser-client';
 import { useWebsite } from '@/lib/admin/website-context';
-import { useAutosave } from '@/lib/hooks/use-autosave';
 import { ConfirmDialog } from '@/components/admin/confirm-dialog';
 import { DomainWizard } from '@/components/admin/domain-wizard';
 import { VersionTimeline } from '@/components/admin/version-timeline';
@@ -56,7 +55,7 @@ export default function SettingsTab() {
   }
 
   async function handleUnpublish() {
-    await save({ status: 'draft' } as any);
+    await save({ status: 'draft' });
     setShowUnpublish(false);
   }
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { createSupabaseBrowserClient } from '@/lib/supabase/browser-client';
 import { WebsiteCard } from '@/components/admin/website-card';
 import { EmptyState } from '@/components/admin/empty-state';
@@ -24,11 +24,7 @@ export default function DashboardPage() {
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const supabase = createSupabaseBrowserClient();
 
-  useEffect(() => {
-    loadWebsites();
-  }, []);
-
-  async function loadWebsites() {
+  const loadWebsites = useCallback(async () => {
     setLoading(true);
     setAccessError(null);
     try {
@@ -63,7 +59,11 @@ export default function DashboardPage() {
     } finally {
       setLoading(false);
     }
-  }
+  }, [supabase]);
+
+  useEffect(() => {
+    void loadWebsites();
+  }, [loadWebsites]);
 
   async function handleDelete(id: string) {
     await supabase

--- a/app/domain/[host]/[[...slug]]/page.tsx
+++ b/app/domain/[host]/[[...slug]]/page.tsx
@@ -14,10 +14,19 @@ import { SafeHtml } from '@/lib/sanitize';
 import { generateHreflangLinks } from '@/lib/seo/hreflang';
 import { getDefaultLegalContent } from '@/lib/legal-defaults';
 import Image from 'next/image';
+import type { ThemeInput } from '@/lib/theme/m3-theme-provider';
 
 interface CustomDomainPageProps {
   params: Promise<{ host: string; slug?: string[] }>;
   searchParams: Promise<{ category?: string; page?: string }>;
+}
+
+function getInitialTheme(theme: WebsiteData['theme'] | null | undefined): ThemeInput | undefined {
+  if (!theme?.tokens || !theme?.profile) return undefined;
+  return {
+    tokens: theme.tokens as ThemeInput['tokens'],
+    profile: theme.profile as ThemeInput['profile'],
+  };
 }
 
 async function getWebsiteByCustomDomain(customDomain: string): Promise<WebsiteData | null> {
@@ -95,7 +104,7 @@ export default async function CustomDomainPage({ params, searchParams }: CustomD
     const schemas = generateBlogListingSchemas(posts, website, baseUrl);
 
     return (
-      <M3ThemeProvider initialTheme={website.theme?.tokens ? ({ tokens: website.theme.tokens, profile: website.theme.profile } as any) : undefined}>
+      <M3ThemeProvider initialTheme={getInitialTheme(website.theme)}>
         <GoogleTagManager analytics={website.analytics} />
         <div className="min-h-screen flex flex-col">
           <GoogleTagManagerBody analytics={website.analytics} />
@@ -248,7 +257,7 @@ export default async function CustomDomainPage({ params, searchParams }: CustomD
     const schemas = generateBlogPostSchemas(post, website, baseUrl);
 
     return (
-      <M3ThemeProvider initialTheme={website.theme?.tokens ? ({ tokens: website.theme.tokens, profile: website.theme.profile } as any) : undefined}>
+      <M3ThemeProvider initialTheme={getInitialTheme(website.theme)}>
         <GoogleTagManager analytics={website.analytics} />
         <div className="min-h-screen flex flex-col">
           <GoogleTagManagerBody analytics={website.analytics} />
@@ -399,7 +408,7 @@ export default async function CustomDomainPage({ params, searchParams }: CustomD
     const legalContent = customContent || getDefaultLegalContent(legalType, siteName);
 
     return (
-      <M3ThemeProvider initialTheme={website.theme?.tokens ? ({ tokens: website.theme.tokens, profile: website.theme.profile } as any) : undefined}>
+      <M3ThemeProvider initialTheme={getInitialTheme(website.theme)}>
         <GoogleTagManager analytics={website.analytics} />
         <div className="min-h-screen flex flex-col">
           <GoogleTagManagerBody analytics={website.analytics} />
@@ -461,7 +470,7 @@ export default async function CustomDomainPage({ params, searchParams }: CustomD
   }
 
   return (
-    <M3ThemeProvider initialTheme={website.theme?.tokens ? ({ tokens: website.theme.tokens, profile: website.theme.profile } as any) : undefined}>
+    <M3ThemeProvider initialTheme={getInitialTheme(website.theme)}>
       {/* Google Tag Manager and Analytics Scripts */}
       <GoogleTagManager analytics={website.analytics} />
 
@@ -483,7 +492,7 @@ export default async function CustomDomainPage({ params, searchParams }: CustomD
 export const revalidate = 300;
 
 // Generate metadata
-export async function generateMetadata({ params, searchParams }: CustomDomainPageProps) {
+export async function generateMetadata({ params }: CustomDomainPageProps) {
   const { host, slug } = await params;
   const decodedHost = decodeURIComponent(host);
   const normalizedHost = decodedHost.toLowerCase().replace(/\.$/, '');

--- a/app/editor/[websiteId]/blog/[postId]/page.tsx
+++ b/app/editor/[websiteId]/blog/[postId]/page.tsx
@@ -18,6 +18,23 @@ interface BlogPostData {
   featured_image: string | null;
 }
 
+interface BlogScoreResult {
+  checks: Array<{
+    id: string;
+    category: 'seo' | 'readability' | 'structure' | 'geo';
+    pass: boolean;
+    score: number;
+    weight: number;
+    message: string;
+  }>;
+  overall: number;
+  seo: number;
+  readability: number;
+  structure: number;
+  geo: number;
+  grade: 'A' | 'B' | 'C' | 'D' | 'F';
+}
+
 interface BlogPostPageProps {
   params: Promise<{ websiteId: string; postId: string }>;
 }
@@ -37,7 +54,7 @@ export default function BlogPostPage({ params }: BlogPostPageProps) {
   const [seoTitle, setSeoTitle] = useState('');
   const [seoDescription, setSeoDescription] = useState('');
   const [tokenRef, setTokenRef] = useState<string | null>(null);
-  const [scoreResult, setScoreResult] = useState<any>(null);
+  const [scoreResult, setScoreResult] = useState<BlogScoreResult | null>(null);
   const [isScoring, setIsScoring] = useState(false);
 
   const getSupabase = useCallback(() => {

--- a/app/editor/[websiteId]/page.tsx
+++ b/app/editor/[websiteId]/page.tsx
@@ -8,6 +8,7 @@ import { renderSectionWithResult } from '@/lib/sections/render-section';
 import { EditableSection } from '@/components/editor/editable-section';
 import { EditorShell } from '@/components/editor/editor-shell';
 import type { WebsiteData, WebsiteSection } from '@/lib/supabase/get-website';
+import type { ThemeInput } from '@/lib/theme/m3-theme-provider';
 
 // ============================================================================
 // Legacy Editor Page — Puck removed (#569)
@@ -43,6 +44,14 @@ interface WebsiteSnapshot {
     config: Record<string, unknown>;
     content: Record<string, unknown>;
   }>;
+}
+
+function getInitialTheme(theme: WebsiteSnapshot['website']['theme'] | null | undefined): ThemeInput | undefined {
+  if (!theme?.tokens || !theme?.profile) return undefined;
+  return {
+    tokens: theme.tokens as ThemeInput['tokens'],
+    profile: theme.profile as ThemeInput['profile'],
+  };
 }
 
 export default function EditorPage({ params }: EditorPageProps) {
@@ -217,7 +226,7 @@ export default function EditorPage({ params }: EditorPageProps) {
   // Legacy Canvas Mode (read-only preview)
   // ============================================================================
   return (
-    <M3ThemeProvider initialTheme={data.website.theme?.tokens ? ({ tokens: data.website.theme.tokens, profile: data.website.theme.profile } as any) : undefined}>
+    <M3ThemeProvider initialTheme={getInitialTheme(data.website.theme)}>
       <div className="min-h-screen">
         {(data.sections || []).map((section) => {
           const sectionForRender = {

--- a/app/site/[subdomain]/buscar/search-client.tsx
+++ b/app/site/[subdomain]/buscar/search-client.tsx
@@ -101,7 +101,7 @@ export function SearchPageClient({ subdomain, initialQuery, website }: SearchPag
     }, 400);
 
     return () => clearTimeout(timeout);
-  }, [query, subdomain]);
+  }, [query, subdomain, website.id]);
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();

--- a/app/site/[subdomain]/layout.tsx
+++ b/app/site/[subdomain]/layout.tsx
@@ -9,11 +9,20 @@ import { SmoothScroll } from '@/components/ui/smooth-scroll';
 import { GoogleTagManager, GoogleTagManagerBody } from '@/components/analytics/google-tag-manager';
 import { buildNavTree, getDefaultNavigation } from '@/lib/utils/navigation';
 import { getBasePath } from '@/lib/utils/base-path';
+import type { ThemeInput } from '@/lib/theme/m3-theme-provider';
 import '@/app/globals.css';
 
 interface SiteLayoutProps {
   children: React.ReactNode;
   params: Promise<{ subdomain: string }>;
+}
+
+function getInitialTheme(theme: { tokens: Record<string, unknown>; profile: Record<string, unknown> } | null | undefined): ThemeInput | undefined {
+  if (!theme?.tokens || !theme?.profile) return undefined;
+  return {
+    tokens: theme.tokens as ThemeInput['tokens'],
+    profile: theme.profile as ThemeInput['profile'],
+  };
 }
 
 // Generate metadata for SEO
@@ -89,7 +98,7 @@ export default async function SiteLayout({ children, params }: SiteLayoutProps) 
     : getDefaultNavigation(website.sections, basePath);
 
   return (
-    <M3ThemeProvider initialTheme={website.theme?.tokens ? ({ tokens: website.theme.tokens, profile: website.theme.profile } as any) : undefined}>
+    <M3ThemeProvider initialTheme={getInitialTheme(website.theme)}>
       {/* Google Tag Manager and Analytics Scripts */}
       <GoogleTagManager analytics={website.analytics} />
 

--- a/app/site/[subdomain]/planners/[slug]/page.tsx
+++ b/app/site/[subdomain]/planners/[slug]/page.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { getWebsiteBySubdomain } from '@/lib/supabase/get-website';
 import { getPlanners, slugify } from '@/lib/supabase/get-planners';
-import type { PlannerData } from '@/lib/supabase/get-planners';
 import { getReviewsForContext } from '@/lib/supabase/get-reviews';
 import { ReviewsBlock } from '@/components/site/reviews-block';
 

--- a/components/aceternity/text-generate-effect.tsx
+++ b/components/aceternity/text-generate-effect.tsx
@@ -30,7 +30,7 @@ export const TextGenerateEffect = ({
         delay: stagger(0.2),
       }
     )
-  }, [scope.current])
+  }, [animate, duration, filter])
 
   const renderWords = () => {
     return (

--- a/components/admin/admin-topbar.tsx
+++ b/components/admin/admin-topbar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import Image from 'next/image';
 import { createSupabaseBrowserClient } from '@/lib/supabase/browser-client';
 import { useRouter } from 'next/navigation';
 import { Moon, Sun } from 'lucide-react';
@@ -134,9 +135,12 @@ export function AdminTopbar({
             className="flex items-center gap-2 rounded-full hover:ring-2 hover:ring-[var(--studio-focus)]/50 transition-all"
           >
             {avatarUrl ? (
-              <img
+              <Image
                 src={avatarUrl}
                 alt={userName || 'User'}
+                width={32}
+                height={32}
+                unoptimized
                 className="w-8 h-8 rounded-full object-cover"
               />
             ) : (

--- a/components/admin/blog-editor-admin.tsx
+++ b/components/admin/blog-editor-admin.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useMemo, useCallback, useRef, lazy, Suspense } from 'react';
+import { useState, useMemo, lazy, Suspense } from 'react';
+import Image from 'next/image';
 import type { AutosaveStatus } from '@/lib/hooks/use-autosave';
 
 // Lazy-load TipTap BlogEditor to avoid SSR issues with ProseMirror
@@ -172,7 +173,14 @@ export function BlogEditorComponent({
               <h4 className="text-sm font-semibold text-slate-900 dark:text-white mb-3">Featured Image</h4>
               {post.featured_image ? (
                 <div className="relative">
-                  <img src={post.featured_image} alt="" className="w-full h-40 object-cover rounded-lg" />
+                  <Image
+                    src={post.featured_image}
+                    alt=""
+                    width={640}
+                    height={160}
+                    unoptimized
+                    className="w-full h-40 object-cover rounded-lg"
+                  />
                   <button
                     onClick={() => onChange({ ...post, featured_image: null })}
                     className="absolute top-2 right-2 p-1 bg-black/50 rounded-full text-white"

--- a/components/admin/brand-kit-editor.tsx
+++ b/components/admin/brand-kit-editor.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Image from 'next/image';
 import { useAutosave } from '@/lib/hooks/use-autosave';
 import type { WebsiteData } from '@bukeer/website-contract';
 
@@ -10,13 +11,15 @@ interface BrandKitEditorProps {
 }
 
 export function BrandKitEditor({ website, onSave }: BrandKitEditorProps) {
-  const content = website.content || {} as any;
-  const profile = (website.theme?.profile || {}) as any;
+  const content = website.content;
+  const profile = website.theme?.profile ?? {};
+  const initialBrandMood =
+    typeof profile.brandMood === 'string' ? profile.brandMood : 'corporate';
 
   const [logo, setLogo] = useState(content.logo || '');
   const [logoLight, setLogoLight] = useState(content.logoLight || '');
   const [logoDark, setLogoDark] = useState(content.logoDark || '');
-  const [brandMood, setBrandMood] = useState(profile.brandMood || 'corporate');
+  const [brandMood, setBrandMood] = useState(initialBrandMood);
 
   const MOODS = [
     { id: 'adventurous', label: 'Adventurous', desc: 'Bold & dynamic' },
@@ -36,9 +39,9 @@ export function BrandKitEditor({ website, onSave }: BrandKitEditorProps) {
         content: { ...content, logo: data.logo, logoLight: data.logoLight, logoDark: data.logoDark },
         theme: {
           ...website.theme,
-          profile: { ...(website.theme?.profile as any), brandMood: data.brandMood },
+          profile: { ...profile, brandMood: data.brandMood },
         },
-      } as any);
+      });
     },
   });
 
@@ -51,7 +54,14 @@ export function BrandKitEditor({ website, onSave }: BrandKitEditorProps) {
         <h3 className="text-sm font-semibold text-slate-900 dark:text-white mb-3">Logo</h3>
         {logo ? (
           <div className="relative inline-block">
-            <img src={logo} alt="Logo" className="h-16 object-contain" />
+            <Image
+              src={logo}
+              alt="Logo"
+              width={256}
+              height={64}
+              unoptimized
+              className="h-16 w-auto object-contain"
+            />
             <button
               onClick={() => setLogo('')}
               className="absolute -top-2 -right-2 p-1 bg-red-500 text-white rounded-full"
@@ -88,7 +98,14 @@ export function BrandKitEditor({ website, onSave }: BrandKitEditorProps) {
             {logoLight ? (
               <div className="relative mb-3">
                 <div className="rounded-lg p-4 flex items-center justify-center" style={{ backgroundColor: '#ffffff', border: '1px solid #e2e8f0' }}>
-                  <img src={logoLight} alt="Logo fondos claros" className="h-12 object-contain" />
+                  <Image
+                    src={logoLight}
+                    alt="Logo fondos claros"
+                    width={240}
+                    height={48}
+                    unoptimized
+                    className="h-12 w-auto object-contain"
+                  />
                 </div>
                 <button
                   onClick={() => setLogoLight('')}
@@ -116,7 +133,14 @@ export function BrandKitEditor({ website, onSave }: BrandKitEditorProps) {
             {logoDark ? (
               <div className="relative mb-3">
                 <div className="rounded-lg p-4 flex items-center justify-center" style={{ backgroundColor: '#1a1a2e' }}>
-                  <img src={logoDark} alt="Logo fondos oscuros" className="h-12 object-contain" />
+                  <Image
+                    src={logoDark}
+                    alt="Logo fondos oscuros"
+                    width={240}
+                    height={48}
+                    unoptimized
+                    className="h-12 w-auto object-contain"
+                  />
                 </div>
                 <button
                   onClick={() => setLogoDark('')}

--- a/components/admin/bulk-seo-modal.tsx
+++ b/components/admin/bulk-seo-modal.tsx
@@ -184,7 +184,7 @@ export function BulkSeoModal({ isOpen, onClose, websiteId, items, onApplied }: B
     setApplying(false);
     setState('applied');
     onApplied();
-  }, [generated, onApplied]);
+  }, [generated, onApplied, websiteId]);
 
   const handleClose = () => {
     if (abortRef.current) {

--- a/components/admin/command-palette.tsx
+++ b/components/admin/command-palette.tsx
@@ -18,6 +18,12 @@ interface SearchResult {
   type: 'website' | 'action';
 }
 
+interface WebsiteSearchRow {
+  id: string;
+  subdomain: string;
+  content: { siteName?: string } | null;
+}
+
 export function CommandPalette({ open, onClose }: CommandPaletteProps) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SearchResult[]>([]);
@@ -54,7 +60,7 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
         .ilike('subdomain', `%${query}%`)
         .limit(5);
 
-      const websites: SearchResult[] = (data || []).map((w: any) => ({
+      const websites: SearchResult[] = ((data as WebsiteSearchRow[] | null) || []).map((w) => ({
         id: w.id,
         title: w.content?.siteName || w.subdomain,
         subtitle: w.subdomain,

--- a/components/admin/content-editor.tsx
+++ b/components/admin/content-editor.tsx
@@ -10,7 +10,7 @@ interface ContentEditorProps {
 }
 
 export function ContentEditor({ website, onSave }: ContentEditorProps) {
-  const c = website.content || {} as any;
+  const c = website.content;
   const [siteName, setSiteName] = useState(c.siteName || '');
   const [tagline, setTagline] = useState(c.tagline || '');
   const [email, setEmail] = useState(c.contact?.email || '');
@@ -31,7 +31,7 @@ export function ContentEditor({ website, onSave }: ContentEditorProps) {
           contact: { email: d.email, phone: d.phone, address: d.address },
           social: d.social,
         },
-      } as any);
+      });
     },
   });
 

--- a/components/admin/domain-wizard.tsx
+++ b/components/admin/domain-wizard.tsx
@@ -13,7 +13,6 @@ export function DomainWizard({ websiteId, currentDomain }: DomainWizardProps) {
   const [domain, setDomain] = useState(currentDomain || '');
   const [step, setStep] = useState(currentDomain ? 2 : 0);
   const [verifying, setVerifying] = useState(false);
-  const [verified, setVerified] = useState(false);
 
   async function saveDomain() {
     await supabase.from('websites').update({ custom_domain: domain }).eq('id', websiteId);
@@ -25,7 +24,6 @@ export function DomainWizard({ websiteId, currentDomain }: DomainWizardProps) {
     // In production, this would check DNS records
     setTimeout(() => {
       setVerifying(false);
-      setVerified(true);
       setStep(2);
     }, 2000);
   }

--- a/components/admin/seo-baseline-28d.tsx
+++ b/components/admin/seo-baseline-28d.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import type { AnalyticsOverviewDTO } from '@/lib/seo/dto';
-import { StudioBadge, StudioButton } from '@/components/studio/ui/primitives';
+import { StudioBadge } from '@/components/studio/ui/primitives';
 import { cn } from '@/lib/utils';
 
 interface SeoBaseline28DProps {
@@ -65,7 +65,8 @@ function TrendBadge({ trendValue }: { trendValue: number | null | undefined }) {
   return <StudioBadge tone="neutral">→ Estable</StudioBadge>;
 }
 
-export function SeoBaseline28D({ overview, websiteId: _websiteId }: SeoBaseline28DProps) {
+export function SeoBaseline28D({ overview, websiteId }: SeoBaseline28DProps) {
+  void websiteId;
   const [brandFilter, setBrandFilter] = useState<BrandFilter>('all');
   const isLoading = overview === null;
 

--- a/components/admin/seo-competitive-analysis.tsx
+++ b/components/admin/seo-competitive-analysis.tsx
@@ -284,7 +284,7 @@ function KeywordGap({
 
 // ─── Section C: Backlinks Summary KPI cards ───────────────────────────────────
 
-function BacklinksSummary({ websiteId }: { websiteId: string }) {
+function BacklinksSummary() {
   const kpis = [
     { label: 'Dominios referentes', value: '—' },
     { label: 'Total Backlinks', value: '—' },
@@ -431,7 +431,7 @@ export function SeoCompetitiveAnalysis({ competitors, websiteId }: SeoCompetitiv
 
       {/* C + D: Two-column layout for backlinks summary and anchor distribution */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <BacklinksSummary websiteId={websiteId} />
+        <BacklinksSummary />
         <AnchorDistribution />
       </div>
 

--- a/components/admin/seo-editor.tsx
+++ b/components/admin/seo-editor.tsx
@@ -10,8 +10,8 @@ interface SeoEditorProps {
 }
 
 export function SeoEditor({ website, onSave }: SeoEditorProps) {
-  const c = website.content || {} as any;
-  const a = website.analytics || {} as any;
+  const c = website.content;
+  const a = website.analytics ?? {};
 
   const [seoTitle, setSeoTitle] = useState(c.seo?.title || '');
   const [seoDesc, setSeoDesc] = useState(c.seo?.description || '');
@@ -34,7 +34,7 @@ export function SeoEditor({ website, onSave }: SeoEditorProps) {
           custom_head_scripts: d.headScripts,
           custom_body_scripts: d.bodyScripts,
         },
-      } as any);
+      });
     },
   });
 

--- a/components/admin/seo-item-detail.tsx
+++ b/components/admin/seo-item-detail.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import Image from 'next/image';
 import { cn } from '@/lib/utils';
 import { StudioTabs, StudioButton, StudioBadge, StudioInput, StudioSelect, StudioTextarea } from '@/components/studio/ui/primitives';
 import { createSupabaseBrowserClient } from '@/lib/supabase/browser-client';
@@ -1807,7 +1808,14 @@ export function SeoItemDetail({
 
           <div className="border border-[var(--studio-border)] rounded overflow-hidden max-w-lg">
             {item.image ? (
-              <img src={item.image} alt={item.name} className="w-full h-48 object-cover" />
+              <Image
+                src={item.image}
+                alt={item.name}
+                width={640}
+                height={192}
+                unoptimized
+                className="w-full h-48 object-cover"
+              />
             ) : (
               <div className="w-full h-48 bg-[var(--studio-border)] flex items-center justify-center text-[var(--studio-text-muted)] text-sm">
                 No image

--- a/components/admin/seo-locale-settings.tsx
+++ b/components/admin/seo-locale-settings.tsx
@@ -58,7 +58,8 @@ interface SeoLocaleSettingsProps {
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export function SeoLocaleSettings({ websiteId: _websiteId }: SeoLocaleSettingsProps) {
+export function SeoLocaleSettings({ websiteId }: SeoLocaleSettingsProps) {
+  void websiteId;
   // A) Locales activos
   const [activeLocales, setActiveLocales] = useState<string[]>(['es-CO']);
   const [showAddForm, setShowAddForm] = useState(false);

--- a/components/admin/seo-okr-cycle.tsx
+++ b/components/admin/seo-okr-cycle.tsx
@@ -339,7 +339,8 @@ function Ciclo90D() {
 
 // ─── Main export ──────────────────────────────────────────────────────────────
 
-export function SeoOkrCycle({ websiteId: _websiteId, overview }: SeoOkrCycleProps) {
+export function SeoOkrCycle({ websiteId, overview }: SeoOkrCycleProps) {
+  void websiteId;
   return (
     <div className="space-y-3 mt-4">
       {/* Section title */}

--- a/components/admin/seo-overview-table.tsx
+++ b/components/admin/seo-overview-table.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
+import Image from 'next/image';
 import { useParams, useRouter } from 'next/navigation';
 import type { ScoredItem } from '@/lib/seo/scored-item';
 
@@ -126,7 +127,14 @@ export function SeoOverviewTable({ items }: SeoOverviewTableProps) {
                 >
                   <td className="px-3 py-2">
                     {item.image ? (
-                      <img src={item.image} alt="" className="w-8 h-8 rounded object-cover" />
+                      <Image
+                        src={item.image}
+                        alt=""
+                        width={32}
+                        height={32}
+                        unoptimized
+                        className="w-8 h-8 rounded object-cover"
+                      />
                     ) : (
                       <div className="w-8 h-8 rounded bg-[var(--studio-border)] flex items-center justify-center">
                         <svg className="w-4 h-4 text-[var(--studio-text-muted)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/components/admin/structure-editor.tsx
+++ b/components/admin/structure-editor.tsx
@@ -23,22 +23,33 @@ interface StructureEditorProps {
 }
 
 export function StructureEditor({ website, onSave }: StructureEditorProps) {
-  const siteParts = (website.site_parts || {}) as any;
-  const [headerVariant, setHeaderVariant] = useState(siteParts.header?.variant || 'left-logo');
-  const [footerVariant, setFooterVariant] = useState(siteParts.footer?.variant || '4-column');
+  const siteParts = (website.site_parts ?? {}) as Partial<NonNullable<WebsiteData['site_parts']>>;
+  const [headerVariant, setHeaderVariant] = useState<string>(siteParts.header?.variant || 'left-logo');
+  const [footerVariant, setFooterVariant] = useState<string>(siteParts.footer?.variant || '4-column');
   const [stickyMobile, setStickyMobile] = useState(siteParts.mobileStickyBar?.enabled ?? true);
 
   const { status } = useAutosave({
     data: { headerVariant, footerVariant, stickyMobile },
     onSave: async (data) => {
-      await onSave({
-        site_parts: {
-          ...siteParts,
-          header: { ...siteParts.header, variant: data.headerVariant },
-          footer: { ...siteParts.footer, variant: data.footerVariant },
-          mobileStickyBar: { ...siteParts.mobileStickyBar, enabled: data.stickyMobile },
+      const updatedSiteParts: NonNullable<WebsiteData['site_parts']> = {
+        header: {
+          blocks: siteParts.header?.blocks ?? ['logo', 'nav', 'cta', 'theme_toggle'],
+          shrinkOnScroll: siteParts.header?.shrinkOnScroll ?? false,
+          variant: data.headerVariant as NonNullable<WebsiteData['site_parts']>['header']['variant'],
         },
-      } as any);
+        footer: {
+          blocks: siteParts.footer?.blocks ?? ['logo', 'nav', 'legal', 'contact', 'social', 'copyright'],
+          variant: data.footerVariant as NonNullable<WebsiteData['site_parts']>['footer']['variant'],
+        },
+        mobileStickyBar: {
+          buttons: siteParts.mobileStickyBar?.buttons ?? [],
+          enabled: data.stickyMobile,
+        },
+      };
+
+      await onSave({
+        site_parts: updatedSiteParts,
+      });
     },
   });
 

--- a/components/admin/template-section.tsx
+++ b/components/admin/template-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase/browser-client';
 import { useWebsite } from '@/lib/admin/website-context';
@@ -33,11 +34,7 @@ export function TemplateSection({ websiteId }: { websiteId: string }) {
   const [applying, setApplying] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    loadCurrentTemplate();
-  }, [website?.template_id]);
-
-  async function loadCurrentTemplate() {
+  const loadCurrentTemplate = useCallback(async () => {
     setLoading(true);
     if (!website?.template_id) {
       setCurrentTemplate(null);
@@ -53,7 +50,11 @@ export function TemplateSection({ websiteId }: { websiteId: string }) {
 
     setCurrentTemplate(data as TemplateInfo | null);
     setLoading(false);
-  }
+  }, [supabase, website?.template_id]);
+
+  useEffect(() => {
+    loadCurrentTemplate();
+  }, [loadCurrentTemplate]);
 
   function handleSelectTemplate(templateId: string) {
     setSelectedTemplateId(templateId);
@@ -107,9 +108,12 @@ export function TemplateSection({ websiteId }: { websiteId: string }) {
         <h3 className="text-sm font-semibold text-[var(--studio-text)] mb-3">Current Template</h3>
         <div className="studio-card p-4 flex items-center gap-4">
           {currentTemplate?.thumbnail_url ? (
-            <img
+            <Image
               src={currentTemplate.thumbnail_url}
               alt={currentTemplate.name}
+              width={64}
+              height={64}
+              unoptimized
               className="w-16 h-16 rounded-lg object-cover bg-[var(--studio-surface-elevated)]"
             />
           ) : (

--- a/components/admin/template-selector.tsx
+++ b/components/admin/template-selector.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
 import { createSupabaseBrowserClient } from '@/lib/supabase/browser-client';
 
@@ -42,11 +43,7 @@ export function TemplateSelector({ open, currentTemplateId, onSelect, onClose }:
   const [templates, setTemplates] = useState<TemplateItem[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    if (open) loadTemplates();
-  }, [open]);
-
-  async function loadTemplates() {
+  const loadTemplates = useCallback(async () => {
     setLoading(true);
     const { data } = await supabase
       .from('website_templates')
@@ -58,7 +55,11 @@ export function TemplateSelector({ open, currentTemplateId, onSelect, onClose }:
 
     setTemplates((data as TemplateItem[]) || []);
     setLoading(false);
-  }
+  }, [supabase]);
+
+  useEffect(() => {
+    if (open) loadTemplates();
+  }, [open, loadTemplates]);
 
   return (
     <AnimatePresence>
@@ -121,9 +122,12 @@ export function TemplateSelector({ open, currentTemplateId, onSelect, onClose }:
                         }`}
                       >
                         {tpl.thumbnail_url ? (
-                          <img
+                          <Image
                             src={tpl.thumbnail_url}
                             alt={tpl.name}
+                            width={240}
+                            height={80}
+                            unoptimized
                             className="w-full h-20 object-cover rounded-lg bg-[var(--studio-surface-elevated)]"
                           />
                         ) : (

--- a/components/admin/theme-editor.tsx
+++ b/components/admin/theme-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import { useAutosave } from '@/lib/hooks/use-autosave';
 import type { WebsiteData } from '@bukeer/website-contract';
 
@@ -31,31 +31,47 @@ interface ThemeEditorProps {
 
 export function ThemeEditor({ website, onSave }: ThemeEditorProps) {
   const theme = website.theme || { tokens: { colors: { seedColor: '#1976D2' } }, profile: {} };
-  const tokens = theme.tokens as any;
-  const profile = theme.profile as any;
+  const tokens = theme.tokens ?? {};
+  const profile = theme.profile ?? {};
+  const colors =
+    tokens.colors && typeof tokens.colors === 'object'
+      ? (tokens.colors as Record<string, unknown>)
+      : {};
+  const typography =
+    profile.typography && typeof profile.typography === 'object'
+      ? (profile.typography as Record<string, unknown>)
+      : {};
+  const layout =
+    profile.layout && typeof profile.layout === 'object'
+      ? (profile.layout as Record<string, unknown>)
+      : {};
 
-  const [seedColor, setSeedColor] = useState(tokens?.colors?.seedColor || '#1976D2');
-  const [brandMood, setBrandMood] = useState(profile?.brandMood || 'corporate');
-  const [headingFont, setHeadingFont] = useState(profile?.typography?.headingFont || 'Montserrat');
-  const [bodyFont, setBodyFont] = useState(profile?.typography?.bodyFont || 'Open Sans');
-  const [radius, setRadius] = useState(profile?.radius ?? 12);
-  const [layoutVariant, setLayoutVariant] = useState(profile?.layout?.variant || 'modern');
+  const [seedColor, setSeedColor] = useState(typeof colors.seedColor === 'string' ? colors.seedColor : '#1976D2');
+  const [brandMood, setBrandMood] = useState(typeof profile.brandMood === 'string' ? profile.brandMood : 'corporate');
+  const [headingFont, setHeadingFont] = useState(
+    typeof typography.headingFont === 'string' ? typography.headingFont : 'Montserrat'
+  );
+  const [bodyFont, setBodyFont] = useState(
+    typeof typography.bodyFont === 'string' ? typography.bodyFont : 'Open Sans'
+  );
+  const [radius, setRadius] = useState(typeof profile.radius === 'number' ? profile.radius : 12);
+  const [layoutVariant, setLayoutVariant] = useState(typeof layout.variant === 'string' ? layout.variant : 'modern');
 
   const themeData = {
-    tokens: { ...tokens, colors: { ...tokens?.colors, seedColor } },
+    tokens: { ...tokens, colors: { ...colors, seedColor } },
     profile: {
       ...profile,
       brandMood,
       typography: { headingFont, bodyFont },
       radius,
-      layout: { ...profile?.layout, variant: layoutVariant },
+      layout: { ...layout, variant: layoutVariant },
     },
   };
 
   const { status } = useAutosave({
     data: themeData,
     onSave: async (data) => {
-      await onSave({ theme: data } as any);
+      await onSave({ theme: data });
     },
     debounceMs: 1500,
   });

--- a/components/admin/website-card.tsx
+++ b/components/admin/website-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import Image from 'next/image';
 import { motion } from 'framer-motion';
 import { StatusBadge } from './status-badge';
 
@@ -33,7 +34,14 @@ export function WebsiteCard({
         {/* Preview thumbnail */}
         <div className="aspect-video bg-[var(--studio-panel)] relative overflow-hidden">
           {ogImage ? (
-            <img src={ogImage} alt={name} className="w-full h-full object-cover" />
+            <Image
+              src={ogImage}
+              alt={name}
+              fill
+              unoptimized
+              sizes="(max-width: 1024px) 100vw, 33vw"
+              className="w-full h-full object-cover"
+            />
           ) : (
             <div className="flex items-center justify-center h-full text-[var(--studio-text-muted)]">
               <svg className="w-12 h-12" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/components/analytics/google-tag-manager.tsx
+++ b/components/analytics/google-tag-manager.tsx
@@ -15,6 +15,7 @@
  */
 
 import Script from 'next/script';
+import Image from 'next/image';
 
 export interface AnalyticsConfig {
   gtm_id?: string;           // Google Tag Manager ID (GTM-XXXXXX)
@@ -127,9 +128,10 @@ export function FacebookPixelScript({ analytics }: GoogleTagManagerProps) {
         }}
       />
       <noscript>
-        <img
-          height="1"
-          width="1"
+        <Image
+          height={1}
+          width={1}
+          unoptimized
           style={{ display: 'none' }}
           src={`https://www.facebook.com/tr?id=${analytics.facebook_pixel_id}&ev=PageView&noscript=1`}
           alt=""

--- a/components/editor/blog-editor.tsx
+++ b/components/editor/blog-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, type ComponentProps } from 'react';
 import { GradeBadge, ScoreDetailPanel, ScoreWarningBanner } from './score-display';
 import { TiptapEditor } from './tiptap-editor';
 import { TiptapToolbar } from './tiptap-toolbar';
@@ -8,22 +8,14 @@ import { SlashMenu } from './slash-command';
 import type { Editor } from '@tiptap/react';
 import '../../styles/tiptap-bukeer.css';
 
-interface ScoringResult {
-  overall: number;
-  seo: number;
-  readability: number;
-  structure: number;
-  geo: number;
-  grade: 'A' | 'B' | 'C' | 'D' | 'F';
-  checks: any[];
-}
+type ScoringResult = NonNullable<ComponentProps<typeof ScoreDetailPanel>['score']>;
 
 interface BlogEditorProps {
   initialContent?: string;
   initialTitle?: string;
   onChange?: (content: string) => void;
   onTitleChange?: (title: string) => void;
-  onSeoDataChange?: (data: { faqItems?: any[]; seoKeywords?: string[]; tldr?: string }) => void;
+  onSeoDataChange?: (data: { faqItems?: unknown[]; seoKeywords?: string[]; tldr?: string }) => void;
   websiteId: string;
   postId?: string;
   authToken?: string;
@@ -46,7 +38,6 @@ export function BlogEditor({
   onTitleChange,
   onSeoDataChange,
   websiteId,
-  postId,
   authToken,
   scoreResult,
   onScoreRefresh,
@@ -61,10 +52,6 @@ export function BlogEditor({
   // Live content ref — avoids re-rendering the entire tree on every keystroke.
   const contentRef = useRef(initialContent);
   const wordCountTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const authHeaders: Record<string, string> = authToken
-    ? { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` }
-    : { 'Content-Type': 'application/json' };
 
   const handleTitleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -118,11 +105,15 @@ export function BlogEditor({
       setAiError(null);
 
       try {
+        const requestHeaders: Record<string, string> = authToken
+          ? { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` }
+          : { 'Content-Type': 'application/json' };
+
         if (action === 'draft' || action === 'draft-v2') {
           const isV2 = action === 'draft-v2';
           const res = await fetch('/api/ai/editor/generate-blog', {
             method: 'POST',
-            headers: authHeaders,
+            headers: requestHeaders,
             body: JSON.stringify({
               topic: title || 'Travel tips',
               locale: 'es',
@@ -144,7 +135,7 @@ export function BlogEditor({
         } else if (action === 'improve' || action === 'seo') {
           const res = await fetch('/api/ai/editor/improve-text', {
             method: 'POST',
-            headers: authHeaders,
+            headers: requestHeaders,
             body: JSON.stringify({ text: contentRef.current, action: 'rewrite' }),
           });
           if (!res.ok) throw new Error('Failed to improve');
@@ -153,7 +144,7 @@ export function BlogEditor({
         } else if (action === 'translate') {
           const res = await fetch('/api/ai/editor/improve-text', {
             method: 'POST',
-            headers: authHeaders,
+            headers: requestHeaders,
             body: JSON.stringify({
               text: contentRef.current,
               action: 'translate',
@@ -170,7 +161,7 @@ export function BlogEditor({
         setIsGenerating(false);
       }
     },
-    [title, setEditorContent, onTitleChange, onSeoDataChange, authHeaders]
+    [authToken, title, setEditorContent, onTitleChange, onSeoDataChange]
   );
 
   return (
@@ -272,7 +263,7 @@ export function BlogEditor({
       {/* Status bar */}
       <div className="tiptap-status-bar">
         <span className="word-count">{wordCount} palabras</span>
-        <span>Escribe "/" para insertar bloques · WYSIWYG · Markdown</span>
+        <span>Escribe &quot;/&quot; para insertar bloques · WYSIWYG · Markdown</span>
       </div>
 
       {/* Slash command menu — rendered via portal, outside TiptapEditor tree */}

--- a/components/editor/editor-shell.tsx
+++ b/components/editor/editor-shell.tsx
@@ -5,7 +5,6 @@ import { createClient } from '@supabase/supabase-js';
 import {
   DndContext,
   DragEndEvent,
-  DragOverlay,
   closestCenter,
   PointerSensor,
   useSensor,
@@ -25,7 +24,8 @@ import { Toolbar, type ViewportSize } from './toolbar';
 import { SectionPalette } from './section-palette';
 import { CanvasFrame } from './canvas-frame';
 import { CopilotBar, type CopilotPlan } from './copilot-bar';
-import { createAuthClient, getAuthUser } from '@/lib/auth/require-auth';
+import { createAuthClient } from '@/lib/auth/require-auth';
+import type { ThemeInput } from '@/lib/theme/m3-theme-provider';
 import type { WebsiteData, WebsiteSection } from '@/lib/supabase/get-website';
 
 interface EditorSection {
@@ -309,9 +309,7 @@ export function EditorShell({ websiteId, initialToken }: EditorShellProps) {
   }, [websiteId, data, getSupabase]);
 
   // Section select
-  const handleSectionSelect = useCallback((
-    id: string, type: string, enabled: boolean, content: Record<string, unknown>
-  ) => {
+  const handleSectionSelect = useCallback((id: string, type: string) => {
     setSelectedSectionId(id);
     setSelectedSectionType(type);
   }, []);
@@ -406,6 +404,9 @@ export function EditorShell({ websiteId, initialToken }: EditorShellProps) {
 
   const websiteForRender = buildWebsiteForRender();
   if (!websiteForRender) return null;
+  const initialTheme: ThemeInput | undefined = data.website.theme?.tokens && data.website.theme?.profile
+    ? ({ tokens: data.website.theme.tokens, profile: data.website.theme.profile } as unknown as ThemeInput)
+    : undefined;
 
   return (
     <div className="h-screen flex flex-col">
@@ -431,7 +432,7 @@ export function EditorShell({ websiteId, initialToken }: EditorShellProps) {
           <SectionPalette isOpen={paletteOpen} onToggle={() => setPaletteOpen(!paletteOpen)} />
 
           <CanvasFrame websiteId={websiteId} viewport={viewport}>
-            <M3ThemeProvider initialTheme={data.website.theme?.tokens ? ({ tokens: data.website.theme.tokens, profile: data.website.theme.profile } as any) : undefined}>
+            <M3ThemeProvider initialTheme={initialTheme}>
               <SortableContext
                 items={data.sections.map((s) => s.id)}
                 strategy={verticalListSortingStrategy}

--- a/components/editor/section-palette.tsx
+++ b/components/editor/section-palette.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 import { useDraggable } from '@dnd-kit/core';
-import { SECTION_TYPES } from '@bukeer/website-contract';
 import type { SectionTypeValue } from '@bukeer/website-contract';
 
 const SECTION_CATEGORIES: Record<string, { label: string; types: SectionTypeValue[] }> = {

--- a/components/maps/shared-marker.tsx
+++ b/components/maps/shared-marker.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Image from 'next/image';
 import type { MapMarker, MapMarkerKind } from '@/lib/maps/types';
 import { mapKindLabel } from '@/lib/maps/utils';
 
@@ -100,11 +101,14 @@ export function MarkerButton({ marker, markerColors, selected, onClick }: Marker
           }}
         >
           {destinationMeta?.image ? (
-            <img
+            <Image
               src={destinationMeta.image}
               alt=""
-              aria-hidden="true"
+              width={40}
+              height={40}
+              sizes="40px"
               className="h-full w-full object-cover"
+              aria-hidden="true"
             />
           ) : (
             <span className="text-[12px] font-bold text-white">

--- a/components/site/mobile-sticky-bar.tsx
+++ b/components/site/mobile-sticky-bar.tsx
@@ -27,7 +27,7 @@ export function MobileStickyBar({ website }: MobileStickyBarProps) {
   if (config && !config.enabled) return null;
 
   // Resolve buttons: explicit config or auto-generate from content
-  let buttons = config?.buttons || [];
+  const buttons = config?.buttons ? [...config.buttons] : [];
 
   if (buttons.length === 0) {
     // Auto-generate from content

--- a/components/site/reviews-block.tsx
+++ b/components/site/reviews-block.tsx
@@ -78,19 +78,18 @@ function ReviewCard({ review }: { review: GoogleReviewData }) {
         <div className="flex items-center gap-3 min-w-0">
           {/* Avatar */}
           {hasPhoto ? (
-            /* eslint-disable-next-line @next/next/no-img-element */
-            <img
+            <Image
               src={review.author_photo!}
               alt={review.author_name}
               width={48}
               height={48}
+              sizes="48px"
               className="rounded-full object-cover flex-shrink-0"
               style={{
                 width: 48,
                 height: 48,
                 border: '2px solid var(--accent, #16a34a)',
               }}
-              loading="lazy"
             />
           ) : (
             <div
@@ -143,12 +142,12 @@ function ReviewCard({ review }: { review: GoogleReviewData }) {
       {/* Review image thumbnail (if available) — shown ABOVE the quote */}
       {firstImage && (
         <div className="mt-3 aspect-video relative overflow-hidden rounded-lg">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
+          <Image
             src={firstImage.thumbnail ?? firstImage.url}
             alt={`Foto de ${review.author_name}`}
+            fill
+            sizes="(max-width: 768px) 100vw, 33vw"
             className="w-full h-full object-cover"
-            loading="lazy"
           />
         </div>
       )}

--- a/components/site/section-error-boundary.tsx
+++ b/components/site/section-error-boundary.tsx
@@ -21,7 +21,8 @@ export class SectionErrorBoundary extends React.Component<
     hasError: false,
   };
 
-  static getDerivedStateFromError(_error: Error): SectionErrorBoundaryState {
+  static getDerivedStateFromError(error: Error): SectionErrorBoundaryState {
+    void error;
     return { hasError: true };
   }
 

--- a/components/site/sections/hero-section.tsx
+++ b/components/site/sections/hero-section.tsx
@@ -213,6 +213,7 @@ export function HeroSection({ section, website }: HeroSectionProps) {
 
   const y = useTransform(scrollYProgress, [0, 1], ['0%', '50%']);
   const opacity = useTransform(scrollYProgress, [0, 0.5, 1], [1, 0.8, 0.3]);
+  const immersiveScale = useTransform(scrollYProgress, [0, 1], [1, 1.08]);
 
   // Content is normalized to camelCase by render-section.tsx
   const sectionContent = section.content as {
@@ -263,7 +264,7 @@ export function HeroSection({ section, website }: HeroSectionProps) {
       <div ref={containerRef} className="relative h-screen min-h-[700px] overflow-hidden">
         {/* Background with parallax + scale */}
         <motion.div
-          style={{ y, opacity, scale: useTransform(scrollYProgress, [0, 1], [1, 1.08]) }}
+          style={{ y, opacity, scale: immersiveScale }}
           className="absolute inset-0 w-full h-[115%]"
         >
           {sectionContent.backgroundVideo ? (

--- a/components/site/sections/packages-section.tsx
+++ b/components/site/sections/packages-section.tsx
@@ -41,7 +41,7 @@ export function PackagesSection({ section, website }: PackagesSectionProps) {
   const title = sectionContent.title || 'Paquetes de Viaje';
   const subtitle = sectionContent.subtitle;
   const eyebrow = sectionContent.eyebrow || 'Experiencias Curadas';
-  const packages = sectionContent.packages || [];
+  const packages = useMemo(() => sectionContent.packages ?? [], [sectionContent.packages]);
 
   // Destination filter state
   const [activeDestination, setActiveDestination] = useState<string>('Todos');

--- a/components/site/sections/stats-section.tsx
+++ b/components/site/sections/stats-section.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { motion } from 'framer-motion';
 import { WebsiteData, WebsiteSection } from '@/lib/supabase/get-website';
 import { NumberTicker } from '@/components/ui/number-ticker';
 import { BlurFade } from '@/components/ui/blur-fade';

--- a/components/site/site-footer.tsx
+++ b/components/site/site-footer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import Image from 'next/image';
 import { WebsiteData } from '@/lib/supabase/get-website';
 import { getBasePath } from '@/lib/utils/base-path';
 import { resolveNavHref } from '@/lib/utils/navigation';
@@ -66,7 +67,14 @@ export function SiteFooter({ website, isCustomDomain = false, navigation }: Site
   const LogoBlock = (
     <Link href={`${basePath}/`} className="inline-block">
       {siteLogo ? (
-        <img src={siteLogo} alt={siteName} className="h-12 w-auto object-contain" />
+        <Image
+          src={siteLogo}
+          alt={siteName}
+          width={192}
+          height={48}
+          sizes="192px"
+          className="h-12 w-auto object-contain"
+        />
       ) : (
         <span className="text-2xl font-bold">{siteName}</span>
       )}

--- a/components/site/site-header.tsx
+++ b/components/site/site-header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import Image from 'next/image';
 import { useState, useEffect, useCallback } from 'react';
 import { usePathname } from 'next/navigation';
 import { WebsiteData } from '@/lib/supabase/get-website';
@@ -124,9 +125,12 @@ export function SiteHeader({ website, isCustomDomain = false, navigation }: Site
               className="absolute left-1/2 -translate-x-1/2 z-20 flex items-center justify-center max-w-[56vw] px-2 shrink-0 group"
             >
               {currentLogo ? (
-                <img
+                <Image
                   src={currentLogo}
                   alt={siteName}
+                  width={220}
+                  height={56}
+                  sizes="(max-width: 1024px) 56vw, 220px"
                   className={`w-auto max-w-full object-contain transition-all duration-500 ${isTransparent ? 'h-10' : 'h-8'}`}
                 />
               ) : (
@@ -168,9 +172,12 @@ export function SiteHeader({ website, isCustomDomain = false, navigation }: Site
           <div className="hidden lg:flex h-full items-center justify-between">
             <Link href={`${basePath}/`} className="flex items-center gap-2 shrink-0 group">
               {currentLogo ? (
-                <img
+                <Image
                   src={currentLogo}
                   alt={siteName}
+                  width={220}
+                  height={56}
+                  sizes="220px"
                   className={`w-auto object-contain transition-all duration-500 ${isTransparent ? 'h-11' : 'h-8'}`}
                 />
               ) : (

--- a/components/studio/page-editor.tsx
+++ b/components/studio/page-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useEffect, useMemo, useRef, SyntheticEvent } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { DndContext, DragOverlay, PointerSensor, useSensor, useSensors, type DragEndEvent, type DragStartEvent } from '@dnd-kit/core';
 import { arrayMove } from '@dnd-kit/sortable';
 import { createSupabaseBrowserClient } from '@/lib/supabase/browser-client';
@@ -43,14 +43,12 @@ import {
   Pencil,
   Moon,
   Sun,
-  RefreshCw,
   PanelRightClose,
   PanelRightOpen,
   PanelLeftClose,
   PanelLeftOpen,
   Undo2,
   Redo2,
-  LayoutGrid,
 } from 'lucide-react';
 import type { WebsiteData, WebsiteSection } from '@bukeer/website-contract';
 import type { SectionTypeValue } from '@bukeer/website-contract';
@@ -176,7 +174,7 @@ export function PageEditor({ websiteId, pageId, onBack }: PageEditorProps) {
   // Track original section IDs from DB (for homepage INSERT/DELETE detection)
   const dbSectionIdsRef = useRef<Set<string>>(new Set());
   // Undo/redo history
-  const [history, setHistory] = useState<EditorSection[][]>([]);
+  const [history] = useState<EditorSection[][]>([]);
   const [historyIndex, setHistoryIndex] = useState(-1);
   // exactPreviewRef removed — no more iframe
 
@@ -751,29 +749,7 @@ export function PageEditor({ websiteId, pageId, onBack }: PageEditorProps) {
   // Undo / Redo
   // ============================================================================
 
-  const pushHistory = useCallback(
-    (prev: EditorSection[]) => {
-      setHistory((h) => {
-        const newHistory = h.slice(0, historyIndex + 1);
-        newHistory.push(prev);
-        // Keep max 30 entries
-        if (newHistory.length > 30) newHistory.shift();
-        return newHistory;
-      });
-      setHistoryIndex((i) => Math.min(i + 1, 29));
-    },
-    [historyIndex]
-  );
-
-  // Wrap updateSections to track history
   const originalUpdateSections = updateSections;
-  const updateSectionsWithHistory = useCallback(
-    (newSections: EditorSection[]) => {
-      pushHistory(sections);
-      originalUpdateSections(newSections);
-    },
-    [sections, pushHistory, originalUpdateSections]
-  );
 
   const handleUndo = useCallback(() => {
     if (historyIndex < 0 || history.length === 0) return;

--- a/components/studio/section-canvas.tsx
+++ b/components/studio/section-canvas.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState, useEffect, useCallback, Fragment } from 'react';
+import { useRef, useState, useEffect, Fragment } from 'react';
 import { cn } from '@/lib/utils';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { useDroppable } from '@dnd-kit/core';

--- a/components/studio/section-form.tsx
+++ b/components/studio/section-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback } from 'react';
+import Image from 'next/image';
 import { StudioInput, StudioSelect, StudioTextarea } from '@/components/studio/ui/primitives';
 import { getSectionFieldConfig } from '@/lib/studio/section-fields';
 import type { FieldDefinition } from '@/lib/studio/section-fields';
@@ -116,12 +117,15 @@ function FieldRenderer({ field, value, onChange }: FieldRendererProps) {
           />
           {stringValue && (
             <div className="mt-1 rounded-md overflow-hidden border border-[var(--studio-border)] bg-[var(--studio-panel)]">
-              <img
+              <Image
                 src={stringValue}
                 alt={field.label}
+                width={640}
+                height={96}
+                unoptimized
                 className="w-full h-24 object-cover"
                 onError={(e) => {
-                  (e.target as HTMLImageElement).style.display = 'none';
+                  e.currentTarget.style.display = 'none';
                 }}
               />
             </div>

--- a/components/studio/section-overlay.tsx
+++ b/components/studio/section-overlay.tsx
@@ -4,14 +4,12 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { cn } from '@/lib/utils';
 import { useDroppable } from '@dnd-kit/core';
 import {
-  GripVertical,
   ChevronUp,
   ChevronDown,
   Copy,
   Eye,
   EyeOff,
   Trash2,
-  Plus,
 } from 'lucide-react';
 import type { EditorSection } from '@/lib/studio/section-actions';
 
@@ -35,7 +33,6 @@ interface SectionOverlayProps {
   onDuplicate: (id: string) => void;
   onToggleVisibility: (id: string) => void;
   onDelete: (id: string) => void;
-  onAddSection: () => void;
   /** Increment this when iframe content changes (e.g. after load/save) */
   iframeLoadKey?: number;
   /** True when a section card is being dragged from the Elements panel */
@@ -82,7 +79,6 @@ export function SectionOverlay({
   onDuplicate,
   onToggleVisibility,
   onDelete,
-  onAddSection,
   iframeLoadKey = 0,
   isDraggingNewSection = false,
 }: SectionOverlayProps) {

--- a/components/studio/section-toolbar.tsx
+++ b/components/studio/section-toolbar.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useCallback } from 'react';
 import { cn } from '@/lib/utils';
 import {
   GripVertical,

--- a/components/studio/seo-panel.tsx
+++ b/components/studio/seo-panel.tsx
@@ -13,7 +13,6 @@ import {
 } from '@/components/studio/ui/primitives';
 import {
   scorePageContent,
-  type PageScoringResult,
   type PageScoreCheck,
 } from '@/lib/studio/score-page-content';
 import type { EditorSection } from '@/lib/studio/section-actions';
@@ -110,11 +109,9 @@ function CheckItem({ check }: { check: PageScoreCheck }) {
 // ============================================================================
 
 function KeywordsManager({
-  websiteId,
   initialKeywords,
   onKeywordsChange,
 }: {
-  websiteId: string;
   initialKeywords: string[];
   onKeywordsChange: (keywords: string[]) => void;
 }) {
@@ -197,6 +194,7 @@ export function SeoPanel({
   seoDescription,
   onSeoChange,
 }: SeoPanelProps) {
+  void pageId;
   const [keywords, setKeywords] = useState<string[]>([]);
   const [loadingKeywords, setLoadingKeywords] = useState(true);
   const supabase = createSupabaseBrowserClient();
@@ -312,7 +310,6 @@ export function SeoPanel({
         {!loadingKeywords && (
           <StudioPanel className="p-4">
             <KeywordsManager
-              websiteId={websiteId}
               initialKeywords={keywords}
               onKeywordsChange={handleKeywordsChange}
             />

--- a/components/studio/ui/primitives.tsx
+++ b/components/studio/ui/primitives.tsx
@@ -31,9 +31,9 @@ interface StudioButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement
   size?: StudioComponentSize;
 }
 
-interface StudioInputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+type StudioInputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
-interface StudioTextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+type StudioTextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 interface StudioPanelProps {
   children: ReactNode;
@@ -74,7 +74,7 @@ interface StudioSelectProps extends Omit<React.SelectHTMLAttributes<HTMLSelectEl
   options: StudioSelectOption[];
 }
 
-interface StudioListRowProps extends React.HTMLAttributes<HTMLDivElement> {}
+type StudioListRowProps = React.HTMLAttributes<HTMLDivElement>;
 
 interface StudioEmptyStateProps {
   title: string;

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -11,7 +11,7 @@ const AccordionHeaderPrimitive = AccordionPrimitive.Header as unknown as React.E
 const AccordionTriggerPrimitive = AccordionPrimitive.Trigger as unknown as React.ElementType;
 const AccordionPanelPrimitive = AccordionPrimitive.Panel as unknown as React.ElementType;
 
-function Accordion<Value = any>({
+function Accordion<Value = unknown>({
   className,
   ...props
 }: AccordionPrimitive.Root.Props<Value>) {

--- a/components/ui/text-generate-effect.tsx
+++ b/components/ui/text-generate-effect.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect } from 'react';
 import { motion, stagger, useAnimate, useInView } from 'framer-motion';
-import { cn } from '@/lib/utils';
 
 interface TextGenerateEffectProps {
   words: string;

--- a/lib/admin/permissions.ts
+++ b/lib/admin/permissions.ts
@@ -3,6 +3,8 @@
  * 3 levels: viewer, editor, publisher
  */
 
+import type { SupabaseClient } from '@supabase/supabase-js';
+
 export type AdminRole = 'viewer' | 'editor' | 'publisher' | 'owner';
 
 export interface AdminPermissions {
@@ -68,7 +70,7 @@ export function hasPermission(
 export async function getUserRole(
   userId: string,
   accountId: string,
-  supabase: { from: (table: string) => any }
+  supabase: SupabaseClient
 ): Promise<AdminRole> {
   const { data } = await supabase
     .from('user_roles')

--- a/lib/admin/website-context.tsx
+++ b/lib/admin/website-context.tsx
@@ -74,7 +74,7 @@ export function WebsiteProvider({ websiteId, children }: WebsiteProviderProps) {
   }, [websiteId, supabase]);
 
   const publish = useCallback(async () => {
-    await save({ status: 'published' } as any);
+    await save({ status: 'published' });
   }, [save]);
 
   return (

--- a/lib/ai/rate-limit.ts
+++ b/lib/ai/rate-limit.ts
@@ -153,7 +153,6 @@ export async function cleanupStaleEntries(): Promise<number> {
 export async function recordCost(key: string, costUsd: number): Promise<void> {
   const supabase = getServiceClient();
   if (!supabase) return;
-  const now = new Date();
 
   // Find the most recent rate limit entry for this key
   const { data: entry } = await supabase

--- a/lib/analytics/track.ts
+++ b/lib/analytics/track.ts
@@ -62,7 +62,6 @@ export function trackEvent(
     }
 
     if (process.env.NODE_ENV !== 'production') {
-      // eslint-disable-next-line no-console
       console.log(`[analytics.${name}]`, cleaned);
     }
   } catch {

--- a/lib/legal-defaults.ts
+++ b/lib/legal-defaults.ts
@@ -29,6 +29,7 @@ export function getDefaultTermsContent(siteName: string): string {
 }
 
 export function getDefaultPrivacyContent(siteName: string): string {
+  void siteName;
   const date = formatDate();
   return `<h1>Política de Privacidad</h1>
 <p><em>Última actualización: ${date}</em></p>
@@ -44,7 +45,8 @@ export function getDefaultPrivacyContent(siteName: string): string {
 <p>Para ejercer tus derechos sobre tus datos personales, contáctanos a través del formulario del sitio.</p>`;
 }
 
-export function getDefaultCancellationContent(_siteName: string): string {
+export function getDefaultCancellationContent(siteName: string): string {
+  void siteName;
   const date = formatDate();
   return `<h1>Política de Cancelación</h1>
 <p><em>Última actualización: ${date}</em></p>

--- a/lib/sections/section-registry.tsx
+++ b/lib/sections/section-registry.tsx
@@ -11,6 +11,7 @@
 
 import dynamic from 'next/dynamic';
 import type { WebsiteData, WebsiteSection } from '@/lib/supabase/get-website';
+import { SectionLoader } from '@/components/ui/branded-loader';
 
 // ============================================================================
 // Component Type Definition
@@ -35,7 +36,6 @@ import { HeroSection } from '@/components/site/sections/hero-section';
 
 // Loading skeleton for below-fold sections — branded compass loader
 const SectionSkeleton = () => {
-  const { SectionLoader } = require('@/components/ui/branded-loader');
   return <SectionLoader />;
 };
 

--- a/lib/seo/llms-txt.ts
+++ b/lib/seo/llms-txt.ts
@@ -16,6 +16,11 @@ interface Destination {
   slug: string;
 }
 
+function getPostViewCount(post: BlogPost): number {
+  const postWithViews = post as BlogPost & { view_count?: unknown };
+  return typeof postWithViews.view_count === 'number' ? postWithViews.view_count : 0;
+}
+
 export function generateLlmsTxt(
   website: WebsiteData,
   posts: BlogPost[],
@@ -55,7 +60,7 @@ export function generateLlmsTxt(
   // Travel Guides (top 20 published posts by views)
   const publishedPosts = posts
     .filter(p => p.status === 'published')
-    .sort((a, b) => ((b as any).view_count || 0) - ((a as any).view_count || 0))
+    .sort((a, b) => getPostViewCount(b) - getPostViewCount(a))
     .slice(0, 20);
 
   if (publishedPosts.length > 0) {

--- a/lib/seo/og-helpers.ts
+++ b/lib/seo/og-helpers.ts
@@ -1,4 +1,4 @@
-import type { WebsiteData, WebsiteSection } from '@bukeer/website-contract';
+import type { WebsiteData } from '@bukeer/website-contract';
 
 /**
  * og:image fallback cascade for public site pages.


### PR DESCRIPTION
## Summary
- resolves the lint debt tracked in #124 across app/components/lib
- migrates remaining `no-img-element` offenders to `next/image` and cleans related hook/type lint issues for #125
- keeps maps marker behavior intact while removing lint blockers in `components/maps/shared-marker.tsx`

## What changed
- removed unused vars/imports and fixed `prefer-const`
- replaced `any` with concrete types / safe narrowed types
- fixed hook dependency/order warnings and `react/no-unescaped-entities`
- replaced blocking `<img>` usages with `next/image` + proper sizing
- fixed `no-empty-object-type` and legacy `require` import usage

## Validation
- `npm run lint` ✅ (no warnings or errors)
- `npm run typecheck` ✅
- `npm run test -- --passWithNoTests` ⚠️ fails in pre-existing suite `__tests__/api/ai-editor-routes.test.ts` due response-shape mismatch expectations (`data.error` string vs object)
- `npm run session:run` ⚠️ attempted; observed existing baseline failures and auth rate-limit (`AuthApiError 429`) unrelated to lint/img scope

Closes #124
Closes #125