### PR TITLE
[Stage 2 / W7-a] Onboarding + runbook + cutover (#221)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,7 +4,7 @@
 >
 > **Convention:** `[[ADR-XXX]]` or `[[SPEC_NAME]]` = wikilink resolved below. `[text](path.md)` = regular markdown link. Both coexist.
 
-Last updated: 2026-04-19 (EPIC #214 Stage 1 W1 — matrix refresh pkg+act editable + blog Section P + hotels as-is + Section M booking DEFER; pilot-readiness concept section expanded with matrix/ADR wikilinks); 2026-04-19 (ADR-025 priority-v2 alignment: Activities target Studio ownership with W2 pending); 2026-04-19 (EPIC #214 client priority change v2 — pilot-readiness concept scope notes); 2026-04-19 (EPIC #214 Stage 0 — ADR-024 + ADR-025 skeletons + pilot-readiness-deps); 2026-04-19 (EPIC #190 certification rerun evidence); 2026-04-18 (EPIC #190 certification run evidence + checklist); 2026-04-17 (WIKI full-refresh + #103 media closure checklist); 2026-04-17 wiki-patch (epic128 evidence + issue resolution rows)
+Last updated: 2026-04-19 (EPIC #214 Stage 2 W7-a — training onboarding ColombiaTours + pilot runbook + cutover checklist); 2026-04-19 (EPIC #214 Stage 1 W1 — matrix refresh pkg+act editable + blog Section P + hotels as-is + Section M booking DEFER; pilot-readiness concept section expanded with matrix/ADR wikilinks); 2026-04-19 (ADR-025 priority-v2 alignment: Activities target Studio ownership with W2 pending); 2026-04-19 (EPIC #214 client priority change v2 — pilot-readiness concept scope notes); 2026-04-19 (EPIC #214 Stage 0 — ADR-024 + ADR-025 skeletons + pilot-readiness-deps); 2026-04-19 (EPIC #190 certification rerun evidence); 2026-04-18 (EPIC #190 certification run evidence + checklist); 2026-04-17 (WIKI full-refresh + #103 media closure checklist); 2026-04-17 wiki-patch (epic128 evidence + issue resolution rows)
 
 ---
 
@@ -119,7 +119,19 @@ Feature requests formalized. Status tracked inline. GitHub Issues = source of tr
 | [[github-actions-billing-incident]] | [file](./ops/github-actions-billing-incident.md) | Runbook: CI fails in 3-4s → GitHub billing/spending-limit issue, not code. |
 | [[transcreate-website-content-runbook]] | [file](./ops/transcreate-website-content-runbook.md) | End-to-end flow: traducir todo el contenido de un sitio (glossary → AI draft → review → apply → verify). |
 | [[studio-editor-v2-rollback]] | [file](./ops/studio-editor-v2-rollback.md) | Rollback runbook for #190 Studio Editor v2 — 4 levels (field / website / account / data restore) + pre-flight re-enable gate. |
+| [[pilot-runbook-colombiatours]] | [file](./ops/pilot-runbook-colombiatours.md) | EPIC #214 pilot cutover runbook (cross-links 4 existing runbooks; DNS TTL / ±24 h Flutter rule / SLA / post-cutover cadence). |
+| [[cutover-checklist]] | [file](./ops/cutover-checklist.md) | Standalone reusable cutover checklist imported into pilot runbook §5.1 (preflight / cutover / post-cutover / rollback criteria + sequence). |
+| [[release-gate-checklist]] | [file](./ops/release-gate-checklist.md) | Go/No-Go automated gate checklist for prod deploys (EPIC #207 certification). |
+| [[ci-seo-i18n-gate]] | [file](./ops/ci-seo-i18n-gate.md) | CI gate `@p0-seo` + nightly Worker preview (ADR-013). |
 | [[product-landing-rollout-runbook]] | [file](./runbooks/product-landing-rollout-runbook.md) | Rollout for public site rendering / ISR changes. |
+
+---
+
+## Training
+
+| Wikilink | File | Audience | Purpose |
+|----------|------|----------|---------|
+| [[colombiatours-onboarding]] | [file](./training/colombiatours-onboarding.md) | Partner Rol 2 (ColombiaTours) | Pilot onboarding: Flows 1-5 (marketing / booking-DEFER / layout / SEO / translation) + FAQ + what-NOT-to-do + cheat-sheet. Spanish-first. Screencasts pending W7-c. |
 
 ---
 
@@ -353,6 +365,7 @@ Each concept below lists the ADRs/SPECs/ops docs that touch it. Use this to find
 - Stage 0 artefacts (2026-04-19): [[ADR-024-booking-v1-pilot-scope]] · [[ADR-025-studio-flutter-field-ownership]] · [[pilot-readiness-deps]]
 - Recovery Gate prereq of Stage 4: [#226](https://github.com/weppa-cloud/bukeer-studio/issues/226) QA Recovery Gate P0 GUI (blocks W4 #218, W5 #219, W6 #220 kickoff; details in [[pilot-readiness-deps]] §Parallel / Recovery Gate)
 - Stage 1 W1 artefacts (2026-04-19): [[product-detail-matrix]] (refresh pkg+act editable + Sections M/N/O/P + Hotel column as-is + 🟡-flag legend) · [[package-detail-anatomy]] (hygiene checklist cross-ref) · [[product-detail-inventory]] (§3.2 ownership matrix aligned with matrix Sections N/O)
+- Stage 2 W7-a artefacts (2026-04-19): [[colombiatours-onboarding]] (partner-facing training — Flows 1-5 + FAQ + what-NOT-to-do + cheat-sheet; screencasts pending W7-c) · [[pilot-runbook-colombiatours]] (operational runbook — cross-links 4 existing runbooks; DNS TTL / ±24 h Flutter rule / SLA / post-cutover cadence) · [[cutover-checklist]] (standalone preflight/cutover/post-cutover/rollback checklist)
 - **Client priority change v2 (2026-04-19)** — logged in [[pilot-readiness-deps]]: priority 1 = translation (blog + pkg + act); priority 2 = editing (pkg + act Studio editors); hotels as-is (Flutter-owner); booking V1 DEFER post-pilot (ADR-024 Accepted PR pending); no rate-limit mitigation. W2 + W5 bumped to XL; W3 becomes docs-only DEFER closure.
 - Matrix foundation: [[product-detail-matrix]] (W1 pkg+act editable + Section M Booking DEFER + Section N editor→campo + Section O Flutter-only gaps + Section P Blog transcreate + 🟡-flag legend + Hotel column as-is)
 - Cross-repo boundary: [[cross-repo-flutter]] (Flutter-owner fields per [[ADR-025]])
@@ -394,6 +407,11 @@ Obsidian resolves `[[ADR-005]]` by filename stem or alias. Claude Code / Codex g
 | `[[ADR-025]]` | `docs/architecture/ADR-025-studio-flutter-field-ownership.md` |
 | `[[ADR-025-studio-flutter-field-ownership]]` | `docs/architecture/ADR-025-studio-flutter-field-ownership.md` |
 | `[[pilot-readiness-deps]]` | `docs/specs/pilot-readiness-deps.md` |
+| `[[colombiatours-onboarding]]` | `docs/training/colombiatours-onboarding.md` |
+| `[[pilot-runbook-colombiatours]]` | `docs/ops/pilot-runbook-colombiatours.md` |
+| `[[cutover-checklist]]` | `docs/ops/cutover-checklist.md` |
+| `[[release-gate-checklist]]` | `docs/ops/release-gate-checklist.md` |
+| `[[ci-seo-i18n-gate]]` | `docs/ops/ci-seo-i18n-gate.md` |
 | `[[ADR-022]]` | Flutter repo — auth token boundary |
 | `[[ADR-032]]` | Flutter repo — catalog v2 |
 | `[[ARCHITECTURE]]` | `docs/architecture/ARCHITECTURE.md` |

--- a/docs/ops/cutover-checklist.md
+++ b/docs/ops/cutover-checklist.md
@@ -1,0 +1,152 @@
+# Cutover Checklist — ColombiaTours Pilot
+
+Standalone, reusable checklist imported into [`pilot-runbook-colombiatours.md`](./pilot-runbook-colombiatours.md) §5.1. Can be copied per-tenant for future pilots (adjust tenant-specific values at the top).
+
+**Pilot tenant:** ColombiaTours (`colombiatours.travel`).
+**Worker:** `bukeer-web-public`.
+**Related runbooks (do NOT duplicate — see them for full detail):**
+- [`product-landing-v1-runbook.md`](./product-landing-v1-runbook.md) — structural precedent (preflight / deploy / monitoring / rollback).
+- [`release-gate-checklist.md`](./release-gate-checklist.md) — Go/No-Go automated gate.
+- [`studio-editor-v2-rollback.md`](./studio-editor-v2-rollback.md) — Studio editor flag rollback L1–L4.
+- [`ci-seo-i18n-gate.md`](./ci-seo-i18n-gate.md) — `@p0-seo` CI gate + nightly Worker preview.
+
+> **Booking-specific rows removed per priority change v2 (2026-04-19).** Booking V1 is DEFERRED post-pilot. WhatsApp + phone CTA parity stays.
+
+---
+
+## Preflight — T-24 h
+
+Owner: **Release lead** unless noted.
+
+| # | Item | Owner | Verification |
+|---|------|-------|--------------|
+| P-01 | DNS TTL lowered to **300 s** on `colombiatours.travel` apex + CNAME | Platform | `dig colombiatours.travel +short` + `dig A colombiatours.travel` TTL column |
+| P-02 | No Flutter migration scheduled in the ±24 h window | Cross-repo lead | Link to last commit of migrations in `weppa-cloud/bukeer-flutter` with timestamp |
+| P-03 | On-call staffed (platform + release lead + partner liaison) | Release lead | Names posted in `#pilot-colombiatours` |
+| P-04 | Worker `bukeer-web-public` current deploy verified green | Platform | `npx wrangler deployments list --name bukeer-web-public` — top entry matches `main` HEAD |
+| P-05 | Lighthouse baseline captured (home + pkg detail + act detail + blog detail, es + en) | QA | Artifact link to `artifacts/qa/pilot/<date>/lighthouse-baseline/` |
+| P-06 | Pilot seed `pilot-colombiatours-*` clean in staging | QA | `cleanupPilotSeed` log green; zero stale rows |
+| P-07 | Partner Slack channel `#pilot-colombiatours` active with partner + oncall + release lead | Release lead | Channel member list |
+| P-08 | Release-gate checklist fully signed off | Release lead | `release-gate-checklist.md` all boxes ticked |
+| P-09 | Rollback command verified in staging (`npx wrangler rollback --name bukeer-web-public` dry-run) | Platform | Staging incident log entry with elapsed time |
+| P-10 | Comms template (pre-deploy) posted in partner channel | Release lead | Slack link |
+
+---
+
+## Cutover — T-0
+
+Owner: **Release lead** + **Platform on-call**.
+
+| # | Item | Owner | Verification |
+|---|------|-------|--------------|
+| C-01 | Final Go/No-Go call — all preflight rows ticked | Release lead | Comment on #213 + Slack |
+| C-02 | DNS change executed (`colombiatours.travel` A/CNAME → Worker) | Platform | `dig` + `curl -I https://colombiatours.travel` → 200 |
+| C-03 | Worker `bukeer-web-public` serves `colombiatours.travel` | Platform | `curl -s https://colombiatours.travel | head -3` + `cf-ray` header present |
+| C-04 | Smoke tests via Playwright MCP (home, 1 pkg, 1 act, 1 blog, `/en/` variants) | QA | Smoke artifacts saved to `artifacts/qa/pilot/<date>/cutover-smoke/` |
+| C-05 | JSON-LD probe on 4 content types | QA | `curl -s https://colombiatours.travel/paquetes/<slug> \| grep -c 'application/ld+json'` ≥ 1 |
+| C-06 | Sitemap reachable | QA | `curl -s https://colombiatours.travel/sitemap.xml \| xmllint --noout -` |
+| C-07 | `robots.txt` + `llms.txt` reachable | QA | `curl -I https://colombiatours.travel/robots.txt` 200 |
+| C-08 | Partner Slack notified — deploy started | Release lead | Slack message (template §6.2 of `product-landing-v1-runbook.md`) |
+
+---
+
+## Post-cutover — T+15 min
+
+Owner: **Platform on-call**.
+
+| # | Item | Owner | Verification |
+|---|------|-------|--------------|
+| PC-01 | Traffic rate on Worker nominal (no drop, no spike anomaly) | Platform | CF Observability dashboard link |
+| PC-02 | Worker 5xx rate < 1% | Platform | `npx wrangler tail bukeer-web-public --status=error` for 5 min |
+| PC-03 | P95 TTFB < 1500 ms | Platform | CF Observability |
+| PC-04 | Core Web Vitals sample (home + pkg detail, mobile + desktop) | QA | Lighthouse vs baseline (P-05) — delta ≤ 10 pts |
+| PC-05 | Search Console inspection sample (home + 1 pkg + 1 act + 1 blog, es + en) | SEO owner | `mcp__search-console__inspection_inspect` output saved |
+| PC-06 | WhatsApp CTA + phone CTA parity check on pkg + act | Partner | Manual click → WhatsApp deep-link opens with correct number |
+| PC-07 | ISR revalidation working | Platform | `POST /api/revalidate` to 1 known slug + verify response in < 60 s |
+| PC-08 | Partner confirms first edit cycle on Studio post-cutover | Partner | Slack confirmation with slug + timestamp |
+
+---
+
+## Rollback criteria — any breach = decide rollback
+
+Owner: **Release lead** (decision) + **Platform** (execution).
+
+| # | Criterion | Threshold |
+|---|-----------|-----------|
+| R-01 | Worker error rate sustained 5 min | > 2% |
+| R-02 | P95 TTFB sustained 5 min | > 3 s |
+| R-03 | Search Console "Could not fetch" on inspection sample | > 20% |
+| R-04 | Partner reports blocking critical issue | Any confirmed blocker |
+| R-05 | Missing JSON-LD on any content type | Any miss |
+| R-06 | Broken WhatsApp/phone CTA deep-link | Any type |
+
+If any criterion fires → **decide rollback within 10 min**.
+
+---
+
+## Rollback sequence — ≤ 5 min execution
+
+Owner: **Platform on-call**.
+
+| # | Step | Target time | Command / action |
+|---|------|-------------|------------------|
+| RB-01 | Decision call by release lead | ≤ 10 min from signal | Slack announcement + record trigger |
+| RB-02 | Partner comms (template §6.4 of `product-landing-v1-runbook.md`) | ≤ 1 min | Slack post |
+| RB-03 | Worker rollback | ≤ 2 min | `npx wrangler rollback --name bukeer-web-public` |
+| RB-04 | DNS revert (if DNS cutover is what introduced the regression) | ≤ 2 min | Cloudflare DNS panel → revert to prior A/CNAME |
+| RB-05 | Cache purge (CF + Vercel edge if dirty) | ≤ 1 min | CF dashboard → Purge custom URLs |
+| RB-06 | Verify rollback (curl + Lighthouse quick) | ≤ 2 min | `curl -I https://colombiatours.travel` + spot-check page |
+| RB-07 | Revalidate ISR with rolled-back build | ≤ 1 min | `bash scripts/revalidate-all-tenants.sh` |
+| RB-08 | Post-mortem issue opened | ≤ 24 h | GitHub issue with `post-mortem` label + runbook link |
+
+**Studio editor v2 misbehavior:** if the trigger is a flag-level Studio editor issue (not Worker), do **NOT** run Worker rollback. Follow [`studio-editor-v2-rollback.md`](./studio-editor-v2-rollback.md) L1–L4 instead.
+
+**Translation rollback:** revert to prior `Reviewed` state in Studio; public URL falls back to base locale until republish. No Worker rollback needed.
+
+---
+
+## Post-rollback — within 30 min
+
+| # | Item | Owner | Verification |
+|---|------|-------|--------------|
+| PR-01 | Partner notified of rollback outcome | Release lead | Slack |
+| PR-02 | `curl -I https://colombiatours.travel` returns 200 | Platform | Command output |
+| PR-03 | ISR refreshed all tenants | Platform | Script log green |
+| PR-04 | Post-rollback checklist from `product-landing-v1-runbook.md` §8.4 completed | Platform | Runbook link |
+| PR-05 | Post-mortem issue opened + linked to this runbook | Release lead | Issue URL |
+
+---
+
+## DNS TTL guidance
+
+| Phase | TTL | Rationale |
+|-------|-----|-----------|
+| T-24 h to T+24 h | **300 s (5 min)** | Fast rollback window; DNS revert propagation ≤ 5 min |
+| T+24 h onwards (soak complete) | **3600 s (1 h)** | Normal resolver cache; cost of rollback acceptable |
+
+Raise TTL back to 3600 s only after the +24 h cadence checkpoint passes.
+
+---
+
+## SLA targets — summary
+
+| Action | Target |
+|--------|--------|
+| Rollback decision | ≤ 10 min from first confirmed signal |
+| Rollback execution (`wrangler rollback`) | ≤ 5 min |
+| DNS propagation (with TTL 300 s) | ≤ 60 s |
+| Partner comms post-rollback | ≤ 1 min |
+| Post-mortem issue opened | ≤ 24 h |
+
+---
+
+## Sign-off (per cutover instance)
+
+| Role | Name | Date | Status |
+|------|------|------|--------|
+| Release lead |  |  |  |
+| Platform on-call |  |  |  |
+| QA lead |  |  |  |
+| Partner (ColombiaTours) |  |  |  |
+
+File a copy of this completed checklist under `docs/qa/pilot/sign-off-YYYY-MM-DD.md` per cutover (or rollback) event.

--- a/docs/ops/pilot-runbook-colombiatours.md
+++ b/docs/ops/pilot-runbook-colombiatours.md
@@ -1,0 +1,187 @@
+# Pilot Runbook — ColombiaTours
+
+**Tenant:** ColombiaTours (`colombiatours.travel`).
+**Worker:** `bukeer-web-public`.
+**Owner:** Release lead + Platform on-call.
+**Status:** Active for EPIC [#214](https://github.com/weppa-cloud/bukeer-studio/issues/214) pilot cutover.
+**Last updated:** 2026-04-19 (W7-a skeleton).
+
+This runbook **cross-references and extends** four existing runbooks. It does **NOT** duplicate their content. Consult each linked runbook at the referenced step:
+
+- [`product-landing-v1-runbook.md`](./product-landing-v1-runbook.md) — structural precedent (preflight / deploy / monitoring / rollback).
+- [`release-gate-checklist.md`](./release-gate-checklist.md) — Go/No-Go automated gate.
+- [`studio-editor-v2-rollback.md`](./studio-editor-v2-rollback.md) — Studio editor flag rollback L1–L4.
+- [`ci-seo-i18n-gate.md`](./ci-seo-i18n-gate.md) — `@p0-seo` CI gate + nightly Worker preview.
+
+Audience: on-call engineers, release lead, partner liaison, orchestrator. Training audience (partner Rol 2) reads [`docs/training/colombiatours-onboarding.md`](../training/colombiatours-onboarding.md) instead.
+
+---
+
+## 1. Scope snapshot (priority change v2 — 2026-04-19)
+
+- **Translation** top priority — blog + packages + activities (hotels excluded from transcreate).
+- **Editing** second — packages + activities Studio-editable; hotels Flutter-owner (SEO meta still editable in Studio).
+- **Booking V1 DEFERRED** post-pilot — WhatsApp + phone CTAs only. See [[ADR-024]] + issue [#217](https://github.com/weppa-cloud/bukeer-studio/issues/217).
+- **No rate-limit mitigation** required — client accepts direct transcreate API usage.
+
+Full context: priority change v2 comment on EPIC [#214](https://github.com/weppa-cloud/bukeer-studio/issues/214).
+
+---
+
+## 2. Cutover checklist (imported)
+
+Full checklist lives in [`cutover-checklist.md`](./cutover-checklist.md). Summary of sections:
+
+1. Preflight (T-24 h) — 10 items (P-01 … P-10).
+2. Cutover (T-0) — 8 items (C-01 … C-08).
+3. Post-cutover (T+15 min) — 8 items (PC-01 … PC-08).
+4. Rollback criteria — 6 triggers (R-01 … R-06).
+5. Rollback sequence (≤ 5 min exec) — 8 steps (RB-01 … RB-08).
+6. Post-rollback — 5 items (PR-01 … PR-05).
+7. DNS TTL guidance.
+8. SLA targets summary.
+9. Sign-off template.
+
+**Owner of each row + verification command / URL** is defined in the checklist file. Copy that checklist into the cutover-day artifact bundle.
+
+**Booking-specific rows removed** per priority change v2. WhatsApp + phone CTA parity check stays (see PC-06 in `cutover-checklist.md`).
+
+---
+
+## 3. Preflight rule — no Flutter migration ±24 h
+
+Hard constraint: **no Flutter migration may land in the ±24 h window around cutover.**
+
+Rationale: the Supabase project is shared between Studio (Next.js) and Flutter admin. A Flutter-side schema change during the cutover window can silently break Studio SSR or Studio writes. Mitigation is coordination — the bukeer-flutter maintainers hold migrations while the pilot cutover is live.
+
+Verification (preflight item P-02):
+- Link to last commit of migrations in `weppa-cloud/bukeer-flutter` with timestamp.
+- Cross-repo confirmation in `#pilot-colombiatours` or equivalent Slack channel before T-0.
+
+Forward-only rule (general): **NEVER run `supabase migration down`** for Flutter migrations (`#752`, `#753`, `#754`). See `product-landing-v1-runbook.md` §8.3.
+
+---
+
+## 4. 48-h soak on staging
+
+Mirrors `product-landing-v1-runbook.md` §3.2.
+
+- Staging Worker with pilot-seeded ColombiaTours data must be green for 48 h before cutover.
+- Monitor at T+5 min, T+1 h, T+4 h, T+24 h, T+48 h (KPIs from `product-landing-v1-runbook.md` §5).
+- Soak may be waived (explicit decision + sign-off) if staging is not representative and direct ColombiaTours validation is performed — record rationale in the release-gate checklist appendix.
+
+---
+
+## 5. Rollback SLA targets
+
+| Action | Target |
+|--------|--------|
+| Decision (release lead) | ≤ 10 min from first confirmed signal |
+| Execution (`wrangler rollback`) | ≤ 5 min |
+| Propagation (Worker) | ≤ 60 s |
+| DNS propagation (with TTL 300 s) | ≤ 60 s |
+| Partner comms post-rollback | ≤ 1 min |
+| Post-mortem issue opened | ≤ 24 h |
+
+Escalation chain: owner → platform on-call → release lead. See `product-landing-v1-runbook.md` §7 post-mortem triggers.
+
+**DNS TTL policy:**
+- Cutover day: ≤ 300 s on apex/CNAME.
+- Post-soak (after T+24 h cadence): 3600 s.
+
+**Worker rollback:** `npx wrangler rollback --name bukeer-web-public`. See `product-landing-v1-runbook.md` §8.
+
+**Studio editor v2 flag rollback:** for editor-surface regressions (not Worker-level), follow [`studio-editor-v2-rollback.md`](./studio-editor-v2-rollback.md) L1–L4 **instead of** Worker rollback.
+
+**Translation rollback:** revert to prior `Reviewed` state in Studio → public URL falls back to base locale until republish. No Worker rollback needed.
+
+---
+
+## 6. Post-cutover cadence
+
+Mirrors `product-landing-v1-runbook.md` §10 closeout; expanded with partner-facing checkpoints.
+
+### T+24 h
+
+| Item | Owner | KPI |
+|------|-------|-----|
+| Error rate review | Platform | < 2% sustained |
+| P95 TTFB review | Platform | < 1500 ms |
+| CWV review (home + pkg + act + blog, es + en) | QA | Delta vs baseline ≤ 10 pts |
+| Partner confirms first edit cycle post-cutover | Partner | Slack comment with slug |
+| ISR revalidation working on sample | Platform | `POST /api/revalidate` success |
+
+### T+7 d
+
+| Item | Owner | KPI |
+|------|-------|-----|
+| Google Search Console indexing delta | SEO owner | > 80% of pilot URLs indexed |
+| Organic impressions baseline vs WordPress pre-migration | SEO owner | No regression > 20% |
+| Partner satisfaction check-in | Partner liaison | Comment on [#213](https://github.com/weppa-cloud/bukeer-studio/issues/213) |
+| Coverage matrix drift alerts triaged | QA | 0 unresolved `error` alerts |
+| Any follow-up P0 issues opened | Release lead | GitHub issue links |
+
+### T+30 d
+
+| Item | Owner | KPI |
+|------|-------|-----|
+| Organic ranking delta vs baseline | SEO owner | No regression on top-20 target keywords |
+| Conversion tracking delta (WhatsApp CTA CTR) | Growth | Within ±30% of baseline |
+| Formal ownership transfer (Studio) to partner | Release lead | Email / Slack confirmation archived |
+| EPIC closeout | Orchestrator | Close #214 + #213 + sign-off comment on #207 |
+| Post-mortem archived even if no incidents | Release lead | `docs/ops/post-mortem/pilot-colombiatours-cutover.md` |
+
+---
+
+## 7. Soft-freeze during screencast capture
+
+Between screencast capture day (W7-c) and partner review session, **do not** land PRs that touch Studio editorial surfaces without a `screencast-refresh` ticket. This prevents the partner-facing training from drifting from the UI they will see live.
+
+---
+
+## 8. What NOT to do (runbook-level prohibitions)
+
+Partner-facing list lives in `colombiatours-onboarding.md` §"Qué NO debes hacer". Ops-level additions:
+
+1. **NO run `supabase migration down`** for any migration (Flutter or Studio). Forward-only policy.
+2. **NO land Flutter migration in ±24 h cutover window.** Preflight §3.
+3. **NO edit `websites.theme.tokens` JSON manually in the DB.** Use Studio or `@bukeer/theme-sdk` preset. CHECK constraint enforces v3 shape.
+4. **NO run `npm run test:e2e` directly from any agent.** Use session pool (`npm run session:run`). Port 3000 is reserved for manual dev. See `.claude/rules/e2e-sessions.md`.
+5. **NO `wrangler deploy` local for production.** All prod deploys go via CI for audit. See `product-landing-v1-runbook.md` §3.3.
+6. **NO bypass `@p0-seo` gate** without written go from release lead + incident issue + post-mortem follow-up. See `ci-seo-i18n-gate.md` §Emergency bypass.
+7. **NO expose date picker / lead form** — Booking V1 DEFERRED. See [[ADR-024]].
+8. **NO edit hotel marketing/content in Studio** — Flutter-owner. See [[ADR-025]].
+
+---
+
+## 9. Evidence & artifacts
+
+Per-cutover bundle: `artifacts/qa/pilot/YYYY-MM-DD/`.
+
+- `lighthouse-baseline/` — preflight P-05.
+- `cutover-smoke/` — cutover C-04 Playwright MCP outputs.
+- `post-cutover-15min/` — PC-01 … PC-08 outputs.
+- `cadence-24h/` · `cadence-7d/` · `cadence-30d/` — per-checkpoint notes.
+- `incidents/` — if any rollback or degradation event.
+
+Sign-off: `docs/qa/pilot/sign-off-YYYY-MM-DD.md` (template in `cutover-checklist.md` §Sign-off).
+
+---
+
+## 10. Related
+
+- Parent EPIC: [#214](https://github.com/weppa-cloud/bukeer-studio/issues/214).
+- Acceptance sibling: [#213](https://github.com/weppa-cloud/bukeer-studio/issues/213).
+- Certification: [#207](https://github.com/weppa-cloud/bukeer-studio/issues/207).
+- Matrix foundation: [[product-detail-matrix]] (pilot scope).
+- Dependency gate: [[pilot-readiness-deps]].
+- Partner-facing training: [`docs/training/colombiatours-onboarding.md`](../training/colombiatours-onboarding.md).
+- Cutover checklist (standalone): [`cutover-checklist.md`](./cutover-checklist.md).
+- Cross-repo bridge: [[cross-repo-flutter]].
+- ADR references: [[ADR-007]] · [[ADR-011]] · [[ADR-016]] · [[ADR-019]] · [[ADR-020]] · [[ADR-021]] · [[ADR-023]] · [[ADR-024]] · [[ADR-025]].
+
+---
+
+## Changelog
+
+- **2026-04-19** — Initial skeleton (W7-a). Cross-linked 4 existing runbooks; imported cutover checklist; documented DNS TTL guidance + preflight ±24 h rule; SLA target table; post-cutover cadence T+24h / T+7d / T+30d; soft-freeze rule; ops-level NOT-TO-DO list. Booking-specific rows removed per priority change v2. Screencasts + final Flow 6 Variant A / Flow 7 Variant B details deferred to W7-b + W7-c.

--- a/docs/training/colombiatours-onboarding.md
+++ b/docs/training/colombiatours-onboarding.md
@@ -1,0 +1,428 @@
+# Onboarding ColombiaTours — Bukeer Studio (Pilot)
+
+> **Audiencia:** Partner operativo de ColombiaTours (Rol 2 — gestor de contenido). **NO** requiere conocimientos de código, Supabase, ni despliegues.
+>
+> **Qué aprenderás:** cómo editar el contenido de tu sitio público (paquetes y actividades), cómo traducir contenido al inglés y cómo leer el tablero de cobertura SEO. Todo se hace desde Studio (interfaz web).
+
+**Última revisión:** 2026-04-19.
+**Versión doc:** W7-a skeleton (screencasts pendientes en W7-c).
+**Issue tracker:** [#221](https://github.com/weppa-cloud/bukeer-studio/issues/221) · EPIC [#214](https://github.com/weppa-cloud/bukeer-studio/issues/214).
+
+---
+
+## Tabla de contenido
+
+1. [Antes de empezar](#antes-de-empezar)
+2. [Flow 1 — Editar marketing de un paquete](#flow-1--editar-marketing-de-un-paquete)
+3. [Flow 2 — Reservas / Booking (DEFERRED post-pilot)](#flow-2--reservas--booking-deferred-post-pilot)
+4. [Flow 3 — Layout de secciones: hero, video, orden, ocultar, custom](#flow-3--layout-de-secciones-hero-video-orden-ocultar-custom)
+5. [Flow 4 — SEO personalizado por página](#flow-4--seo-personalizado-por-página)
+6. [Flow 5 — Traducción es-CO → en-US (3 sub-flows)](#flow-5--traducción-es-co--en-us-3-sub-flows)
+7. [FAQ — preguntas frecuentes](#faq--preguntas-frecuentes)
+8. [Qué **NO** debes hacer](#qué-no-debes-hacer)
+9. [Cheat-sheet "Si ves X, haz Y"](#cheat-sheet-si-ves-x-haz-y)
+10. [Cómo pedir ayuda](#cómo-pedir-ayuda)
+
+---
+
+## Antes de empezar
+
+- **URL del dashboard:** `https://<dashboard>/dashboard/<websiteId>/`.
+- **Credenciales:** las recibes por el canal oficial (Slack / email) antes del training.
+- **Sesión:** expira tras inactividad; si ves pantalla de login, vuelve a ingresar.
+- **Alcance editorial pilot (confirmado 2026-04-19):**
+  - **Paquetes:** editables 100% desde Studio (marketing + contenido + SEO + traducción).
+  - **Actividades:** editables desde Studio (mismos campos que paquetes, vía W2).
+  - **Hoteles:** se editan en Flutter (equipo catálogo). Studio permite editar **solo** el meta SEO del hotel. Ver [FAQ #5](#por-qué-los-hoteles-se-editan-en-flutter-y-no-en-studio).
+  - **Blog:** editable y traducible desde Studio.
+  - **Reservas (booking):** **no** hay date picker ni formulario de lead todavía. Pilot usa WhatsApp + teléfono. Ver [Flow 2](#flow-2--reservas--booking-deferred-post-pilot) y [FAQ #6](#por-qué-no-hay-date-picker-todavía).
+
+[SCREENSHOT: Dashboard home landing — sidebar con Products / Translations / SEO / Ops]
+
+---
+
+## Flow 1 — Editar marketing de un paquete
+
+**Objetivo:** ajustar la descripción, highlights, inclusiones/exclusiones, galería, recomendaciones e imagen de portada de un paquete existente.
+
+**Ruta Studio:** `/dashboard/<websiteId>/products/<slug>/marketing`
+
+### Pasos
+
+1. **Abrir el paquete.** Desde el sidebar → `Products` → buscar el paquete → clic en el nombre.
+   [SCREENSHOT: Lista de paquetes con campo de búsqueda]
+2. **Entrar al editor de marketing.** Pestaña `Marketing`.
+   [SCREENSHOT: Pestañas Marketing / Content / SEO del detalle de paquete]
+3. **Editar descripción.** Bloque `Descripción` → escribe / pega texto → guardar. Si el texto fue generado por IA verás un badge; puedes reescribirlo manualmente (ver [FAQ #2](#el-badge-de-ia-no-desaparece)).
+   [SCREENSHOT: Editor de descripción con badge AI visible]
+4. **Editar highlights.** Bloque `Highlights` → lista ordenable → arrastrar para reordenar, botón `+` para agregar.
+   [SCREENSHOT: Editor de highlights con lista ordenable]
+5. **Editar inclusiones y exclusiones.** Bloques `Inclusiones` y `Exclusiones` → mismas listas ordenables.
+   [SCREENSHOT: Editor de inclusiones / exclusiones]
+6. **Editar recomendaciones.** Bloque `Recomendaciones` (texto libre + tips).
+   [SCREENSHOT: Editor de recomendaciones]
+7. **Curar galería.** Bloque `Galería` → subir imágenes, reordenar, marcar portada.
+   [SCREENSHOT: Gallery curator con drag-to-reorder]
+8. **Cambiar imagen de portada (cover).** Botón "establecer como portada" sobre una imagen de la galería.
+   [SCREENSHOT: Cover selector con imagen activa destacada]
+9. **Verificar en público.** Abrir `https://<tu-dominio>/paquetes/<slug>` en nueva pestaña. Debería reflejar los cambios en menos de 60 s (ISR). Si no aparece, ver [FAQ #7](#cambio-no-se-refleja).
+   [SCREENSHOT: URL pública del paquete con cambios aplicados]
+
+### Resultado esperado
+
+- El paquete muestra el banner `last_edited_by_surface=studio` (debug / admin view).
+- Badges de IA se muestran si el campo fue generado por IA; desaparecen tras edición manual.
+- Cambios visibles en `/paquetes/<slug>` tras la ventana ISR.
+
+### Errores comunes
+
+- "Guardé pero no veo el cambio" → [FAQ #7](#cambio-no-se-refleja).
+- "La portada no actualiza en las cards del home" → [FAQ #1](#cover-image-no-se-actualiza-en-cards).
+- "Veo 'Solo lectura'" → [FAQ #11](#flag-studio_editor_v2-off--por-qué-aparece-solo-lectura).
+
+---
+
+## Flow 2 — Reservas / Booking (DEFERRED post-pilot)
+
+**Estado: DIFERIDO.** No hay walkthrough de booking en este pilot.
+
+ColombiaTours pilot sale a producción con **WhatsApp + teléfono** como canales de conversión. **No** hay selector de fechas (date picker), **no** hay formulario de lead, **no** hay endpoint `/api/leads` activo. Esto es una decisión explícita del cliente en la reunión del 2026-04-19.
+
+El CTA de WhatsApp sigue siendo la señal de conversión canónica (evento `whatsapp_cta_click`, paridad con el pilot Product Landing v1).
+
+### Referencias
+
+- **ADR-024** (Accepted-DEFER 2026-04-19): `docs/architecture/ADR-024-booking-v1-pilot-scope.md`.
+- **Issue [#217](https://github.com/weppa-cloud/bukeer-studio/issues/217)** — W3 Booking decisión DEFER.
+- **Priority change v2 comment** en EPIC [#214](https://github.com/weppa-cloud/bukeer-studio/issues/214).
+
+**Qué dice el FAQ cuando un cliente pregunta "¿y el botón de reservar?"** Ver [FAQ #6](#por-qué-no-hay-date-picker-todavía).
+
+[SCREENSHOT: Página de producto pública mostrando CTA WhatsApp + teléfono, sin date picker]
+
+---
+
+## Flow 3 — Layout de secciones: hero, video, orden, ocultar, custom
+
+**Objetivo:** cambiar el hero, agregar video, reordenar / ocultar secciones del detalle del producto (paquete o actividad), o inyectar una sección custom.
+
+**Ruta Studio:** `/dashboard/<websiteId>/products/<slug>/content`.
+
+Aplica a **paquetes + actividades** (mismos editores). Hoteles: ver [FAQ #5](#por-qué-los-hoteles-se-editan-en-flutter-y-no-en-studio).
+
+### Pasos — Hero override
+
+1. Pestaña `Content` del producto.
+2. Bloque `Hero override` → elegir imagen / video / configuración alternativa al hero por defecto.
+3. Guardar → preview lateral refresca.
+4. Verificar URL pública.
+
+[SCREENSHOT: Hero override editor con preview]
+
+### Pasos — Video URL
+
+1. Bloque `Video` → pegar URL (YouTube / Vimeo / MP4 directo).
+2. Guardar.
+3. Verificar que el lightbox de video abre desde el hero.
+
+[SCREENSHOT: Video URL editor]
+
+### Pasos — Reordenar / ocultar secciones
+
+1. Bloque `Sections layout`.
+2. Lista de secciones (Hero, Highlights, Itinerary, Gallery, Inclusiones, FAQ, etc.) con handles de drag.
+3. Arrastra para reordenar.
+4. Toggle "Ocultar" por sección → la sección desaparece del render público.
+5. Guardar.
+
+[SCREENSHOT: Sections reorder con toggles de visibilidad]
+
+### Pasos — Inyectar sección custom
+
+1. Bloque `Custom sections`.
+2. Botón `+ Agregar custom section` → elige un tipo del registry (ver [[SECTION_TYPES_REGISTRY]] — interno, no editable aquí).
+3. Rellena los campos (título, copy, imágenes, CTA).
+4. Guardar → aparece en el orden que elegiste en el paso anterior.
+
+[SCREENSHOT: Custom section injector con preview]
+
+### Resultado esperado
+
+- El render público de `/paquetes/<slug>` (o `/actividades/<slug>`) respeta el nuevo orden.
+- Secciones ocultas no se exponen ni en HTML ni en sitemap (si marcaste `robotsNoindex` en SEO — ver Flow 4).
+- Video lightbox abre desde el hero.
+
+---
+
+## Flow 4 — SEO personalizado por página
+
+**Objetivo:** override de `title`, `meta description`, FAQ schema, robots, canonical.
+
+**Ruta Studio:** `/dashboard/<websiteId>/seo/<itemType>/<itemId>`.
+
+Alcance: 4 tipos de contenido — `package`, `activity`, `hotel`, `blog`. (Hoteles: SEO sí editable aquí, aunque marketing/content sea Flutter-owner.)
+
+### Pasos
+
+1. Sidebar → `SEO` → seleccionar tipo (package / activity / hotel / blog) → clic en el ítem.
+2. **Title override** → deja vacío si quieres usar el generado automático; escribe para override.
+3. **Meta description override** → igual, vacío = automático.
+4. **FAQ schema** → agregar Q&A que se emiten como `FAQPage` JSON-LD.
+5. **Robots** → toggle `noindex` / `nofollow` por página si la quieres fuera del índice de Google.
+6. **Canonical URL** → campo opcional; deja en blanco para que Studio use la canónica por defecto.
+7. Guardar.
+8. Verificar en `/<tipo>/<slug>` → inspeccionar `<head>` (título + meta + canonical + robots).
+9. (Opcional) Probar en [Google Rich Results Test](https://search.google.com/test/rich-results) si editaste FAQ schema.
+
+[SCREENSHOT: Editor SEO con title / description / FAQ / robots]
+
+### Resultado esperado
+
+- `<title>` y `<meta description>` en el HTML reflejan tu override.
+- `FAQPage` JSON-LD aparece en el head si agregaste Q&A.
+- Si marcaste `noindex`: la página NO aparece en sitemap. Si marcaste solo `nofollow` (y no `noindex`): sigue en sitemap pero con directivas robots correctas. Ver [FAQ #3](#sitemap-incluye-páginas-ocultas) para la regla exacta.
+
+---
+
+## Flow 5 — Traducción es-CO → en-US (3 sub-flows)
+
+**Objetivo:** traducir contenido es-CO → en-US para que se publique en `/en/...`.
+
+Alcance: **paquetes + actividades + blog** (hoteles NO están en scope de transcreate pilot — ver [FAQ #5](#por-qué-los-hoteles-se-editan-en-flutter-y-no-en-studio)).
+
+**Ruta Studio:** `/dashboard/<websiteId>/translations` (o entry point del dashboard de traducción).
+
+**Ciclo de vida de una traducción:** `Draft` → `Reviewed` → `Applied`. (Los nombres de estado están en inglés porque la UI de Studio los maneja así — están en el i18n catalog.)
+
+### Flow 5.a — Traducir un paquete
+
+1. **Picker.** Abrir dashboard de traducciones → filtrar por tipo `Package` → seleccionar paquete.
+   [SCREENSHOT: Translations picker con filtro Package]
+2. **Stream.** Disparar transcreate → UI muestra stream en vivo (ADR-021 pipeline).
+   [SCREENSHOT: Transcreate stream en progreso]
+3. **Corregir draft.** Revisa línea por línea. Edita términos, tono, keywords locales.
+   [SCREENSHOT: Bilingual editor es-CO / en-US con diferencias resaltadas]
+4. **Reviewed.** Marcar estado `Reviewed` cuando esté listo (opcional: segundo par de ojos).
+   [SCREENSHOT: Estado Draft → Reviewed]
+5. **Applied.** Botón `Apply` publica a `en`. Coverage matrix refresca.
+   [SCREENSHOT: Apply action con confirmación]
+6. **Verificar URL pública.** Abrir `/en/paquetes/<slug>` en nueva pestaña. Validar:
+   - `<html lang="en">`
+   - `<link rel="alternate" hreflang="en">` y contraparte en español
+   - `<link rel="canonical" href="/en/paquetes/<slug>">`
+   - JSON-LD con `inLanguage: "en"` en los campos traducibles
+   [SCREENSHOT: URL pública /en/paquetes/<slug>]
+
+### Flow 5.b — Traducir una actividad
+
+Mismo ciclo; solo cambia el filtro y el path público:
+
+1. Picker → filtro `Activity` → seleccionar.
+2. Stream → corregir → Reviewed → Applied.
+3. Verificar `/en/actividades/<slug>`.
+
+[SCREENSHOT: Translations picker filtro Activity]
+[SCREENSHOT: URL pública /en/actividades/<slug>]
+
+### Flow 5.c — Traducir un blog post
+
+1. Picker → filtro `Blog` → seleccionar post.
+2. Stream → corregir → Reviewed → Applied.
+3. Verificar `/en/blog/<slug>`.
+
+[SCREENSHOT: Translations picker filtro Blog]
+[SCREENSHOT: URL pública /en/blog/<slug>]
+
+### Common — Rollback de traducción
+
+Si al hacer `Apply` algo sale mal:
+
+1. En Studio, vuelve al estado `Reviewed` del registro (hay un selector de revisión anterior).
+2. La URL pública vuelve al locale base (es) hasta que re-publiques.
+3. Procedimiento L1–L4 detallado en [`docs/ops/studio-editor-v2-rollback.md`](../ops/studio-editor-v2-rollback.md).
+
+### Coverage + drift
+
+- Pantalla `Coverage` muestra % traducido por tipo (pkg / act / blog) y alertas de drift (contenido cambió en es-CO después de aplicar en en-US → re-traducir).
+- Si ves una alerta de drift, re-entra al Flow 5.x correspondiente para el ítem listado.
+
+[SCREENSHOT: Coverage matrix con drift alerts]
+
+### Resultado esperado
+
+- URL pública `/en/paquetes/<slug>` (o `/en/actividades/<slug>`, o `/en/blog/<slug>`) renderiza contenido traducido.
+- Head incluye hreflang + canonical + `inLanguage` correctos (ADR-019, ADR-020).
+- Si desactivas en-US, el language switcher hace fallback según ADR-019 — ver [FAQ #4](#language-switcher-salta-al-homepage).
+
+---
+
+## FAQ — preguntas frecuentes
+
+### Cover image no se actualiza en cards
+
+**Síntoma:** cambiaste la portada del paquete pero las cards del home siguen mostrando la anterior.
+
+**Causa:** ventana ISR + cache CDN.
+
+**Resolución:**
+1. Esperar hasta 60 s (ISR window).
+2. Si persiste, probar la URL directa `curl -I https://<tu-dominio>/paquetes/<slug>` y leer header `cf-cache-status`:
+   - `HIT` = Cloudflare aún sirve cache viejo → esperar o pedir purge.
+   - `MISS` / `EXPIRED` = ya tomó el valor nuevo → forzar refresh del navegador (Ctrl+Shift+R).
+3. Si sigue mal después de 5 min, [Cómo pedir ayuda](#cómo-pedir-ayuda).
+
+### El badge de IA no desaparece
+
+**Síntoma:** editaste el texto manualmente pero sigue apareciendo "Generado por IA".
+
+**Causa:** el flag `*_ai_generated=true` no se limpia automáticamente en todos los casos.
+
+**Resolución:** un admin puede correr un override manual `ai_generated=false` en el campo afectado. Avísale al equipo en el canal de soporte con el slug del paquete y el campo (description / highlights / etc.).
+
+### Sitemap incluye páginas ocultas
+
+**Síntoma:** oculté una sección / página y aparece en `sitemap.xml`.
+
+**Causa:** la regla `robotsNoindex` per-page controla la inclusión en el sitemap. "Ocultar" una sección dentro de un producto no saca al producto del sitemap — lo oculta del render.
+
+**Resolución:**
+- Si quieres que la página completa NO esté en sitemap → Flow 4 → marca `noindex`.
+- Si solo quieres ocultar una sección dentro de una página que sigue indexable → Flow 3 (toggle de visibilidad).
+- Referencia: [[ADR-019]] `docs/architecture/ADR-019-multi-locale-url-routing.md` (reglas de sitemap inclusion).
+
+### Language switcher salta al homepage
+
+**Síntoma:** hago clic en "EN" y me manda al home, no al equivalente en inglés de la página actual.
+
+**Causa:** comportamiento fallback de [[ADR-019]]: si la ruta actual no tiene traducción aplicada (`Applied`) en el locale target, el switcher hace fallback al home de ese locale en lugar de dejarte en una URL rota.
+
+**Resolución:**
+- Traduce la página (Flow 5) → aplicar → el switcher respeta la ruta específica.
+- Mientras tanto, la coverage matrix te dice qué falta traducir.
+
+### Por qué los hoteles se editan en Flutter y no en Studio
+
+**Respuesta corta:** decisión de ownership confirmada con cliente el 2026-04-19 para el pilot.
+
+**Respuesta larga:** hoteles tienen un catálogo canónico mantenido en la app Flutter del equipo operaciones (availability, pricing, inventory). Duplicar un editor de marketing en Studio sin la RPC correspondiente generaría drift. Para el pilot:
+
+- **Marketing + contenido de hotel** → editar en Flutter (equipo catálogo).
+- **Meta SEO del hotel** → editar en Studio (Flow 4).
+- **Traducción del hotel** → fuera de scope pilot (hoteles NO están en Flow 5).
+
+Post-pilot: si se construye `update_hotel_marketing_field` RPC, Studio podría adoptar la edición. Ver [[ADR-025]] `docs/architecture/ADR-025-studio-flutter-field-ownership.md` y `.claude/rules/cross-repo-flutter.md`.
+
+### Por qué no hay date picker todavía
+
+**Respuesta corta:** Booking V1 diferido post-pilot por decisión del cliente el 2026-04-19.
+
+**Respuesta larga:** el pilot sale a producción con WhatsApp + teléfono como canales de conversión. Agregar date picker + formulario de lead requiere endpoint `/api/leads` activo + validación + analytics nuevo, todo diferido. Ver [Flow 2](#flow-2--reservas--booking-deferred-post-pilot), [[ADR-024]] `docs/architecture/ADR-024-booking-v1-pilot-scope.md`, issue [#217](https://github.com/weppa-cloud/bukeer-studio/issues/217).
+
+### Sesión expira
+
+**Síntoma:** veo pantalla de login o "Tu sesión ha expirado".
+
+**Resolución:** volver a iniciar sesión con tus credenciales. Si no tienes las credenciales, [Cómo pedir ayuda](#cómo-pedir-ayuda).
+
+### Cambio no se refleja
+
+**Síntoma:** guardé un cambio en Studio y no se ve en el sitio público.
+
+**Resolución en orden:**
+1. Esperar hasta 60 s (ventana ISR).
+2. Forzar refresh del navegador (Ctrl+Shift+R).
+3. Probar en ventana privada / otro navegador para descartar cache local.
+4. Si persiste, avisar al equipo con el slug afectado.
+
+### Error 429
+
+**Síntoma:** ves "429 Too Many Requests".
+
+**Estado actual (pilot):** **no** debería ocurrir en operación normal. El cliente aceptó el uso directo de la API de transcreate sin mitigaciones de TM short-circuit. Si aparece, reportar al equipo.
+
+### Traducción parece no actualizarse
+
+**Síntoma:** apliqué una traducción (`Applied`) y la URL `/en/...` sigue mostrando el texto viejo o en español.
+
+**Resolución:**
+1. Verifica que el estado está en `Applied` (no solo `Reviewed`).
+2. Ventana ISR — esperar 60 s.
+3. Refrescar navegador.
+4. Distinguir entre:
+   - **Coverage cache** (tablero de traducciones) — actualiza cada ~5 min.
+   - **Render cache** (página pública) — ISR, ~60 s.
+5. Si el coverage dice `Applied` pero la URL pública sigue en español → forzar revalidación (pedir al equipo correr `POST /api/revalidate` si hace falta).
+
+### Flag studio_editor_v2 off — por qué aparece "Solo lectura"
+
+**Síntoma:** entro a un editor y todos los campos están deshabilitados con mensaje "Solo lectura — este campo se edita en Flutter".
+
+**Causa:** el flag `studio_editor_v2` está desactivado (globalmente, por cuenta o por sitio). Esto puede ser por un rollback preventivo post-incidente.
+
+**Resolución:** contactar al equipo; el runbook de rollback [`docs/ops/studio-editor-v2-rollback.md`](../ops/studio-editor-v2-rollback.md) §8 documenta el proceso de re-habilitación.
+
+### Cómo pedir ayuda
+
+**Canal primario:** Slack — canal `#pilot-colombiatours` (invitación enviada pre-cutover).
+
+**SLA pilot:**
+- Incidente crítico (sitio caído, error rate > 2%) → respuesta ≤ 10 min dentro de horario operativo.
+- Duda operativa (cómo editar X, dónde está Y) → respuesta ≤ 1 día hábil.
+- Request de cambio (nuevo feature, reescribir doc) → triage en sync semanal.
+
+**Información que necesitamos cuando reportas:**
+- URL afectada.
+- Slug del producto / paquete / blog.
+- Captura de pantalla si es UI.
+- Hora aproximada del problema.
+- Qué esperabas vs qué viste.
+
+---
+
+## Qué **NO** debes hacer
+
+Esta sección es vinculante. Hacer cualquiera de estas cosas puede romper el sitio o perder datos.
+
+1. **NO ejecutar `supabase migration down`** (aplica a cualquier migración, pero especialmente a migraciones del repo Flutter `#752`, `#753`, `#754`). Las migraciones son forward-only. Ver `docs/ops/product-landing-v1-runbook.md` §8.3.
+2. **NO landear migraciones Flutter en la ventana cutover ±24 h.** Preflight §5.2 del pilot runbook.
+3. **NO editar manualmente el blob JSON `theme.tokens` en la DB.** Usa Studio o un theme-sdk preset.
+4. **NO correr `npm run test:e2e` directo** desde un agente o terminal local. Usar siempre el session pool (`npm run session:run`). Puerto 3000 es exclusivo para dev manual. Ver `.claude/rules/e2e-sessions.md`.
+5. **NO ejecutar `wrangler deploy` local para producción.** Todos los deploys prod van por CI (auditoría). Ver `docs/ops/product-landing-v1-runbook.md` §3.3.
+6. **NO saltarse el gate `@p0-seo`** sin justificación escrita del release lead. Ver `docs/ops/ci-seo-i18n-gate.md` §Emergency bypass.
+7. **NO intentar editar hotel marketing/content en Studio.** Hotel es Flutter-owner. Usa el handoff protocol o el equipo catálogo. SEO del hotel sí va en Studio (Flow 4).
+8. **NO exponer date picker / lead form en pilot cutover.** Booking V1 está DEFERRED.
+
+---
+
+## Cheat-sheet "Si ves X, haz Y"
+
+| Si ves... | Haz... |
+|-----------|--------|
+| "Solo lectura" en un editor | [FAQ #11](#flag-studio_editor_v2-off--por-qué-aparece-solo-lectura) — contactar equipo |
+| Badge "Generado por IA" que no se va | [FAQ #2](#el-badge-de-ia-no-desaparece) — pedir override manual |
+| Cambio guardado pero invisible en público | [FAQ #7](#cambio-no-se-refleja) — esperar 60 s + refresh forzado |
+| Cover vieja en las cards del home | [FAQ #1](#cover-image-no-se-actualiza-en-cards) — probe `cf-cache-status` |
+| Sitemap incluye una página que oculté | [FAQ #3](#sitemap-incluye-páginas-ocultas) — usar `noindex` en Flow 4, no solo hide |
+| Language switcher salta al home | [FAQ #4](#language-switcher-salta-al-homepage) — traducir la página (Flow 5) |
+| Hotel no aparece en editor marketing | [FAQ #5](#por-qué-los-hoteles-se-editan-en-flutter-y-no-en-studio) — es Flutter-owner |
+| Cliente pregunta por botón "Reservar" | [FAQ #6](#por-qué-no-hay-date-picker-todavía) — Booking DEFERRED |
+| Error 429 | [FAQ #9](#error-429) — reportar (no debería ocurrir) |
+| Traducción aplicada pero público en español | [FAQ #10](#traducción-parece-no-actualizarse) — distinguir coverage cache vs render cache |
+
+---
+
+## Cómo pedir ayuda
+
+- **Canal Slack:** `#pilot-colombiatours`
+- **SLA crítico:** ≤ 10 min (error rate > 2%, sitio caído).
+- **SLA operativo:** ≤ 1 día hábil (dudas, cómo editar X).
+- **Incluir siempre:** URL + slug + screenshot + hora + expectativa vs realidad.
+
+---
+
+**Cambios en este documento:** se versiona con el repo. Screencasts (W7-c) reemplazarán los `[SCREENSHOT: ...]` placeholders cuando se graben contra la UI final post-cutover.
+
+**Referencias rápidas:**
+- [`docs/ops/pilot-runbook-colombiatours.md`](../ops/pilot-runbook-colombiatours.md) — runbook operacional cutover.
+- [`docs/ops/cutover-checklist.md`](../ops/cutover-checklist.md) — checklist cutover day.
+- [[ADR-019]] · [[ADR-020]] · [[ADR-021]] · [[ADR-024]] · [[ADR-025]].


### PR DESCRIPTION
## Summary

Stage 2 W7-a of EPIC #214 pilot readiness — training + ops documentation skeleton covering Flows 1-5, operational runbook, and standalone cutover checklist for the ColombiaTours cutover.

- **`docs/training/colombiatours-onboarding.md`** — partner-facing training (Rol 2 audience, Spanish-first). Covers Flow 1 (marketing edit pkg), Flow 2 (Booking DEFER note w/ WhatsApp+phone CTAs), Flow 3 (layout: hero/video/sections), Flow 4 (SEO per-page), Flow 5 (3 transcreate sub-flows: pkg/act/blog). FAQ (cover ISR, AI badge, sitemap hidden, language switcher fallback, hoteles Flutter-owner, no date picker, etc.), what-NOT-to-do list, cheat-sheet, SLA. Screencast placeholders for W7-c.
- **`docs/ops/pilot-runbook-colombiatours.md`** — operational runbook cross-linking (NOT duplicating) `product-landing-v1-runbook.md`, `release-gate-checklist.md`, `studio-editor-v2-rollback.md`, `ci-seo-i18n-gate.md`. Priority-v2 scope snapshot, preflight ±24 h Flutter rule, 48 h soak, rollback SLA (≤10/5/60s), DNS TTL 300s/3600s, post-cutover cadence T+24h / T+7d / T+30d, soft-freeze rule, ops-level NOT-TO-DO.
- **`docs/ops/cutover-checklist.md`** — standalone reusable checklist (markdown checkboxes + owners + verification commands/URLs) imported into pilot runbook §5.1. Preflight (10 rows) / Cutover (8) / Post-cutover (8) / Rollback criteria (6) / Rollback sequence (8) / Post-rollback (5) / DNS TTL / SLA / Sign-off.
- **`docs/INDEX.md`** — ops table rows added; new Training section; pilot-readiness concept section Stage 2 W7-a artefacts entry; resolution map rows for 3 new artefacts + 2 cross-linked ops docs.

W7-b (Flows 6 Activity / 7 Hotel / 8 Flutter handoff) and W7-c (screencasts + partner session) follow in separate PRs per split plan.

## Test plan

- [ ] Review training doc as if reading partner-fresh — Flow 1..5 steps clear, FAQ answers partner likely questions.
- [ ] Verify runbook cross-links resolve to the four existing ops docs (no duplicated content).
- [ ] Verify cutover checklist row IDs P-01..P-10, C-01..C-08, PC-01..PC-08, R-01..R-06, RB-01..RB-08, PR-01..PR-05 are all present and have owner + verification column.
- [ ] INDEX wikilinks: `grep '\[\[colombiatours-onboarding\|\[\[pilot-runbook-colombiatours\|\[\[cutover-checklist' docs/` returns ≥ 3 (currently 7).
- [ ] Grep-gate: no hardcoded Studio UI copy strings in runbook/checklist code blocks (i18n keys only where applicable).
- [ ] No code changes, no spec bodies edited, no ADR edits.

## Follow-ups

- W7-b: Flows 6 Activity (Variant A — Studio native editor, depends on W2 merge), Flow 7 Hotel (Variant B Flutter handoff), Flow 8 what remains Flutter.
- W7-c: 8+ Loom screencasts (≤ 5 min each) + Drive mirror + partner review session; fills the `[SCREENSHOT: ...]` placeholders.
- Partner sign-off comment on #213 pre-session (AC-W7-7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)