### PR TITLE
[Stage 2 / W2] Activities marketing parity (RPC + routes + editors + ADR-025) (#216)

### DIFF
--- a/__tests__/lib/features/resolve-studio-editor-v2.test.ts
+++ b/__tests__/lib/features/resolve-studio-editor-v2.test.ts
@@ -1,0 +1,118 @@
+/**
+ * W2 #216 AC-W2-5 — integration test for `resolveStudioEditorV2Flag` against
+ * a mocked Supabase client. Verifies wiring between the RPC call, the Zod
+ * parse of the returned payload, the 3-scope resolution (website > account >
+ * default), and defensive fallback when the RPC fails or the payload is
+ * malformed.
+ *
+ * A live-DB integration test is available under the pilot seed fixtures in
+ * W4; this spec stays at the unit-integration layer so CI runs offline.
+ */
+
+import {
+  resolveStudioEditorV2Flag,
+  isStudioFieldEnabled,
+} from '@/lib/features/studio-editor-v2';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+type RpcPayload = unknown;
+type RpcError = { message: string } | null;
+
+function mockSupabaseWithRpc(result: { data: RpcPayload; error: RpcError }): SupabaseClient {
+  return {
+    rpc: jest.fn(async () => result),
+  } as unknown as SupabaseClient;
+}
+
+describe('resolveStudioEditorV2Flag', () => {
+  const ACCOUNT_ID = '00000000-0000-0000-0000-000000000001';
+  const WEBSITE_ID = '00000000-0000-0000-0000-000000000002';
+
+  it('returns website-scope resolution when the RPC reports website override', async () => {
+    const supabase = mockSupabaseWithRpc({
+      data: {
+        enabled: true,
+        fields: ['description'],
+        scope: 'website',
+      },
+      error: null,
+    });
+
+    const resolution = await resolveStudioEditorV2Flag(supabase, ACCOUNT_ID, WEBSITE_ID);
+    expect(resolution.enabled).toBe(true);
+    expect(resolution.fields).toEqual(['description']);
+    expect(resolution.scope).toBe('website');
+  });
+
+  it('returns account-scope resolution when website row is absent', async () => {
+    const supabase = mockSupabaseWithRpc({
+      data: {
+        enabled: true,
+        fields: [],
+        scope: 'account',
+      },
+      error: null,
+    });
+
+    const resolution = await resolveStudioEditorV2Flag(supabase, ACCOUNT_ID, WEBSITE_ID);
+    expect(resolution.scope).toBe('account');
+    expect(isStudioFieldEnabled(resolution, 'description')).toBe(true);
+    // Activities editors hit the same gate — verify a representative activity-targeted field.
+    expect(isStudioFieldEnabled(resolution, 'program_gallery')).toBe(true);
+  });
+
+  it('returns default resolution when no flag row exists at all', async () => {
+    const supabase = mockSupabaseWithRpc({
+      data: {
+        enabled: false,
+        fields: [],
+        scope: 'default',
+      },
+      error: null,
+    });
+
+    const resolution = await resolveStudioEditorV2Flag(supabase, ACCOUNT_ID, null);
+    expect(resolution.enabled).toBe(false);
+    expect(resolution.scope).toBe('default');
+    expect(isStudioFieldEnabled(resolution, 'description')).toBe(false);
+  });
+
+  it('falls back to safe default when the RPC errors (DB unreachable, permission denied)', async () => {
+    const supabase = mockSupabaseWithRpc({
+      data: null,
+      error: { message: 'permission denied for function resolve_studio_editor_v2' },
+    });
+
+    const resolution = await resolveStudioEditorV2Flag(supabase, ACCOUNT_ID, WEBSITE_ID);
+    expect(resolution).toEqual({ enabled: false, fields: [], scope: 'default' });
+  });
+
+  it('falls back to safe default when the RPC payload is malformed', async () => {
+    const supabase = mockSupabaseWithRpc({
+      data: { enabled: 'yes', fields: 'description' }, // wrong shapes → Zod parse fails
+      error: null,
+    });
+
+    const resolution = await resolveStudioEditorV2Flag(supabase, ACCOUNT_ID, WEBSITE_ID);
+    expect(resolution).toEqual({ enabled: false, fields: [], scope: 'default' });
+  });
+
+  it('per-field whitelist flips Studio ownership for activities + packages alike', async () => {
+    const supabase = mockSupabaseWithRpc({
+      data: {
+        enabled: false,
+        fields: ['program_highlights', 'program_gallery'],
+        scope: 'website',
+      },
+      error: null,
+    });
+
+    const resolution = await resolveStudioEditorV2Flag(supabase, ACCOUNT_ID, WEBSITE_ID);
+    // Studio-owned (regardless of product type):
+    expect(isStudioFieldEnabled(resolution, 'program_highlights')).toBe(true);
+    expect(isStudioFieldEnabled(resolution, 'program_gallery')).toBe(true);
+    // Flutter-owned (not in whitelist):
+    expect(isStudioFieldEnabled(resolution, 'description')).toBe(false);
+    expect(isStudioFieldEnabled(resolution, 'program_notes')).toBe(false);
+  });
+});

--- a/__tests__/lib/features/studio-editor-v2.test.ts
+++ b/__tests__/lib/features/studio-editor-v2.test.ts
@@ -26,7 +26,8 @@ describe('studio-editor-v2 flag resolution', () => {
     scope: 'account',
   };
 
-  describe('3-level resolution order (field > account > default)', () => {
+  // 3 scopes + per-field whitelist — see packages/website-contract/src/schemas/marketing-patch.ts:82-86.
+  describe('3-scope resolution order (field whitelist > account flag > default)', () => {
     it('default → Flutter for all fields', () => {
       expect(isStudioFieldEnabled(defaultRes, 'description')).toBe(false);
       expect(whichSurface(defaultRes, 'program_highlights')).toBe('flutter');
@@ -38,7 +39,7 @@ describe('studio-editor-v2 flag resolution', () => {
       expect(whichSurface(accountWideRes, 'social_image')).toBe('studio');
     });
 
-    it('per-field override takes precedence over account flag', () => {
+    it('per-field whitelist takes precedence when enabled=false', () => {
       // perFieldRes.enabled=false but fields=['description','program_highlights']
       expect(isStudioFieldEnabled(perFieldRes, 'description')).toBe(true);
       expect(isStudioFieldEnabled(perFieldRes, 'program_highlights')).toBe(true);
@@ -46,12 +47,39 @@ describe('studio-editor-v2 flag resolution', () => {
       expect(whichSurface(perFieldRes, 'program_inclusions')).toBe('flutter');
     });
 
-    it('account flag with field exclusion — fields[] is whitelist not blacklist', () => {
+    it('account flag enabled with field exclusion — fields[] is whitelist not blacklist', () => {
       // When enabled=true + fields=['description']:
       // current behavior: enabled=true wins → all fields to Studio
       // (field list only acts as EXTRA enablement when enabled=false)
       expect(isStudioFieldEnabled(mixedRes, 'description')).toBe(true);
       expect(isStudioFieldEnabled(mixedRes, 'program_inclusions')).toBe(true);
+    });
+  });
+
+  describe('product type parity (W2 #216 AC-W2-5 + ADR-025)', () => {
+    // Flag resolution is product-type-agnostic: the same resolution applies
+    // to both package_kits and activities rows. The caller (marketing/actions
+    // or content/actions) dispatches to the right RPC based on productType,
+    // but the flag gate is identical.
+    it('resolution is product-type-agnostic — same rules for package + activity editors', () => {
+      expect(isStudioFieldEnabled(accountWideRes, 'description')).toBe(true);
+      // The editor passes the same `field` key regardless of productType,
+      // so all MarketingFieldName values pass through the same gate.
+      const allFields: Array<Parameters<typeof isStudioFieldEnabled>[1]> = [
+        'description',
+        'program_highlights',
+        'program_inclusions',
+        'program_exclusions',
+        'program_notes',
+        'program_meeting_info',
+        'program_gallery',
+        'social_image',
+        'cover_image_url',
+      ];
+      for (const f of allFields) {
+        expect(isStudioFieldEnabled(accountWideRes, f)).toBe(true);
+        expect(isStudioFieldEnabled(defaultRes, f)).toBe(false);
+      }
     });
   });
 });

--- a/app/dashboard/[websiteId]/products/[slug]/content/actions.ts
+++ b/app/dashboard/[websiteId]/products/[slug]/content/actions.ts
@@ -12,6 +12,8 @@ import {
 } from '@bukeer/website-contract';
 import type { HeroOverrideValue } from '@/components/admin/page-customization/hero-override-editor';
 import { z } from 'zod';
+import type { ProductEditorType } from '@/lib/admin/product-resolver';
+import { publicPathPrefix, pageProductTypeValue } from '@/lib/admin/product-resolver';
 
 const log = createLogger('actions.product-page-customization');
 
@@ -27,6 +29,7 @@ const HeroOverrideSchema = z
 
 const HiddenSectionsSchema = z.array(z.string().min(1).max(64)).max(50);
 const SectionsOrderSchema = z.array(z.string().min(1).max(64)).max(50);
+
 interface AuthorizedContext {
   accountId: string;
   userId: string;
@@ -58,20 +61,30 @@ async function authorize(websiteId: string): Promise<AuthorizedContext> {
   return { accountId: ctx.accountId, userId: ctx.userId, role: ctx.role };
 }
 
-async function ensurePackageTenancy(productId: string, accountId: string): Promise<{ slug: string }> {
+/**
+ * Generalized product tenancy check — replaces `ensurePackageTenancy`.
+ * Routes to `package_kits` or `activities` based on `productType`.
+ */
+async function ensureTenancy(
+  productType: ProductEditorType,
+  productId: string,
+  accountId: string,
+): Promise<{ slug: string }> {
   const supabase = createSupabaseServiceRoleClient();
+  const table = productType === 'package' ? 'package_kits' : 'activities';
   const { data } = await supabase
-    .from('package_kits')
+    .from(table)
     .select('id, slug')
     .eq('id', productId)
     .eq('account_id', accountId)
-    .maybeSingle<{ id: string; slug: string }>();
-  if (!data) throw new Error('NOT_FOUND');
+    .maybeSingle<{ id: string; slug: string | null }>();
+  if (!data || !data.slug) throw new Error('NOT_FOUND');
   return { slug: data.slug };
 }
 
 async function upsertPage(
   websiteId: string,
+  productType: ProductEditorType,
   productId: string,
   userId: string,
   patch: Record<string, unknown>,
@@ -83,7 +96,7 @@ async function upsertPage(
     .select('id')
     .eq('website_id', websiteId)
     .eq('product_id', productId)
-    .eq('product_type', 'package')
+    .eq('product_type', pageProductTypeValue(productType))
     .maybeSingle<{ id: string }>();
 
   if (existing) {
@@ -92,7 +105,12 @@ async function upsertPage(
       .update({ ...patch, updated_by: userId, updated_at: new Date().toISOString() })
       .eq('id', existing.id);
     if (error) {
-      log.error('update_failed', { website_id: websiteId, product_id: productId, error: error.message });
+      log.error('update_failed', {
+        website_id: websiteId,
+        product_id: productId,
+        product_type: productType,
+        error: error.message,
+      });
       throw new Error('PERSIST_FAILED');
     }
     return;
@@ -101,7 +119,7 @@ async function upsertPage(
   const { error } = await supabase.from('website_product_pages').insert({
     website_id: websiteId,
     product_id: productId,
-    product_type: 'package',
+    product_type: pageProductTypeValue(productType),
     custom_highlights: [],
     custom_faq: [],
     seo_highlights: [],
@@ -115,7 +133,12 @@ async function upsertPage(
   });
 
   if (error) {
-    log.error('insert_failed', { website_id: websiteId, product_id: productId, error: error.message });
+    log.error('insert_failed', {
+      website_id: websiteId,
+      product_id: productId,
+      product_type: productType,
+      error: error.message,
+    });
     throw new Error('PERSIST_FAILED');
   }
 }
@@ -123,76 +146,82 @@ async function upsertPage(
 export async function saveHeroOverride(input: {
   websiteId: string;
   productId: string;
+  productType: ProductEditorType;
   value: HeroOverrideValue | null;
 }): Promise<void> {
   const parsed = HeroOverrideSchema.safeParse(input.value);
   if (!parsed.success) throw new Error('VALIDATION_ERROR');
 
   const auth = await authorize(input.websiteId);
-  const { slug } = await ensurePackageTenancy(input.productId, auth.accountId);
+  const { slug } = await ensureTenancy(input.productType, input.productId, auth.accountId);
 
-  await upsertPage(input.websiteId, input.productId, auth.userId, {
+  await upsertPage(input.websiteId, input.productType, input.productId, auth.userId, {
     custom_hero: parsed.data,
   });
 
   log.info('hero_override_saved', {
     website_id: input.websiteId,
     product_id: input.productId,
+    product_type: input.productType,
     user_id: auth.userId,
     cleared: parsed.data === null,
   });
 
-  revalidatePath(`/paquetes/${slug}`);
+  revalidatePath(`${publicPathPrefix(input.productType)}/${slug}`);
 }
 
 export async function saveVisibility(input: {
   websiteId: string;
   productId: string;
+  productType: ProductEditorType;
   hidden: string[];
 }): Promise<void> {
   const parsed = HiddenSectionsSchema.safeParse(input.hidden);
   if (!parsed.success) throw new Error('VALIDATION_ERROR');
 
   const auth = await authorize(input.websiteId);
-  const { slug } = await ensurePackageTenancy(input.productId, auth.accountId);
+  const { slug } = await ensureTenancy(input.productType, input.productId, auth.accountId);
 
-  await upsertPage(input.websiteId, input.productId, auth.userId, {
+  await upsertPage(input.websiteId, input.productType, input.productId, auth.userId, {
     hidden_sections: parsed.data,
   });
 
   log.info('visibility_saved', {
     website_id: input.websiteId,
     product_id: input.productId,
+    product_type: input.productType,
     user_id: auth.userId,
     hidden_count: parsed.data.length,
   });
 
-  revalidatePath(`/paquetes/${slug}`);
+  revalidatePath(`${publicPathPrefix(input.productType)}/${slug}`);
 }
 
 export async function saveOrder(input: {
   websiteId: string;
   productId: string;
+  productType: ProductEditorType;
   order: string[];
 }): Promise<void> {
   const parsed = SectionsOrderSchema.safeParse(input.order);
   if (!parsed.success) throw new Error('VALIDATION_ERROR');
 
   const auth = await authorize(input.websiteId);
-  const { slug } = await ensurePackageTenancy(input.productId, auth.accountId);
+  const { slug } = await ensureTenancy(input.productType, input.productId, auth.accountId);
 
-  await upsertPage(input.websiteId, input.productId, auth.userId, {
+  await upsertPage(input.websiteId, input.productType, input.productId, auth.userId, {
     sections_order: parsed.data,
   });
 
   log.info('order_saved', {
     website_id: input.websiteId,
     product_id: input.productId,
+    product_type: input.productType,
     user_id: auth.userId,
     count: parsed.data.length,
   });
 
-  revalidatePath(`/paquetes/${slug}`);
+  revalidatePath(`${publicPathPrefix(input.productType)}/${slug}`);
 }
 
 const VideoActionInput = z.object({
@@ -200,40 +229,76 @@ const VideoActionInput = z.object({
   video_caption: z.string().max(200).nullable(),
 });
 
+function rpcNameFor(productType: ProductEditorType): string {
+  return productType === 'package'
+    ? 'update_package_kit_marketing_field'
+    : 'update_activity_marketing_field';
+}
+
+/**
+ * W2 #216 AC-W2-6 — video URL + caption updates route through the single-tx
+ * RPC (Option A) so `app.edit_surface='studio'` is set, the audit trigger
+ * stamps `surface='studio'`, and `last_edited_by_surface='studio'` lands on
+ * the row. The RPC accepts one column per call; we issue two calls in
+ * sequence (both inside independent txs) — both must succeed or the UI treats
+ * the save as failed.
+ */
 export async function saveVideoUrl(input: {
   websiteId: string;
   productId: string;
+  productType: ProductEditorType;
   value: { video_url: string | null; video_caption: string | null };
 }): Promise<void> {
   const parsed = VideoActionInput.safeParse(input.value);
   if (!parsed.success) throw new Error('VALIDATION_ERROR');
 
   const auth = await authorize(input.websiteId);
-  const { slug } = await ensurePackageTenancy(input.productId, auth.accountId);
+  const { slug } = await ensureTenancy(input.productType, input.productId, auth.accountId);
 
   const supabase = createSupabaseServiceRoleClient();
-  const { error } = await supabase
-    .from('package_kits')
-    .update({
-      video_url: parsed.data.video_url,
-      video_caption: parsed.data.video_caption,
-    })
-    .eq('id', input.productId)
-    .eq('account_id', auth.accountId);
+  const rpc = rpcNameFor(input.productType);
 
-  if (error) {
-    log.error('video_update_failed', { product_id: input.productId, error: error.message });
+  const { error: urlError } = await supabase.rpc(rpc, {
+    p_product_id: input.productId,
+    p_account_id: auth.accountId,
+    p_column: 'video_url',
+    p_value: parsed.data.video_url as unknown as object,
+    p_ai_flag_column: null,
+  });
+  if (urlError) {
+    log.error('video_url_update_failed', {
+      product_id: input.productId,
+      product_type: input.productType,
+      error: urlError.message,
+    });
+    throw new Error('PERSIST_FAILED');
+  }
+
+  const { error: captionError } = await supabase.rpc(rpc, {
+    p_product_id: input.productId,
+    p_account_id: auth.accountId,
+    p_column: 'video_caption',
+    p_value: parsed.data.video_caption as unknown as object,
+    p_ai_flag_column: null,
+  });
+  if (captionError) {
+    log.error('video_caption_update_failed', {
+      product_id: input.productId,
+      product_type: input.productType,
+      error: captionError.message,
+    });
     throw new Error('PERSIST_FAILED');
   }
 
   log.info('video_url_updated', {
     website_id: input.websiteId,
     product_id: input.productId,
+    product_type: input.productType,
     user_id: auth.userId,
     has_url: Boolean(parsed.data.video_url),
   });
 
-  revalidatePath(`/paquetes/${slug}`);
+  revalidatePath(`${publicPathPrefix(input.productType)}/${slug}`);
 }
 
 const AI_FLAG_COLUMNS: Record<string, string> = {
@@ -241,9 +306,14 @@ const AI_FLAG_COLUMNS: Record<string, string> = {
   highlights: 'highlights_ai_generated',
 };
 
+/**
+ * W2 #216 AC-W2-6 — AI-flag toggle routes through the same RPC so the audit
+ * trigger stamps `surface='studio'` + `last_edited_by_surface='studio'`.
+ */
 export async function toggleAiFlag(input: {
   websiteId: string;
   productId: string;
+  productType: ProductEditorType;
   field: string;
   locked: boolean;
 }): Promise<void> {
@@ -251,52 +321,66 @@ export async function toggleAiFlag(input: {
   if (!column) throw new Error('VALIDATION_ERROR');
 
   const auth = await authorize(input.websiteId);
-  const { slug } = await ensurePackageTenancy(input.productId, auth.accountId);
+  const { slug } = await ensureTenancy(input.productType, input.productId, auth.accountId);
 
   const supabase = createSupabaseServiceRoleClient();
-  const { error } = await supabase
-    .from('package_kits')
-    .update({ [column]: !input.locked })
-    .eq('id', input.productId)
-    .eq('account_id', auth.accountId);
+  // `locked=true` means user declared the field non-AI → flip stored flag to false.
+  // `locked=false` means user declared the field AI-generated → flip stored flag to true.
+  const nextValue = !input.locked;
+
+  const { error } = await supabase.rpc(rpcNameFor(input.productType), {
+    p_product_id: input.productId,
+    p_account_id: auth.accountId,
+    p_column: column,
+    p_value: nextValue as unknown as object,
+    p_ai_flag_column: null,
+  });
 
   if (error) {
-    log.error('ai_flag_update_failed', { product_id: input.productId, field: input.field, error: error.message });
+    log.error('ai_flag_update_failed', {
+      product_id: input.productId,
+      product_type: input.productType,
+      field: input.field,
+      error: error.message,
+    });
     throw new Error('PERSIST_FAILED');
   }
 
   log.info('ai_flag_toggled', {
     website_id: input.websiteId,
     product_id: input.productId,
+    product_type: input.productType,
     user_id: auth.userId,
     field: input.field,
     locked: input.locked,
   });
 
-  revalidatePath(`/paquetes/${slug}`);
+  revalidatePath(`${publicPathPrefix(input.productType)}/${slug}`);
 }
 
 export async function saveCustomSections(input: {
   websiteId: string;
   productId: string;
+  productType: ProductEditorType;
   sections: CustomSection[];
 }): Promise<void> {
   const parsed = CustomSectionsArraySchema.safeParse(input.sections);
   if (!parsed.success) throw new Error('VALIDATION_ERROR');
 
   const auth = await authorize(input.websiteId);
-  const { slug } = await ensurePackageTenancy(input.productId, auth.accountId);
+  const { slug } = await ensureTenancy(input.productType, input.productId, auth.accountId);
 
-  await upsertPage(input.websiteId, input.productId, auth.userId, {
+  await upsertPage(input.websiteId, input.productType, input.productId, auth.userId, {
     custom_sections: parsed.data,
   });
 
   log.info('custom_sections_saved', {
     website_id: input.websiteId,
     product_id: input.productId,
+    product_type: input.productType,
     user_id: auth.userId,
     count: parsed.data.length,
   });
 
-  revalidatePath(`/paquetes/${slug}`);
+  revalidatePath(`${publicPathPrefix(input.productType)}/${slug}`);
 }

--- a/app/dashboard/[websiteId]/products/[slug]/content/page.tsx
+++ b/app/dashboard/[websiteId]/products/[slug]/content/page.tsx
@@ -16,18 +16,11 @@ import {
   toggleAiFlag,
 } from './actions';
 import type { CustomSection } from '@bukeer/website-contract';
+import { resolveProductRow, pageProductTypeValue } from '@/lib/admin/product-resolver';
 
 interface PageProps {
   params: Promise<{ websiteId: string; slug: string }>;
 }
-
-type PackageRow = {
-  id: string;
-  account_id: string;
-  slug: string;
-  video_url: string | null;
-  video_caption: string | null;
-};
 
 type PageRow = {
   custom_hero: { title?: string | null; subtitle?: string | null; backgroundImage?: string | null } | null;
@@ -48,20 +41,20 @@ export default async function ProductContentPage({ params }: PageProps) {
 
   if (!website) notFound();
 
-  const { data: pkg } = await supabase
-    .from('package_kits')
-    .select('id, account_id, slug, video_url, video_caption')
-    .eq('slug', slug)
-    .eq('account_id', website.account_id)
-    .maybeSingle<PackageRow>();
+  const resolved = await resolveProductRow(supabase, {
+    accountId: website.account_id,
+    slug,
+    mode: 'content',
+  });
+  if (!resolved) notFound();
 
-  if (!pkg) notFound();
+  const { productType, row: product } = resolved;
 
   const { data: page } = await supabase
     .from('website_product_pages')
     .select('custom_hero, custom_sections, sections_order, hidden_sections')
-    .eq('product_id', pkg.id)
-    .eq('product_type', 'package')
+    .eq('product_id', product.id)
+    .eq('product_type', pageProductTypeValue(productType))
     .eq('website_id', websiteId)
     .maybeSingle<PageRow>();
 
@@ -72,7 +65,7 @@ export default async function ProductContentPage({ params }: PageProps) {
   };
 
   const { data: healthRaw } = await supabase.rpc('get_product_content_health', {
-    p_product_id: pkg.id,
+    p_product_id: product.id,
   });
   const health: ContentHealth | null = healthRaw
     ? ContentHealthSchema.safeParse(healthRaw).data ?? null
@@ -81,7 +74,9 @@ export default async function ProductContentPage({ params }: PageProps) {
   return (
     <div className="mx-auto max-w-4xl space-y-6 p-6">
       <header>
-        <p className="text-xs font-mono uppercase tracking-wide text-muted-foreground">Website {websiteId}</p>
+        <p className="text-xs font-mono uppercase tracking-wide text-muted-foreground">
+          Website {websiteId} · type: {productType}
+        </p>
         <h1 className="text-2xl font-bold text-foreground">Contenido de &ldquo;{slug}&rdquo;</h1>
         <p className="text-sm text-muted-foreground">
           Personalización por landing: hero, visibilidad + orden de secciones, secciones custom, video.
@@ -89,61 +84,61 @@ export default async function ProductContentPage({ params }: PageProps) {
       </header>
 
       <VideoUrlEditor
-        productId={pkg.id}
-        videoUrl={pkg.video_url}
-        videoCaption={pkg.video_caption}
+        productId={product.id}
+        videoUrl={product.video_url}
+        videoCaption={product.video_caption}
         onSave={async (next) => {
           'use server';
-          await saveVideoUrl({ websiteId, productId: pkg.id, value: next });
+          await saveVideoUrl({ websiteId, productId: product.id, productType, value: next });
         }}
       />
 
       {health && health.ai_fields.length > 0 && (
         <AiFlagsPanel
-          productId={pkg.id}
+          productId={product.id}
           aiFields={health.ai_fields}
           onToggle={async (field, locked) => {
             'use server';
-            await toggleAiFlag({ websiteId, productId: pkg.id, field, locked });
+            await toggleAiFlag({ websiteId, productId: product.id, productType, field, locked });
           }}
         />
       )}
 
       <HeroOverrideEditor
-        productId={pkg.id}
+        productId={product.id}
         value={heroValue}
         onSave={async (next) => {
           'use server';
-          await saveHeroOverride({ websiteId, productId: pkg.id, value: next });
+          await saveHeroOverride({ websiteId, productId: product.id, productType, value: next });
         }}
       />
 
       <SectionVisibilityToggle
-        productId={pkg.id}
-        productType="package"
+        productId={product.id}
+        productType={productType}
         hiddenSections={page?.hidden_sections ?? []}
         onChange={async (next) => {
           'use server';
-          await saveVisibility({ websiteId, productId: pkg.id, hidden: next });
+          await saveVisibility({ websiteId, productId: product.id, productType, hidden: next });
         }}
       />
 
       <SectionsReorderEditor
-        productId={pkg.id}
-        productType="package"
+        productId={product.id}
+        productType={productType}
         sectionsOrder={page?.sections_order ?? []}
         onChange={async (next) => {
           'use server';
-          await saveOrder({ websiteId, productId: pkg.id, order: next });
+          await saveOrder({ websiteId, productId: product.id, productType, order: next });
         }}
       />
 
       <CustomSectionsEditor
-        productId={pkg.id}
+        productId={product.id}
         sections={page?.custom_sections ?? []}
         onChange={async (next) => {
           'use server';
-          await saveCustomSections({ websiteId, productId: pkg.id, sections: next });
+          await saveCustomSections({ websiteId, productId: product.id, productType, sections: next });
         }}
       />
     </div>

--- a/app/dashboard/[websiteId]/products/[slug]/marketing/actions.ts
+++ b/app/dashboard/[websiteId]/products/[slug]/marketing/actions.ts
@@ -11,6 +11,8 @@ import {
   type MarketingFieldPatch,
   type MarketingFieldName,
 } from '@bukeer/website-contract';
+import type { ProductEditorType } from '@/lib/admin/product-resolver';
+import { publicPathPrefix } from '@/lib/admin/product-resolver';
 
 const log = createLogger('actions.marketing-field');
 
@@ -58,20 +60,27 @@ async function authorize(websiteId: string): Promise<AuthorizedContext> {
   return { accountId: ctx.accountId, userId: ctx.userId, role: ctx.role };
 }
 
-async function ensurePackageTenancy(
+/**
+ * Generalized tenancy check — replaces the prior `ensurePackageTenancy` helper.
+ * Returns the row's public slug (for revalidatePath) by querying the product
+ * table matching `productType`.
+ */
+async function ensureTenancy(
+  productType: ProductEditorType,
   productId: string,
   accountId: string,
 ): Promise<{ slug: string; id: string }> {
   const supabase = createSupabaseServiceRoleClient();
+  const table = productType === 'package' ? 'package_kits' : 'activities';
   const { data } = await supabase
-    .from('package_kits')
+    .from(table)
     .select('id, slug')
     .eq('id', productId)
     .eq('account_id', accountId)
-    .maybeSingle<{ id: string; slug: string }>();
+    .maybeSingle<{ id: string; slug: string | null }>();
 
-  if (!data) throw new Error('NOT_FOUND');
-  return data;
+  if (!data || !data.slug) throw new Error('NOT_FOUND');
+  return { id: data.id, slug: data.slug };
 }
 
 async function ensureFieldIsStudioOwned(
@@ -93,9 +102,16 @@ async function ensureFieldIsStudioOwned(
   }
 }
 
+function rpcNameFor(productType: ProductEditorType): string {
+  return productType === 'package'
+    ? 'update_package_kit_marketing_field'
+    : 'update_activity_marketing_field';
+}
+
 export async function saveMarketingField(input: {
   websiteId: string;
   productId: string;
+  productType: ProductEditorType;
   patch: MarketingFieldPatch;
 }): Promise<void> {
   const parsed = MarketingFieldPatchSchema.safeParse(input.patch);
@@ -105,7 +121,7 @@ export async function saveMarketingField(input: {
   }
 
   const auth = await authorize(input.websiteId);
-  const { slug } = await ensurePackageTenancy(input.productId, auth.accountId);
+  const { slug } = await ensureTenancy(input.productType, input.productId, auth.accountId);
   await ensureFieldIsStudioOwned(input.websiteId, auth.accountId, parsed.data.field);
 
   const column = FIELD_TO_COLUMN[parsed.data.field];
@@ -113,9 +129,10 @@ export async function saveMarketingField(input: {
 
   const supabase = createSupabaseServiceRoleClient();
 
-  // Single-transaction RPC: sets app.edit_surface='studio' (trigger reads this)
-  // + performs UPDATE + resets AI flag when applicable — all atomic.
-  const { error } = await supabase.rpc('update_package_kit_marketing_field', {
+  // Single-transaction RPC per product type: sets app.edit_surface='studio'
+  // (audit trigger reads this) + performs UPDATE + resets AI flag when
+  // applicable — all atomic.
+  const { error } = await supabase.rpc(rpcNameFor(input.productType), {
     p_product_id: input.productId,
     p_account_id: auth.accountId,
     p_column: column,
@@ -127,6 +144,7 @@ export async function saveMarketingField(input: {
     log.error('marketing_update_failed', {
       website_id: input.websiteId,
       product_id: input.productId,
+      product_type: input.productType,
       field: parsed.data.field,
       error: error.message,
     });
@@ -136,9 +154,10 @@ export async function saveMarketingField(input: {
   log.info('marketing_field_saved', {
     website_id: input.websiteId,
     product_id: input.productId,
+    product_type: input.productType,
     user_id: auth.userId,
     field: parsed.data.field,
   });
 
-  revalidatePath(`/paquetes/${slug}`);
+  revalidatePath(`${publicPathPrefix(input.productType)}/${slug}`);
 }

--- a/app/dashboard/[websiteId]/products/[slug]/marketing/page.tsx
+++ b/app/dashboard/[websiteId]/products/[slug]/marketing/page.tsx
@@ -12,27 +12,11 @@ import { SocialImagePicker } from '@/components/admin/marketing/social-image-pic
 import { GalleryCurator, type GalleryItem } from '@/components/admin/marketing/gallery-curator';
 import { saveMarketingField } from './actions';
 import type { MarketingFieldName } from '@bukeer/website-contract';
+import { resolveProductRow } from '@/lib/admin/product-resolver';
 
 interface PageProps {
   params: Promise<{ websiteId: string; slug: string }>;
 }
-
-type PackageRow = {
-  id: string;
-  account_id: string;
-  slug: string;
-  description: string | null;
-  description_ai_generated: boolean | null;
-  program_highlights: string[] | null;
-  highlights_ai_generated: boolean | null;
-  program_inclusions: string[] | null;
-  program_exclusions: string[] | null;
-  program_notes: string | null;
-  program_meeting_info: string | null;
-  program_gallery: GalleryItem[] | null;
-  cover_image_url: string | null;
-  last_edited_by_surface: string | null;
-};
 
 export default async function MarketingPage({ params }: PageProps) {
   const { websiteId, slug } = await params;
@@ -50,31 +34,31 @@ export default async function MarketingPage({ params }: PageProps) {
 
   if (!website) notFound();
 
-  const { data: pkg } = await supabase
-    .from('package_kits')
-    .select(
-      'id, account_id, slug, description, description_ai_generated, program_highlights, highlights_ai_generated, program_inclusions, program_exclusions, program_notes, program_meeting_info, program_gallery, cover_image_url, last_edited_by_surface',
-    )
-    .eq('slug', slug)
-    .eq('account_id', website.account_id)
-    .maybeSingle<PackageRow>();
+  const resolved = await resolveProductRow(supabase, {
+    accountId: website.account_id,
+    slug,
+    mode: 'marketing',
+  });
+  if (!resolved) notFound();
 
-  if (!pkg) notFound();
+  const { productType, row: product } = resolved;
+  const gallery: GalleryItem[] = (product.program_gallery as GalleryItem[] | null) ?? [];
 
   const flagResolution = await resolveStudioEditorV2Flag(supabase, ctx.accountId, websiteId);
-
   const isFieldStudio = (field: MarketingFieldName) => isStudioFieldEnabled(flagResolution, field);
+
+  const contentHref = `/dashboard/${websiteId}/products/${slug}/content`;
 
   return (
     <div className="mx-auto max-w-4xl space-y-6 p-6">
       <header className="flex items-start justify-between gap-4">
         <div>
           <p className="text-xs font-mono uppercase tracking-wide text-muted-foreground">
-            Website {websiteId} · last-edit: {pkg.last_edited_by_surface ?? 'unknown'}
+            Website {websiteId} · type: {productType} · last-edit: {product.last_edited_by_surface ?? 'unknown'}
           </p>
           <h1 className="text-2xl font-bold text-foreground">Marketing de &ldquo;{slug}&rdquo;</h1>
           <p className="text-sm text-muted-foreground">
-            Contenido principal del paquete (descripción, highlights, inclusiones…). Cada campo
+            Contenido principal del producto (descripción, highlights, inclusiones…). Cada campo
             está gobernado por el flag <code>studio_editor_v2</code> — cuando Flutter aún es owner,
             el editor aparece en modo solo lectura.
           </p>
@@ -82,55 +66,55 @@ export default async function MarketingPage({ params }: PageProps) {
             Scope flag: <code>{flagResolution.scope}</code> · Enabled: {String(flagResolution.enabled)}
           </p>
         </div>
-        <Link
-          href={`/dashboard/${websiteId}/products/${slug}/content`}
-          className="text-sm text-primary underline"
-        >
+        <Link href={contentHref} className="text-sm text-primary underline">
           Ir a &ldquo;Contenido&rdquo; →
         </Link>
       </header>
 
       <DescriptionEditor
-        productId={pkg.id}
-        value={pkg.description}
-        aiGenerated={pkg.description_ai_generated ?? false}
+        productId={product.id}
+        value={product.description}
+        aiGenerated={product.description_ai_generated ?? false}
         readOnly={!isFieldStudio('description')}
         onSave={async (next) => {
           'use server';
           await saveMarketingField({
             websiteId,
-            productId: pkg.id,
+            productId: product.id,
+            productType,
             patch: { field: 'description', value: next },
           });
         }}
       />
 
       <HighlightsEditor
-        productId={pkg.id}
-        value={pkg.program_highlights ?? []}
-        aiGenerated={pkg.highlights_ai_generated ?? false}
+        productId={product.id}
+        value={product.program_highlights ?? []}
+        aiGenerated={product.highlights_ai_generated ?? false}
         readOnly={!isFieldStudio('program_highlights')}
         onSave={async (next) => {
           'use server';
           await saveMarketingField({
             websiteId,
-            productId: pkg.id,
+            productId: product.id,
+            productType,
             patch: { field: 'program_highlights', value: next },
           });
         }}
       />
 
       <InclusionsExclusionsEditor
-        productId={pkg.id}
-        inclusions={pkg.program_inclusions ?? []}
-        exclusions={pkg.program_exclusions ?? []}
+        productId={product.id}
+        inclusions={product.program_inclusions ?? []}
+        exclusions={product.program_exclusions ?? []}
         inclusionsReadOnly={!isFieldStudio('program_inclusions')}
         exclusionsReadOnly={!isFieldStudio('program_exclusions')}
         onSaveInclusions={async (next) => {
           'use server';
           await saveMarketingField({
             websiteId,
-            productId: pkg.id,
+            productId: product.id,
+            productType,
             patch: { field: 'program_inclusions', value: next },
           });
         }}
@@ -138,64 +122,69 @@ export default async function MarketingPage({ params }: PageProps) {
           'use server';
           await saveMarketingField({
             websiteId,
-            productId: pkg.id,
+            productId: product.id,
+            productType,
             patch: { field: 'program_exclusions', value: next },
           });
         }}
       />
 
       <RecommendationsEditor
-        productId={pkg.id}
-        value={pkg.program_notes}
+        productId={product.id}
+        value={product.program_notes}
         readOnly={!isFieldStudio('program_notes')}
         onSave={async (next) => {
           'use server';
           await saveMarketingField({
             websiteId,
-            productId: pkg.id,
+            productId: product.id,
+            productType,
             patch: { field: 'program_notes', value: next },
           });
         }}
       />
 
       <InstructionsEditor
-        productId={pkg.id}
-        value={pkg.program_meeting_info}
+        productId={product.id}
+        value={product.program_meeting_info}
         readOnly={!isFieldStudio('program_meeting_info')}
         onSave={async (next) => {
           'use server';
           await saveMarketingField({
             websiteId,
-            productId: pkg.id,
+            productId: product.id,
+            productType,
             patch: { field: 'program_meeting_info', value: next },
           });
         }}
       />
 
       <SocialImagePicker
-        productId={pkg.id}
-        value={pkg.cover_image_url}
+        productId={product.id}
+        value={product.cover_image_url}
         readOnly={!isFieldStudio('social_image')}
         onSave={async (next) => {
           'use server';
           await saveMarketingField({
             websiteId,
-            productId: pkg.id,
+            productId: product.id,
+            productType,
             patch: { field: 'social_image', value: next },
           });
         }}
       />
 
       <GalleryCurator
-        productId={pkg.id}
+        productId={product.id}
         websiteId={websiteId}
-        value={pkg.program_gallery ?? []}
+        value={gallery}
         readOnly={!isFieldStudio('program_gallery')}
         onSave={async (next) => {
           'use server';
           await saveMarketingField({
             websiteId,
-            productId: pkg.id,
+            productId: product.id,
+            productType,
             patch: { field: 'program_gallery', value: next },
           });
         }}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -60,7 +60,7 @@ All ADRs accepted unless noted. Cross-cut by Principles P1–P10 (see [[ARCHITEC
 | [[ADR-021]] | [ADR-021](./architecture/ADR-021-translation-memory-transcreation-pipeline.md) | Translation Memory + AI Transcreation Pipeline | [[translation]] [[TM]] [[AI]] [[transcreation]] [[multi-locale]] |
 | [[ADR-023]] | [ADR-023](./architecture/ADR-023-qa-tooling-studio-editor.md) | QA Tooling: Playwright Component Testing + Visual Regression | [[testing]] [[CT]] [[visual-regression]] [[quality-gate]] |
 | [[ADR-024]] | [ADR-024](./architecture/ADR-024-booking-v1-pilot-scope.md) | Booking V1 Pilot Scope (Proposed — W3 decision meeting) | [[booking]] [[pilot-readiness]] [[leads]] |
-| [[ADR-025]] | [ADR-025](./architecture/ADR-025-studio-flutter-field-ownership.md) | Studio / Flutter Field Ownership Boundary (Proposed — priority-v2 aligned, W2 pending) | [[studio-editor-v2]] [[package-kits]] [[pilot-readiness]] |
+| [[ADR-025]] | [ADR-025](./architecture/ADR-025-studio-flutter-field-ownership.md) | Studio / Flutter Field Ownership Boundary (**Accepted 2026-04-19** — pkg+act Studio-editable, hotels Flutter-owner; Option A RPC expansion + activities parity) | [[studio-editor-v2]] [[package-kits]] [[pilot-readiness]] [[studio-editor-parity-audit]] |
 
 > **Note:** `ADR-022` and `ADR-032` referenced in specs are anchored in `weppa-cloud/bukeer-flutter`. Studio respects them but does not own them. See [[cross-repo-flutter]].
 
@@ -406,6 +406,8 @@ Obsidian resolves `[[ADR-005]]` by filename stem or alias. Claude Code / Codex g
 | `[[package-detail-anatomy]]` | `docs/product/package-detail-anatomy.md` |
 | `[[product-detail-inventory]]` | `docs/product/product-detail-inventory.md` |
 | `[[product-detail-matrix]]` | `docs/product/product-detail-matrix.md` |
+| `[[studio-editor-parity-audit]]` | `docs/product/studio-editor-parity-audit.md` |
+| `[[schema-parity-audit]]` | `docs/product/schema-parity-audit.md` |
 | `[[e2e-sessions]]` | `.claude/rules/e2e-sessions.md` |
 | `[[#127]]` | GitHub Issue — Package Detail Conversion v2 (hero chips, WhatsApp CTA) |
 | `[[#165]]` | GitHub Issue — Product Video Field (video_url + hero lightbox) |

--- a/docs/architecture/ADR-025-studio-flutter-field-ownership.md
+++ b/docs/architecture/ADR-025-studio-flutter-field-ownership.md
@@ -1,47 +1,98 @@
 # ADR-025 — Studio / Flutter Field Ownership Boundary
 
-- Status: Proposed (finalized at W2 #216 PR time)
+- Status: **Accepted — 2026-04-19**
 - Date: 2026-04-19
 - Deciders: tech lead, Studio dev, Flutter dev
-- Related: #190 (Studio Unified Product Editor), #216 (W2 parity audit), [[cross-repo-flutter]], [[ADR-003]] (contract-first)
+- Related: #190 (Studio Unified Product Editor), #216 (W2 parity audit), #204 (activities/hotels parity follow-up), [[cross-repo-flutter]], [[ADR-003]] (contract-first), [[ADR-005]] (security boundaries), [[ADR-023]] (qa-tooling-studio-editor)
 
 ## Context
 
-`app/dashboard/[websiteId]/products/[slug]/marketing/page.tsx` and `.../content/page.tsx` today query `package_kits` exclusively. `product_type='package'` is hardcoded. Activities + Hotels have no marketing / content RPCs in Studio. Partner (Rol 2) needs deterministic answers to "can I edit this field from Studio, or do I need Flutter?".
+`app/dashboard/[websiteId]/products/[slug]/marketing/page.tsx` and `.../content/page.tsx` historically queried `package_kits` exclusively with `product_type='package'` hardcoded. Activities + Hotels had no marketing / content RPCs on the Studio side. Partner (Rol 2) needs deterministic answers to "can I edit this field from Studio, or do I need Flutter?" for each row in the product-detail matrix (W1 #215).
+
+Two additional forcing functions landed 2026-04-19:
+
+1. **Client priority v2** (meeting 2026-04-19): translation + editing for packages **and** activities are the cutover priorities. Hotels stay as-is (Flutter-owner). Booking V1 is deferred post-pilot.
+2. **Schema gap audit** (W2 TVB Round 3): `activities` lacks the 12 parity columns (`program_highlights`, `program_gallery`, `video_url`, `video_caption`, `description_ai_generated`, `highlights_ai_generated`, `cover_image_url`, `program_notes`, `program_meeting_info`, `program_inclusions`, `program_exclusions`, `last_ai_hash`) and ships typo'd columns (`inclutions`, `exclutions`, `recomendations`, `instructions`) that Flutter already reads.
 
 ## Decision
 
 Ownership is **per field × per product type × under `studio_editor_v2` flag**.
 
 ### Packages
-- **Studio-editable** (under flag): `description`, `program_highlights`, `program_inclusions`, `program_exclusions`, `program_notes`, `program_meeting_info`, `cover_image_url`, `program_gallery`, `video_url`, `video_caption`, `custom_hero.{title,subtitle,backgroundImage}`, `custom_sections[]`, `sections_order[]`, `hidden_sections[]`, `custom_seo_title`, `custom_seo_description`, `custom_faq`, `robots_noindex`.
-- **Flutter-owner (canonical)**: `duration_days/nights`, `location`, `city`, `country`, `price`, `user_rating`, `options[]`, `itinerary_items[]`, `meeting_point`, `image`, `slug`, `name`.
 
-### Activities
-- **Flutter-owner** for pilot: all catalog fields + marketing fields.
-- **Post-pilot follow-up**: `update_activity_marketing_field` RPC + Studio editor routes if demand validated.
+- **Studio-editable** (under flag): `description`, `program_highlights`, `program_inclusions`, `program_exclusions`, `program_notes`, `program_meeting_info`, `cover_image_url`, `program_gallery`, `video_url`, `video_caption`, `description_ai_generated`, `highlights_ai_generated`, `custom_hero.{title,subtitle,backgroundImage}`, `custom_sections[]`, `sections_order[]`, `hidden_sections[]`, `custom_seo_title`, `custom_seo_description`, `custom_faq`, `robots_noindex`.
+- **Flutter-owner (canonical)**: `duration_days/nights`, `location`, `city`, `country`, `price`, `user_rating`, `options[]`, `itinerary_items[]`, `meeting_point`, `image`, `slug`, `name`, `status`, `category`.
 
-### Hotels
-- **Flutter-owner** for pilot: all catalog fields + marketing fields.
-- **Studio-editable** via existing SEO item detail: `custom_seo_title`, `custom_seo_description`, `custom_faq`, `robots_noindex`.
-- **Post-pilot follow-up**: `update_hotel_marketing_field` RPC + Studio editor routes.
+### Activities (confirmed Studio-editable 2026-04-19)
+
+- **Studio-editable** (under flag, same whitelist as packages): `description`, `program_highlights`, `program_inclusions`, `program_exclusions`, `program_notes`, `program_meeting_info`, `program_gallery`, `cover_image_url`, `video_url`, `video_caption`, `description_ai_generated`, `highlights_ai_generated`, `custom_hero.*`, `custom_sections[]`, `sections_order[]`, `hidden_sections[]`.
+- **Flutter-owner (canonical)**: `schedule_data`, `main_image`, `experience_type`, `price`, `slug`, `name`, `location`, `city`, `country`, `status`.
+- **Legacy typo'd columns preserved additively** (`inclutions`, `exclutions`, `recomendations`, `instructions`): Flutter continues to read/write these until rename follow-up post-pilot. Studio writes to the **new parity columns** only; public renderer falls back to legacy columns when new columns are NULL.
+
+### Hotels (Flutter-owner for pilot)
+
+- **Flutter-owner** for all catalog + marketing fields.
+- **Studio-editable** via the existing SEO item detail flow only: `custom_seo_title`, `custom_seo_description`, `custom_faq`, `robots_noindex` (on `website_product_pages`).
+- **No `update_hotel_marketing_field` RPC** in pilot. Post-pilot follow-up tracked on #204.
+
+### `website_product_pages` fields (Studio-only writer by construction)
+
+`custom_hero`, `custom_sections`, `sections_order`, `hidden_sections` always write to `website_product_pages` with `product_type in ('package','activity','hotel')`. Because Flutter has no UI that writes these columns, audit-trigger semantics do not apply — the flag resolution for these fields is trivially always-Studio regardless of `studio_editor_v2` state.
+
+## Option A vs Option B decision
+
+**Option A adopted for both RPCs.** The column allowlist on the existing `update_package_kit_marketing_field` RPC is expanded to include `video_url`, `video_caption`, `description_ai_generated`, `highlights_ai_generated`. The parallel `update_activity_marketing_field` RPC (new) ships with an equivalent allowlist. Total RPC count stays at 2 (one per product type) rather than doubling to 4 with dedicated flag/video RPCs. Rationale: single surface per table keeps the audit trigger + `last_edited_by_surface` stamping path uniform, and the allowlist pattern is explicit enough to review.
+
+See migrations:
+- `supabase/migrations/20260502030000_marketing_field_rpc_expand.sql` — package_kits RPC allowlist expansion (Option A).
+- `supabase/migrations/20260502031000_activity_marketing_field_rpc.sql` — activities parity DDL + new `update_activity_marketing_field` RPC.
+
+## Field → pkg column → act column mapping table
+
+All editors send the same `MarketingFieldPatch` payload. The RPCs map the patch `field` to the correct physical column per product type:
+
+| Patch field | `package_kits` column | `activities` column (new, parity) | Legacy Flutter column (activities) |
+|---|---|---|---|
+| `description` | `description` (text) | `description` (text) | `description` (same) |
+| `program_highlights` | `program_highlights` (jsonb) | `program_highlights` (jsonb) | — (new) |
+| `program_inclusions` | `program_inclusions` (jsonb) | `program_inclusions` (jsonb) | `inclutions` (text, typo'd) |
+| `program_exclusions` | `program_exclusions` (jsonb) | `program_exclusions` (jsonb) | `exclutions` (text, typo'd) |
+| `program_notes` | `program_notes` (text) | `program_notes` (text) | `recomendations` (text, typo'd) |
+| `program_meeting_info` | `program_meeting_info` (text) | `program_meeting_info` (text) | `instructions` (text) |
+| `program_gallery` | `program_gallery` (jsonb) | `program_gallery` (jsonb) | — (new) |
+| `social_image` / `cover_image_url` | `cover_image_url` (text) | `cover_image_url` (text) | `main_image` (text) |
+| `video_url` | `video_url` (text + shape CHECK) | `video_url` (text + shape CHECK) | — (new) |
+| `video_caption` | `video_caption` (text) | `video_caption` (text) | — (new) |
+| `description_ai_generated` | `description_ai_generated` (boolean) | `description_ai_generated` (boolean) | — (new) |
+| `highlights_ai_generated` | `highlights_ai_generated` (boolean) | `highlights_ai_generated` (boolean) | — (new) |
+
+Legacy typo'd activity columns are NOT wired through editors but stay in the RPC allowlist for support-tooling interop. Rename deferred post-pilot.
 
 ## Consequences
 
-- Matrix (W1 #215) reflects pkg-only 🟨 scope; Act/Hotel 🚫 "pendiente wire — ver W2/W7".
-- W7 training flows 6 (Activity) + 7 (Hotel) default to Flutter-handoff protocol (Variant B).
-- Flag resolution (3 scopes: website | account | default + per-field whitelist) remains authoritative gate.
-- `last_edited_by_surface` column records Studio vs Flutter writes (audit).
-- Activities scope confirmed Studio-editable post client meeting 2026-04-19 (prep note; final Decision section updated at W2 #216 PR time).
+- **W1 matrix** (#215): Pkg + Act columns now eligible for 🟨/✅; Hotel column stays 🚫 "as-is Flutter-owner, pilot policy".
+- **W7 training** (#221): Flow 6 (Activity) is Variant A (Studio native editor); Flow 7 (Hotel) is Variant B (Flutter handoff).
+- **Flag resolution**: 3 scopes (`website | account | default`) + per-field whitelist (additive when `enabled=false`; `enabled=true` wins over empty `fields[]`). Same semantics apply to both product types; no separate flag per product type.
+- **Audit**: `last_edited_by_surface` column records Studio vs Flutter writes on both `package_kits` and `activities`. Trigger `trg_audit_activities` (migration `20260430000200`) already in place; the new RPC sets `app.edit_surface='studio'` in-tx so the trigger stamps `surface='studio'`.
+- **Public renderer bridge**: activities public render at `/actividades/{slug}` continues to serve Flutter-authored content (reading typo'd columns) until the partner saves via Studio. After a Studio save, the new parity columns take precedence; the renderer falls back to legacy typo'd columns when parity columns are NULL. Documented in the audit doc.
+- **Rollback safety**: the activity RPC migration rollback drops the parity columns + RPC but **does not touch** legacy typo'd columns. A rolled-back activity row still renders from Flutter data. A mid-deploy rollback leaves Studio routes showing read-only badges for activity editors.
+- **Route resolver**: `app/dashboard/[websiteId]/products/[slug]/*` probes `package_kits` first, then `activities`. Slug collisions across the two tables within the same account resolve to packages (matches the public URL prefix precedence `/paquetes` > `/actividades`).
 
-## Refactor at W2 PR time
+## Related migrations
 
-- `toggleAiFlag` + `saveVideoUrl` actions refactored to go through RPC `update_package_kit_marketing_field` (Option A expansion) or new flag RPC (Option B) so `app.edit_surface='studio'` is set in the tx.
-- Final Option A vs B decision logged at W2 PR merge.
-- Migration numbering: `20260501000000_marketing_field_rpc_expand.sql` (verify numbering at PR time).
+- `20260426000000_account_feature_flags.sql` — `resolve_studio_editor_v2` + `toggle_studio_editor_v2` RPCs.
+- `20260426000100_package_kits_audit_log.sql` — audit log table + `trg_audit_package_kits` trigger.
+- `20260426000200_package_kits_last_edited_surface.sql` — `last_edited_by_surface` column on `package_kits`.
+- `20260426000300_marketing_field_update_rpc.sql` — initial `update_package_kit_marketing_field` (narrower allowlist).
+- `20260430000100_activities_hotels_last_edited_surface.sql` — `last_edited_by_surface` on `activities` + `hotels`.
+- `20260430000200_product_edit_history_trigger_activities_hotels.sql` — `fn_audit_activities` + `fn_audit_hotels` triggers.
+- `20260502030000_marketing_field_rpc_expand.sql` — W2 Option A allowlist expansion for packages.
+- `20260502031000_activity_marketing_field_rpc.sql` — W2 activities parity DDL + `update_activity_marketing_field`.
 
 ## Alternatives considered
 
-- **Ship act/hotel RPCs in W2 (bumps to XL)**: rejected for pilot; kept as post-pilot follow-up.
-- **Studio fully owns marketing for all types**: rejected; catalog canonical data belongs to Flutter.
+- **Ship act/hotel RPCs in W2** (original R2 sizing): adopted for activities (this ADR); rejected for hotels pilot.
+- **Option B: new `update_package_kit_flag_field` + `update_activity_flag_field` RPCs**: rejected — doubles maintenance surface for the same audit guarantee.
+- **Studio fully owns marketing for all types**: rejected; catalog canonical data belongs to Flutter (slug, price, status, schedule).
 - **Flutter fully owns everything**: rejected; blocks pilot self-serve requirement.
+- **Rename typo'd columns in this migration**: rejected — breaks Flutter reads mid-deploy. Tracked as post-pilot cleanup.

--- a/docs/product/studio-editor-parity-audit.md
+++ b/docs/product/studio-editor-parity-audit.md
@@ -1,0 +1,158 @@
+# Studio Editor Parity Audit — Packages + Activities
+
+**Status:** Baseline 2026-04-19 (W2 #216 v2)
+**Scope:** `product_type in ('package','activity')`. Hotels are Flutter-owner for the pilot — see [[ADR-025-studio-flutter-field-ownership]].
+**Source of truth:** this doc + ADR-025 + migrations `20260502030000` and `20260502031000`.
+
+---
+
+## 1 · What this doc answers
+
+For every editor under `components/admin/marketing/*` and `components/admin/page-customization/*`:
+
+1. Which server action does it call?
+2. Which DB column (per product type) does the action write?
+3. Where does the public renderer read that column?
+4. Does the save path stamp `last_edited_by_surface='studio'` on the row?
+5. Does `revalidatePath` target the right public URL prefix?
+
+W4 (#218) consumes this trace to build the editor → DB → render E2E specs.
+
+---
+
+## 2 · Editor → action → column → renderer trace
+
+### 2.1 · Marketing editors (`/dashboard/[websiteId]/products/[slug]/marketing`)
+
+Route resolver: [`lib/admin/product-resolver.ts::resolveProductRow({ mode: 'marketing' })`](../../lib/admin/product-resolver.ts) — probes `package_kits` first, then `activities` by (`account_id`, `slug`).
+
+Action: [`app/dashboard/[websiteId]/products/[slug]/marketing/actions.ts::saveMarketingField`](../../app/dashboard/[websiteId]/products/[slug]/marketing/actions.ts) — dispatches to the appropriate RPC per `productType`:
+
+- `package` → `update_package_kit_marketing_field` (migrations `20260426000300` → `20260502030000`)
+- `activity` → `update_activity_marketing_field` (migration `20260502031000`)
+
+Both RPCs set `app.edit_surface='studio'` in the same transaction, so the audit trigger (`trg_audit_package_kits` / `trg_audit_activities`) stamps `surface='studio'` and the RPC sets `last_edited_by_surface='studio'` on the row.
+
+`revalidatePath` prefix: `/paquetes/${slug}` for packages, `/actividades/${slug}` for activities (via [`publicPathPrefix`](../../lib/admin/product-resolver.ts)).
+
+| Editor component | Patch `field` | Package column (`package_kits`) | Activity column (`activities`) | Legacy Flutter column (activities) | Public renderer block |
+|---|---|---|---|---|---|
+| `DescriptionEditor` | `description` | `description` | `description` | `description` | `detail-description` in `components/pages/product-landing-page.tsx` |
+| `HighlightsEditor` | `program_highlights` | `program_highlights` (jsonb) | `program_highlights` (jsonb, new) | — | `detail-highlights` |
+| `InclusionsExclusionsEditor` (inclusions) | `program_inclusions` | `program_inclusions` (jsonb) | `program_inclusions` (jsonb, new) | `inclutions` (text, typo — fallback) | `detail-options` / inclusions list block |
+| `InclusionsExclusionsEditor` (exclusions) | `program_exclusions` | `program_exclusions` (jsonb) | `program_exclusions` (jsonb, new) | `exclutions` (text, typo — fallback) | exclusions list block |
+| `RecommendationsEditor` | `program_notes` | `program_notes` (text) | `program_notes` (text, new) | `recomendations` (text, typo — fallback) | recommendations block |
+| `InstructionsEditor` | `program_meeting_info` | `program_meeting_info` (text) | `program_meeting_info` (text, new) | `instructions` (text — fallback) | meeting point block |
+| `SocialImagePicker` | `social_image` | `cover_image_url` (text) | `cover_image_url` (text, new) | `main_image` (text — fallback) | OG image meta + hero fallback |
+| `GalleryCurator` | `program_gallery` | `program_gallery` (jsonb) | `program_gallery` (jsonb, new) | — | `detail-gallery` |
+
+**Legacy typo'd column fallback:** activities public rendering at `/actividades/[slug]` reads the new parity column first; when NULL (pre-migration activity rows or rows never touched by Studio) it falls back to the legacy typo'd column (`inclutions`, `exclutions`, `recomendations`, `instructions`). After a Studio save to the parity column, the new column wins.
+
+**Flag resolution:** every editor checks `isStudioFieldEnabled(resolution, field)` against `studio_editor_v2` per [`lib/features/studio-editor-v2.ts`](../../lib/features/studio-editor-v2.ts). When the field is not Studio-owned, the editor renders read-only and `saveMarketingField` throws `FIELD_NOT_STUDIO_OWNED` as defense-in-depth.
+
+### 2.2 · Content editors (`/dashboard/[websiteId]/products/[slug]/content`)
+
+Route resolver: [`resolveProductRow({ mode: 'content' })`](../../lib/admin/product-resolver.ts).
+
+Actions: [`app/dashboard/[websiteId]/products/[slug]/content/actions.ts`](../../app/dashboard/[websiteId]/products/[slug]/content/actions.ts) — dispatches by `productType`.
+
+Writer tables:
+- `HeroOverrideEditor`, `SectionVisibilityToggle`, `SectionsReorderEditor`, `CustomSectionsEditor` → `website_product_pages` (Studio-only writer by construction; audit-trigger semantics N/A).
+- `VideoUrlEditor`, `AiFlagsPanel` → `package_kits` or `activities` via the RPC (audit trigger fires).
+
+| Editor component | Server action | Target table / column | Audit stamp `last_edited_by_surface` |
+|---|---|---|---|
+| `HeroOverrideEditor` | `saveHeroOverride` | `website_product_pages.custom_hero` (jsonb `{title,subtitle,backgroundImage}`) | N/A (Studio-only writer) |
+| `SectionVisibilityToggle` | `saveVisibility` | `website_product_pages.hidden_sections` (text[]) | N/A |
+| `SectionsReorderEditor` | `saveOrder` | `website_product_pages.sections_order` (text[]) | N/A |
+| `CustomSectionsEditor` | `saveCustomSections` | `website_product_pages.custom_sections` (jsonb[]) | N/A |
+| `VideoUrlEditor` (url) | `saveVideoUrl` | `package_kits.video_url` or `activities.video_url` via RPC | **Yes — via RPC** (W2 AC-W2-6) |
+| `VideoUrlEditor` (caption) | `saveVideoUrl` | `package_kits.video_caption` or `activities.video_caption` via RPC | **Yes — via RPC** |
+| `AiFlagsPanel` (description) | `toggleAiFlag` | `package_kits.description_ai_generated` or `activities.description_ai_generated` via RPC | **Yes — via RPC** |
+| `AiFlagsPanel` (highlights) | `toggleAiFlag` | `package_kits.highlights_ai_generated` or `activities.highlights_ai_generated` via RPC | **Yes — via RPC** |
+
+Before W2: `saveVideoUrl` + `toggleAiFlag` did raw `.update()` on `package_kits`, so `last_edited_by_surface` stayed at its previous value (typically `'flutter'`). After W2: both actions route through `update_package_kit_marketing_field` / `update_activity_marketing_field`, which set `app.edit_surface='studio'` + stamp the row. See [migration `20260502030000`](../../supabase/migrations/20260502030000_marketing_field_rpc_expand.sql) Option A allowlist expansion + [migration `20260502031000`](../../supabase/migrations/20260502031000_activity_marketing_field_rpc.sql).
+
+`revalidatePath`: uses `publicPathPrefix(productType)` (`/paquetes` or `/actividades`) for every save.
+
+### 2.3 · `website_product_pages` per-site overlay
+
+All four content editors target a single row in `website_product_pages` keyed by (`website_id`, `product_id`, `product_type`). The `product_type` discriminator accepts `'package' | 'activity' | 'hotel' | 'transfer'` per migration `20260424000100`. W2 writes `'package'` or `'activity'` via [`pageProductTypeValue`](../../lib/admin/product-resolver.ts).
+
+---
+
+## 3 · ISR revalidation verification
+
+Post-save, every action issues `revalidatePath(publicPathPrefix(productType) + '/' + slug)`. The public rendering routes that consume these paths:
+
+- Packages: `app/site/[subdomain]/paquetes/[slug]/page.tsx`.
+- Activities: `app/site/[subdomain]/[...slug]/page.tsx` (handles `/actividades/[slug]`).
+
+Flush window: ≤ 5 min. Manual QA verified by editing a field, waiting for revalidation, hitting the public URL.
+
+---
+
+## 4 · `last_edited_by_surface` audit verification
+
+Manual QA checklist for a complete Studio-edit roundtrip:
+
+| Product type | Field | Action | Expected row state after save |
+|---|---|---|---|
+| package | description | `saveMarketingField` | `package_kits.last_edited_by_surface = 'studio'`, `description_ai_generated = false` |
+| package | program_highlights | `saveMarketingField` | `highlights_ai_generated = false`, `last_edited_by_surface = 'studio'` |
+| package | video_url | `saveVideoUrl` | **after W2:** `last_edited_by_surface = 'studio'` |
+| package | description_ai_generated | `toggleAiFlag` | **after W2:** `last_edited_by_surface = 'studio'` |
+| activity | description | `saveMarketingField` | `activities.last_edited_by_surface = 'studio'` |
+| activity | program_highlights | `saveMarketingField` | `activities.highlights_ai_generated = false`, `last_edited_by_surface = 'studio'` |
+| activity | video_url | `saveVideoUrl` | `activities.last_edited_by_surface = 'studio'` |
+| activity | highlights_ai_generated | `toggleAiFlag` | `activities.last_edited_by_surface = 'studio'` |
+
+Audit triggers `trg_audit_package_kits` (migration `20260426000100`) and `trg_audit_activities` (migration `20260430000200`) both read `current_setting('app.edit_surface', true)`. The RPCs set this to `'studio'` via `set_config('app.edit_surface', 'studio', true)` before the UPDATE so the trigger sees it in the same transaction. Rows for which Flutter writes the column continue to log `surface='flutter'` (default branch of the coalesce) or `surface='trigger_default'` when no session config is set.
+
+SQL probe for post-save verification:
+
+```sql
+select last_edited_by_surface, updated_at
+from public.package_kits
+where id = :product_id;
+
+select surface, changed_fields, created_at
+from public.package_kits_audit_log
+where package_kit_id = :product_id
+order by created_at desc
+limit 3;
+```
+
+Equivalent probe for activities uses `public.activities` + `public.product_edit_history` (where `fn_audit_activities` writes via `log_edit_history(…,'activity',…)`).
+
+---
+
+## 5 · Flag resolution coverage
+
+Per [`lib/features/studio-editor-v2.ts`](../../lib/features/studio-editor-v2.ts) + RPC `resolve_studio_editor_v2`:
+
+- **Default** (no `account_feature_flags` row) → Flutter wins. Editors render read-only with "Solo lectura — este campo se edita en Flutter" badge.
+- **Account-wide** (`website_id IS NULL`, `studio_editor_v2_enabled=true`) → all 9 marketing fields Studio-editable.
+- **Website override** (`website_id=<website>`) → takes precedence over account row.
+- **Per-field whitelist** (`studio_editor_v2_fields` jsonb array) → additive when `enabled=false`; `enabled=true` wins globally.
+
+Same semantics apply to both `product_type='package'` and `product_type='activity'`. Hotels do not use the flag (no Studio editor surface).
+
+---
+
+## 6 · Out of scope for this audit
+
+- Hotels editor parity — Flutter-owner for pilot. Tracked post-pilot on #204.
+- Booking V1 — deferred per ADR-024.
+- E2E specs — owned by W4 #218 (this doc provides the trace W4 consumes).
+- Blog transcreate flow — owned by W5 #219.
+
+---
+
+## 7 · References
+
+- ADR: [[ADR-025-studio-flutter-field-ownership]]
+- EPIC: #214 Stage 2 W2 (#216)
+- Shared context: `.claude/rules/cross-repo-flutter.md`
+- Prior audit: [[schema-parity-audit]] (reference for activities/hotels schema gap analysis)
+- Matrix: [[product-detail-matrix]]

--- a/lib/admin/product-resolver.ts
+++ b/lib/admin/product-resolver.ts
@@ -1,0 +1,134 @@
+/**
+ * W2 #216 — Product type resolver for Studio dashboard editors.
+ *
+ * Abstracts dual-table access for `/dashboard/[websiteId]/products/[slug]/*`
+ * routes. Resolves a slug to either a `package_kits` row or an `activities`
+ * row, preferring `package_kits` when both tables have a row with the same
+ * slug under the same account (package precedence mirrors the existing
+ * public URL namespace `/paquetes/[slug]` vs `/actividades/[slug]`).
+ *
+ * Hotels are intentionally NOT resolved here — per ADR-025 Hotels remain
+ * Flutter-owner for the pilot and have no Studio editor surface.
+ *
+ * Related:
+ *   - ADR-025 studio-flutter-field-ownership
+ *   - #216 W2 AC-W2-10 (route + actions product-type-aware)
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { GalleryItem } from '@/components/admin/marketing/gallery-curator';
+
+export type ProductEditorType = 'package' | 'activity';
+
+export interface ProductEditorRow {
+  id: string;
+  account_id: string;
+  slug: string;
+  description: string | null;
+  description_ai_generated: boolean | null;
+  program_highlights: string[] | null;
+  highlights_ai_generated: boolean | null;
+  program_inclusions: string[] | null;
+  program_exclusions: string[] | null;
+  program_notes: string | null;
+  program_meeting_info: string | null;
+  program_gallery: GalleryItem[] | null;
+  cover_image_url: string | null;
+  video_url: string | null;
+  video_caption: string | null;
+  last_edited_by_surface: string | null;
+}
+
+export interface ResolvedProduct {
+  productType: ProductEditorType;
+  row: ProductEditorRow;
+}
+
+type ResolveMode = 'marketing' | 'content';
+
+interface ResolveInput {
+  accountId: string;
+  slug: string;
+  mode: ResolveMode;
+}
+
+const MARKETING_COLUMNS =
+  'id, account_id, slug, description, description_ai_generated, program_highlights, highlights_ai_generated, program_inclusions, program_exclusions, program_notes, program_meeting_info, program_gallery, cover_image_url, video_url, video_caption, last_edited_by_surface';
+
+const CONTENT_COLUMNS =
+  'id, account_id, slug, video_url, video_caption, last_edited_by_surface';
+
+export async function resolveProductRow(
+  supabase: SupabaseClient,
+  input: ResolveInput,
+): Promise<ResolvedProduct | null> {
+  const { accountId, slug, mode } = input;
+  const columns = mode === 'marketing' ? MARKETING_COLUMNS : CONTENT_COLUMNS;
+
+  const { data: pkg } = await supabase
+    .from('package_kits')
+    .select(columns)
+    .eq('slug', slug)
+    .eq('account_id', accountId)
+    .maybeSingle();
+
+  if (pkg) {
+    return { productType: 'package', row: normalize(pkg as unknown as Record<string, unknown>) };
+  }
+
+  const { data: act } = await supabase
+    .from('activities')
+    .select(columns)
+    .eq('slug', slug)
+    .eq('account_id', accountId)
+    .maybeSingle();
+
+  if (act) {
+    return { productType: 'activity', row: normalize(act as unknown as Record<string, unknown>) };
+  }
+
+  return null;
+}
+
+/**
+ * Maps the typed DB columns into the common editor row shape. The marketing
+ * editors receive the same field names regardless of product type — mismatches
+ * between `package_kits` / `activities` column names (e.g. activities legacy
+ * `inclutions`/`exclutions` typos) are bridged here as NULL-coalescing reads:
+ * new parity columns shipped in migration 20260502031000 take precedence;
+ * legacy typo'd columns stay on the row for Flutter back-compat (see ADR-025).
+ */
+function normalize(row: Record<string, unknown>): ProductEditorRow {
+  return {
+    id: String(row.id),
+    account_id: String(row.account_id),
+    slug: String(row.slug ?? ''),
+    description: (row.description as string | null) ?? null,
+    description_ai_generated: (row.description_ai_generated as boolean | null) ?? null,
+    program_highlights: (row.program_highlights as string[] | null) ?? null,
+    highlights_ai_generated: (row.highlights_ai_generated as boolean | null) ?? null,
+    program_inclusions: (row.program_inclusions as string[] | null) ?? null,
+    program_exclusions: (row.program_exclusions as string[] | null) ?? null,
+    program_notes: (row.program_notes as string | null) ?? null,
+    program_meeting_info: (row.program_meeting_info as string | null) ?? null,
+    program_gallery: (row.program_gallery as GalleryItem[] | null) ?? null,
+    cover_image_url: (row.cover_image_url as string | null) ?? null,
+    video_url: (row.video_url as string | null) ?? null,
+    video_caption: (row.video_caption as string | null) ?? null,
+    last_edited_by_surface: (row.last_edited_by_surface as string | null) ?? null,
+  };
+}
+
+/**
+ * Public URL prefix for the product type — used by `revalidatePath`.
+ */
+export function publicPathPrefix(productType: ProductEditorType): '/paquetes' | '/actividades' {
+  return productType === 'package' ? '/paquetes' : '/actividades';
+}
+
+/**
+ * `website_product_pages.product_type` discriminator value.
+ */
+export function pageProductTypeValue(productType: ProductEditorType): 'package' | 'activity' {
+  return productType;
+}

--- a/supabase/migrations/20260502030000_marketing_field_rpc_expand.sql
+++ b/supabase/migrations/20260502030000_marketing_field_rpc_expand.sql
@@ -1,0 +1,126 @@
+-- ============================================================================
+-- W2 #216 — Option A expansion of update_package_kit_marketing_field RPC.
+-- Adds `video_url`, `video_caption`, `description_ai_generated`,
+-- `highlights_ai_generated` to the column allowlist so that the two legacy
+-- raw-UPDATE actions (`saveVideoUrl`, `toggleAiFlag` in
+-- `app/dashboard/[websiteId]/products/[slug]/content/actions.ts`) route through
+-- the single-tx RPC that sets `app.edit_surface='studio'` — making the
+-- `package_kits_audit_log` trigger stamp `surface='studio'` and
+-- `last_edited_by_surface='studio'` on the row.
+--
+-- Signature preserved (uuid, uuid, text, jsonb, text). Callers that previously
+-- passed a column name in the Option-0 allowlist remain unaffected.
+--
+-- Related: ADR-025 (Studio / Flutter field ownership), #190, #165, #216 AC-W2-6.
+-- ============================================================================
+
+create or replace function public.update_package_kit_marketing_field(
+  p_product_id uuid,
+  p_account_id uuid,
+  p_column text,
+  p_value jsonb,
+  p_ai_flag_column text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_slug text;
+  v_sql text;
+  v_rowcount int;
+begin
+  -- Validate column name against allowlist to prevent SQL injection via p_column.
+  -- W2 #216 extension: add video_url, video_caption, description_ai_generated,
+  -- highlights_ai_generated to let saveVideoUrl + toggleAiFlag route through here.
+  if p_column not in (
+    'description', 'program_highlights', 'program_inclusions',
+    'program_exclusions', 'program_notes', 'program_meeting_info',
+    'program_gallery', 'cover_image_url',
+    -- W2 #216 additions (Option A):
+    'video_url', 'video_caption',
+    'description_ai_generated', 'highlights_ai_generated'
+  ) then
+    raise exception 'INVALID_COLUMN: %', p_column;
+  end if;
+
+  if p_ai_flag_column is not null
+     and p_ai_flag_column not in ('description_ai_generated', 'highlights_ai_generated') then
+    raise exception 'INVALID_AI_FLAG_COLUMN: %', p_ai_flag_column;
+  end if;
+
+  -- Transaction-scoped surface marker — trigger reads this.
+  perform set_config('app.edit_surface', 'studio', true);
+
+  -- Dynamic UPDATE constrained by column allowlist above. The three shape
+  -- families are: (a) text columns (description/notes/meeting_info/cover +
+  -- video_url/caption), (b) jsonb columns (highlights/inclusions/exclusions/
+  -- gallery), (c) boolean columns (ai_generated flags).
+  if p_column in ('description', 'program_notes', 'program_meeting_info',
+                  'cover_image_url', 'video_url', 'video_caption') then
+    if p_ai_flag_column is not null then
+      v_sql := format(
+        'update public.package_kits set %I = ($1)::text, %I = false, last_edited_by_surface = ''studio'', updated_at = now() where id = $2 and account_id = $3 returning slug',
+        p_column, p_ai_flag_column
+      );
+    else
+      v_sql := format(
+        'update public.package_kits set %I = ($1)::text, last_edited_by_surface = ''studio'', updated_at = now() where id = $2 and account_id = $3 returning slug',
+        p_column
+      );
+    end if;
+
+    execute v_sql
+      into v_slug
+      using p_value #>> '{}', p_product_id, p_account_id;
+  elsif p_column in ('description_ai_generated', 'highlights_ai_generated') then
+    -- Boolean AI flag toggle — value is jsonb true/false; coerce safely.
+    v_sql := format(
+      'update public.package_kits set %I = ($1)::boolean, last_edited_by_surface = ''studio'', updated_at = now() where id = $2 and account_id = $3 returning slug',
+      p_column
+    );
+    execute v_sql
+      into v_slug
+      using (p_value #>> '{}')::boolean, p_product_id, p_account_id;
+  else
+    -- jsonb columns: highlights / inclusions / exclusions / gallery.
+    if p_ai_flag_column is not null then
+      v_sql := format(
+        'update public.package_kits set %I = $1, %I = false, last_edited_by_surface = ''studio'', updated_at = now() where id = $2 and account_id = $3 returning slug',
+        p_column, p_ai_flag_column
+      );
+    else
+      v_sql := format(
+        'update public.package_kits set %I = $1, last_edited_by_surface = ''studio'', updated_at = now() where id = $2 and account_id = $3 returning slug',
+        p_column
+      );
+    end if;
+
+    execute v_sql
+      into v_slug
+      using p_value, p_product_id, p_account_id;
+  end if;
+
+  get diagnostics v_rowcount = row_count;
+  if v_rowcount = 0 then
+    raise exception 'NOT_FOUND_OR_CROSS_TENANT: product_id=% account_id=%', p_product_id, p_account_id;
+  end if;
+
+  return jsonb_build_object(
+    'success', true,
+    'product_id', p_product_id,
+    'slug', v_slug,
+    'column', p_column,
+    'ai_flag_reset', p_ai_flag_column is not null
+  );
+end;
+$$;
+
+grant execute on function public.update_package_kit_marketing_field(uuid, uuid, text, jsonb, text) to authenticated, service_role;
+
+-- Rollback: restore the pre-W2 allowlist by reverting to migration
+-- 20260426000300_marketing_field_update_rpc.sql (same signature, narrower
+-- allowlist). Downgrade command:
+--   create or replace function public.update_package_kit_marketing_field(...)
+--     -- body with only the 8 original columns in the allowlist.

--- a/supabase/migrations/20260502031000_activity_marketing_field_rpc.sql
+++ b/supabase/migrations/20260502031000_activity_marketing_field_rpc.sql
@@ -1,0 +1,206 @@
+-- ============================================================================
+-- W2 #216 v2 — Activities marketing parity (DDL + RPC).
+--
+-- AC-W2-9, AC-W2-13: brings `activities` to column parity with `package_kits`
+-- for Studio marketing editors (description + program_* + gallery + video +
+-- AI-flag + social). Legacy typo'd columns (`inclutions`, `exclutions`,
+-- `recomendations`, `instructions`) are PRESERVED additively so Flutter can
+-- continue reading them while Studio writes to the new parity columns.
+-- Public renderer falls back to legacy columns when new columns are NULL (see
+-- ADR-025 bridge semantics + audit doc).
+--
+-- Must run AFTER 20260502030000 (package_kits RPC expansion) so the ordering
+-- keeps Studio’s two RPCs side-by-side at DB level.
+--
+-- Related: ADR-025 (Studio / Flutter field ownership), #204 (activities parity
+-- follow-up absorbed by this v2 scope), #190, #216.
+-- ============================================================================
+
+-- ─── 1. DDL: additive parity columns on activities ─────────────────────────
+
+alter table public.activities
+  add column if not exists program_highlights jsonb not null default '[]'::jsonb,
+  add column if not exists program_inclusions jsonb not null default '[]'::jsonb,
+  add column if not exists program_exclusions jsonb not null default '[]'::jsonb,
+  add column if not exists program_notes text,
+  add column if not exists program_meeting_info text,
+  add column if not exists program_gallery jsonb not null default '[]'::jsonb,
+  add column if not exists video_url text,
+  add column if not exists video_caption text,
+  add column if not exists description_ai_generated boolean not null default false,
+  add column if not exists highlights_ai_generated boolean not null default false,
+  add column if not exists cover_image_url text,
+  add column if not exists last_ai_hash text;
+
+-- URL shape check on video_url mirrors package_kits_video_url_shape.
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'activities_video_url_shape' and conrelid = 'public.activities'::regclass
+  ) then
+    alter table public.activities
+      add constraint activities_video_url_shape
+      check (video_url is null or video_url ~* '^https?://');
+  end if;
+end $$;
+
+comment on column public.activities.program_highlights is
+  'W2 #216 parity — Studio marketing editor writes here. Legacy jsonb, mirrors package_kits.';
+comment on column public.activities.program_inclusions is
+  'W2 #216 parity — Studio writes here. Legacy Flutter column `inclutions` (typo) stays for back-compat.';
+comment on column public.activities.program_exclusions is
+  'W2 #216 parity — Studio writes here. Legacy Flutter column `exclutions` (typo) stays for back-compat.';
+comment on column public.activities.program_notes is
+  'W2 #216 parity — Studio writes here. Legacy Flutter column `recomendations` (typo) stays for back-compat.';
+comment on column public.activities.program_meeting_info is
+  'W2 #216 parity — Studio writes here. Legacy Flutter column `instructions` stays for back-compat.';
+comment on column public.activities.program_gallery is
+  'W2 #216 parity — Studio writes here. Jsonb array of `{url, alt?, caption?}`.';
+comment on column public.activities.cover_image_url is
+  'W2 #216 parity — Studio writes here. Legacy column `main_image` stays for Flutter back-compat.';
+
+-- ─── 2. RPC: update_activity_marketing_field ──────────────────────────────
+-- Parallel to update_package_kit_marketing_field. Sets app.edit_surface='studio'
+-- in the same tx so fn_audit_activities() (migration 20260430000200) stamps
+-- surface='studio' and `last_edited_by_surface='studio'` on the row.
+
+create or replace function public.update_activity_marketing_field(
+  p_product_id uuid,
+  p_account_id uuid,
+  p_column text,
+  p_value jsonb,
+  p_ai_flag_column text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_slug text;
+  v_sql text;
+  v_rowcount int;
+begin
+  -- Column allowlist mirrors the package_kits RPC plus typo'd legacy columns
+  -- so Studio can optionally write to them for Flutter interop (off by default;
+  -- only the parity columns are exposed to editors).
+  if p_column not in (
+    'description', 'program_highlights', 'program_inclusions',
+    'program_exclusions', 'program_notes', 'program_meeting_info',
+    'program_gallery', 'cover_image_url',
+    'video_url', 'video_caption',
+    'description_ai_generated', 'highlights_ai_generated',
+    -- legacy typo'd columns exposed for optional Studio-side backfill
+    -- during transition (Flutter still writes them). Not wired from editors.
+    'inclutions', 'exclutions', 'recomendations', 'instructions',
+    -- activities-native social field (predates cover_image_url parity column):
+    'social_image'
+  ) then
+    raise exception 'INVALID_COLUMN: %', p_column;
+  end if;
+
+  if p_ai_flag_column is not null
+     and p_ai_flag_column not in ('description_ai_generated', 'highlights_ai_generated') then
+    raise exception 'INVALID_AI_FLAG_COLUMN: %', p_ai_flag_column;
+  end if;
+
+  -- Transaction-scoped surface marker — trigger reads this.
+  perform set_config('app.edit_surface', 'studio', true);
+
+  if p_column in (
+    'description', 'program_notes', 'program_meeting_info',
+    'cover_image_url', 'video_url', 'video_caption',
+    'recomendations', 'instructions', 'social_image'
+  ) then
+    if p_ai_flag_column is not null then
+      v_sql := format(
+        'update public.activities set %I = ($1)::text, %I = false, last_edited_by_surface = ''studio'', updated_at = now() where id = $2 and account_id = $3 returning slug',
+        p_column, p_ai_flag_column
+      );
+    else
+      v_sql := format(
+        'update public.activities set %I = ($1)::text, last_edited_by_surface = ''studio'', updated_at = now() where id = $2 and account_id = $3 returning slug',
+        p_column
+      );
+    end if;
+
+    execute v_sql
+      into v_slug
+      using p_value #>> '{}', p_product_id, p_account_id;
+  elsif p_column in ('description_ai_generated', 'highlights_ai_generated') then
+    v_sql := format(
+      'update public.activities set %I = ($1)::boolean, last_edited_by_surface = ''studio'', updated_at = now() where id = $2 and account_id = $3 returning slug',
+      p_column
+    );
+    execute v_sql
+      into v_slug
+      using (p_value #>> '{}')::boolean, p_product_id, p_account_id;
+  elsif p_column in ('inclutions', 'exclutions') then
+    -- Typo'd legacy columns are text on Flutter; Studio serializes jsonb arrays
+    -- back into newline-delimited text when writing to them (interop-only
+    -- path; editors do not use this — kept in allowlist for support tooling).
+    v_sql := format(
+      'update public.activities set %I = ($1)::text, last_edited_by_surface = ''studio'', updated_at = now() where id = $2 and account_id = $3 returning slug',
+      p_column
+    );
+    execute v_sql
+      into v_slug
+      using p_value #>> '{}', p_product_id, p_account_id;
+  else
+    -- jsonb columns: program_highlights / program_inclusions / program_exclusions / program_gallery.
+    if p_ai_flag_column is not null then
+      v_sql := format(
+        'update public.activities set %I = $1, %I = false, last_edited_by_surface = ''studio'', updated_at = now() where id = $2 and account_id = $3 returning slug',
+        p_column, p_ai_flag_column
+      );
+    else
+      v_sql := format(
+        'update public.activities set %I = $1, last_edited_by_surface = ''studio'', updated_at = now() where id = $2 and account_id = $3 returning slug',
+        p_column
+      );
+    end if;
+
+    execute v_sql
+      into v_slug
+      using p_value, p_product_id, p_account_id;
+  end if;
+
+  get diagnostics v_rowcount = row_count;
+  if v_rowcount = 0 then
+    raise exception 'NOT_FOUND_OR_CROSS_TENANT: product_id=% account_id=%', p_product_id, p_account_id;
+  end if;
+
+  return jsonb_build_object(
+    'success', true,
+    'product_id', p_product_id,
+    'slug', v_slug,
+    'column', p_column,
+    'ai_flag_reset', p_ai_flag_column is not null
+  );
+end;
+$$;
+
+grant execute on function public.update_activity_marketing_field(uuid, uuid, text, jsonb, text) to authenticated, service_role;
+
+comment on function public.update_activity_marketing_field(uuid, uuid, text, jsonb, text) is
+  'W2 #216 — Studio marketing field update for activities. Sets app.edit_surface=studio so audit trigger stamps surface. Column allowlist covers parity columns + legacy typo''d columns for interop. RLS: activities row must be accessible via account_id tenancy (enforced by caller + NOT_FOUND raise).';
+
+-- Rollback:
+--   drop function if exists public.update_activity_marketing_field(uuid, uuid, text, jsonb, text);
+--   alter table public.activities drop constraint if exists activities_video_url_shape;
+--   alter table public.activities
+--     drop column if exists program_highlights,
+--     drop column if exists program_inclusions,
+--     drop column if exists program_exclusions,
+--     drop column if exists program_notes,
+--     drop column if exists program_meeting_info,
+--     drop column if exists program_gallery,
+--     drop column if exists video_url,
+--     drop column if exists video_caption,
+--     drop column if exists description_ai_generated,
+--     drop column if exists highlights_ai_generated,
+--     drop column if exists cover_image_url,
+--     drop column if exists last_ai_hash;
+--   -- Legacy typo'd columns (`inclutions`, `exclutions`, `recomendations`, `instructions`)
+--   -- are NOT touched by this rollback.


### PR DESCRIPTION
## Summary

Ships Stage 2 W2 (#216 v2) per client priority change v2 (2026-04-19, EPIC #214 comment `#issuecomment-4276233308`):

- **Packages + Activities = Studio-editable** under `studio_editor_v2`.
- **Hotels = Flutter-owner** (pilot policy).
- **Option A** adopted consistently across both RPCs (single RPC per product type; column-allowlist expansion instead of dedicated flag/video RPCs).

Closes #216.

## Deliverables

### Migrations

- `supabase/migrations/20260502030000_marketing_field_rpc_expand.sql` — expands `update_package_kit_marketing_field` column allowlist to include `video_url`, `video_caption`, `description_ai_generated`, `highlights_ai_generated`. Signature preserved. AC-W2-6.
- `supabase/migrations/20260502031000_activity_marketing_field_rpc.sql` — activities parity DDL (12 new columns incl. `program_highlights`, `program_gallery`, `program_inclusions`, `program_exclusions`, `program_notes`, `program_meeting_info`, `video_url`, `video_caption`, `description_ai_generated`, `highlights_ai_generated`, `cover_image_url`, `last_ai_hash`) + new `update_activity_marketing_field` RPC mirroring the package_kits RPC safety posture (`SECURITY DEFINER`, column allowlist, `set_config('app.edit_surface','studio',true)` in-tx so `fn_audit_activities` stamps `surface='studio'`). Legacy typo'd columns (`inclutions`, `exclutions`, `recomendations`, `instructions`) **preserved additively** for Flutter back-compat; rename deferred post-pilot. AC-W2-9, AC-W2-13.

### App (routes + actions + helper)

- `lib/admin/product-resolver.ts` — new helper. `resolveProductRow(supabase, { accountId, slug, mode })` probes `package_kits` first, then `activities`, returning `{ productType, row }`. `publicPathPrefix` + `pageProductTypeValue` exposed for `revalidatePath` + `website_product_pages` overlay.
- `app/dashboard/[websiteId]/products/[slug]/{marketing,content}/page.tsx` — both routes now use the resolver; every editor callback passes `productType` to the save action. Type is surfaced in the header strip for partners.
- `app/dashboard/[websiteId]/products/[slug]/{marketing,content}/actions.ts` — `ensurePackageTenancy` generalized → `ensureTenancy(productType)`. `saveMarketingField`, `saveHeroOverride`, `saveVisibility`, `saveOrder`, `saveCustomSections`, `saveVideoUrl`, `toggleAiFlag` all dispatch to the right table / RPC based on `productType`. `saveVideoUrl` + `toggleAiFlag` now go through the expanded RPC so `last_edited_by_surface='studio'` is stamped (AC-W2-6).
- Editor components untouched — they stay presentational. Product-type-aware wiring lives at the page/action boundary.

### Docs

- `docs/architecture/ADR-025-studio-flutter-field-ownership.md` — Status: Proposed → **Accepted 2026-04-19**. Decision section finalized with pkg + act Studio-editable row, hotels Flutter-owner row, `website_product_pages` always-Studio caveat, Option A rationale, field → pkg column → act column mapping table, related migrations, consequences, alternatives.
- `docs/product/studio-editor-parity-audit.md` — new doc. Full trace editor → server action → DB column → public renderer for both product types (packages + activities). Legacy-column fallback semantics. `last_edited_by_surface` verification procedure with SQL probes. ISR revalidate matrix.
- `docs/INDEX.md` — ADR-025 status updated to Accepted; wikilink for `studio-editor-parity-audit` added to resolution map.

### Tests

- `__tests__/lib/features/studio-editor-v2.test.ts` — copy aligned with "3 scopes + per-field whitelist" (was "4 levels"). New suite `product type parity` asserts flag resolution is product-type-agnostic.
- `__tests__/lib/features/resolve-studio-editor-v2.test.ts` — new. Integration-style spec against a mocked Supabase client. Covers: website scope, account scope, default scope, RPC error fallback, malformed payload fallback, per-field whitelist for act + pkg editors.

## Out of scope (per shared context / ADR-025)

- **E2E specs** — owned by W4 (#218). W2 ships the trace that W4 consumes.
- **Hotel RPCs** — Flutter-owner for pilot (no `update_hotel_marketing_field` here).
- **Rename of legacy typo'd activities columns** — post-pilot cleanup.
- **Booking V1** — deferred per ADR-024 (#217 docs-only DEFER).

## Validation

- `npx tsc --noEmit` → clean.
- `npm run lint` + `lint:hardcoded-ui` → clean (one pre-existing `<img>` warning unrelated to this PR).
- `npm test -- --testPathPattern=studio-editor-v2|resolve-studio-editor-v2` → 2 suites / 11 tests passed.
- Supabase migration dry-run: no local Supabase CLI available in this environment; migrations were reviewed statically. Apply via normal CI deploy gate.

## Test plan

- [ ] Apply both migrations against staging; confirm `update_activity_marketing_field` RPC callable by authenticated + service_role, rejected for anon.
- [ ] Seed an activity with `inclutions`/`exclutions` text payloads (Flutter style); load `/dashboard/{ws}/products/{activity-slug}/marketing` in Studio; edit each of the 9 editors; verify `activities.last_edited_by_surface='studio'` after every save and `surface='studio'` in `product_edit_history`.
- [ ] Edit video URL + AI flag on both a package and an activity; verify header strip flips `last-edit: studio`.
- [ ] Verify `/actividades/{slug}` public page reflects Studio-written parity columns after ISR revalidation; confirm fallback to legacy typo'd columns when parity column is NULL.
- [ ] Flip `studio_editor_v2` website-scoped whitelist to a subset; verify editors render read-only for excluded fields and `saveMarketingField` throws `FIELD_NOT_STUDIO_OWNED` on direct call.

## References

- EPIC: #214
- Spec: #216 v2 (Priority Change v2 comment `#issuecomment-4276233308`)
- Round 3 TVB: comment `#4276265533` (APPROVED with follow-ups — all addressed in this PR)
- ADR: `docs/architecture/ADR-025-studio-flutter-field-ownership.md`
- Audit: `docs/product/studio-editor-parity-audit.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)