### PR TITLE
docs(training): W7-b #221 — Flows 6/7/8 + cutover checklist + FAQ expansion

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,7 +4,7 @@
 >
 > **Convention:** `[[ADR-XXX]]` or `[[SPEC_NAME]]` = wikilink resolved below. `[text](path.md)` = regular markdown link. Both coexist.
 
-Last updated: 2026-04-19 (EPIC #214 Stage 2 W7-a — training onboarding ColombiaTours + pilot runbook + cutover checklist); 2026-04-19 (EPIC #214 Stage 1 W1 — matrix refresh pkg+act editable + blog Section P + hotels as-is + Section M booking DEFER; pilot-readiness concept section expanded with matrix/ADR wikilinks); 2026-04-19 (ADR-025 priority-v2 alignment: Activities target Studio ownership with W2 pending); 2026-04-19 (EPIC #214 client priority change v2 — pilot-readiness concept scope notes); 2026-04-19 (EPIC #214 Stage 0 — ADR-024 + ADR-025 skeletons + pilot-readiness-deps); 2026-04-19 (EPIC #190 certification rerun evidence); 2026-04-18 (EPIC #190 certification run evidence + checklist); 2026-04-17 (WIKI full-refresh + #103 media closure checklist); 2026-04-17 wiki-patch (epic128 evidence + issue resolution rows)
+Last updated: 2026-04-20 (EPIC #214 Stage 5 W7-b — training onboarding extended with Flows 6/7/8 + cutover checklist Stage map + FAQ expansion); 2026-04-19 (EPIC #214 Stage 2 W7-a — training onboarding ColombiaTours + pilot runbook + cutover checklist); 2026-04-19 (EPIC #214 Stage 1 W1 — matrix refresh pkg+act editable + blog Section P + hotels as-is + Section M booking DEFER; pilot-readiness concept section expanded with matrix/ADR wikilinks); 2026-04-19 (ADR-025 priority-v2 alignment: Activities target Studio ownership with W2 pending); 2026-04-19 (EPIC #214 client priority change v2 — pilot-readiness concept scope notes); 2026-04-19 (EPIC #214 Stage 0 — ADR-024 + ADR-025 skeletons + pilot-readiness-deps); 2026-04-19 (EPIC #190 certification rerun evidence); 2026-04-18 (EPIC #190 certification run evidence + checklist); 2026-04-17 (WIKI full-refresh + #103 media closure checklist); 2026-04-17 wiki-patch (epic128 evidence + issue resolution rows)
 
 ---
 
@@ -131,7 +131,7 @@ Feature requests formalized. Status tracked inline. GitHub Issues = source of tr
 
 | Wikilink | File | Audience | Purpose |
 |----------|------|----------|---------|
-| [[colombiatours-onboarding]] | [file](./training/colombiatours-onboarding.md) | Partner Rol 2 (ColombiaTours) | Pilot onboarding: Flows 1-5 (marketing / booking-DEFER / layout / SEO / translation) + FAQ + what-NOT-to-do + cheat-sheet. Spanish-first. Screencasts pending W7-c. |
+| [[colombiatours-onboarding]] | [file](./training/colombiatours-onboarding.md) | Partner Rol 2 (ColombiaTours) | Pilot onboarding: Flows 1-8 (mkt / booking-DEFER / layout / SEO / translation / activity Variant A / hotel Variant B handoff / transcreate technical) + FAQ + what-NOT-to-do + cheat-sheet. Spanish-first. Screencasts pending W7-c. |
 
 ---
 
@@ -366,6 +366,7 @@ Each concept below lists the ADRs/SPECs/ops docs that touch it. Use this to find
 - Recovery Gate prereq of Stage 4: [#226](https://github.com/weppa-cloud/bukeer-studio/issues/226) QA Recovery Gate P0 GUI (blocks W4 #218, W5 #219, W6 #220 kickoff; details in [[pilot-readiness-deps]] §Parallel / Recovery Gate)
 - Stage 1 W1 artefacts (2026-04-19): [[product-detail-matrix]] (refresh pkg+act editable + Sections M/N/O/P + Hotel column as-is + 🟡-flag legend) · [[package-detail-anatomy]] (hygiene checklist cross-ref) · [[product-detail-inventory]] (§3.2 ownership matrix aligned with matrix Sections N/O)
 - Stage 2 W7-a artefacts (2026-04-19): [[colombiatours-onboarding]] (partner-facing training — Flows 1-5 + FAQ + what-NOT-to-do + cheat-sheet; screencasts pending W7-c) · [[pilot-runbook-colombiatours]] (operational runbook — cross-links 4 existing runbooks; DNS TTL / ±24 h Flutter rule / SLA / post-cutover cadence) · [[cutover-checklist]] (standalone preflight/cutover/post-cutover/rollback checklist)
+- Stage 5 W7-b artefacts (2026-04-20) — docs-only extension of W7-a: [[colombiatours-onboarding]] now covers **Flows 6 / 7 / 8** (Activity Studio editor Variant A — see [[studio-unified-product-editor]] / [[ADR-025]]; Hotel Flutter handoff Variant B — see [[field-ownership]]; SEO transcreate technical layer — see [[transcreate-website-content-runbook]] / [[ADR-021]]) + FAQ expansion (Variant A vs B, bulk partial failure, 429 as expected) + cheat-sheet rows for new flows. [[cutover-checklist]] extended with Stage → Flow verification map (W1→W6 deliverables + PRs #225/#227/#229/#237/#238/#239/#230) + per-flow cutover day verification table. **Screencasts (W7-c) still pending** — `{{screenshot-placeholder}}` markers in onboarding doc.
 - **Client priority change v2 (2026-04-19)** — logged in [[pilot-readiness-deps]]: priority 1 = translation (blog + pkg + act); priority 2 = editing (pkg + act Studio editors); hotels as-is (Flutter-owner); booking V1 DEFER post-pilot (ADR-024 Accepted PR pending); no rate-limit mitigation. W2 + W5 bumped to XL; W3 becomes docs-only DEFER closure.
 - Matrix foundation: [[product-detail-matrix]] (W1 pkg+act editable + Section M Booking DEFER + Section N editor→campo + Section O Flutter-only gaps + Section P Blog transcreate + 🟡-flag legend + Hotel column as-is)
 - Cross-repo boundary: [[cross-repo-flutter]] (Flutter-owner fields per [[ADR-025]])
@@ -406,6 +407,8 @@ Obsidian resolves `[[ADR-005]]` by filename stem or alias. Claude Code / Codex g
 | `[[ADR-024-booking-v1-pilot-scope]]` | `docs/architecture/ADR-024-booking-v1-pilot-scope.md` |
 | `[[ADR-025]]` | `docs/architecture/ADR-025-studio-flutter-field-ownership.md` |
 | `[[ADR-025-studio-flutter-field-ownership]]` | `docs/architecture/ADR-025-studio-flutter-field-ownership.md` |
+| `[[field-ownership]]` | `docs/architecture/ADR-025-studio-flutter-field-ownership.md` (concept alias) |
+| `[[booking-defer]]` | `docs/architecture/ADR-024-booking-v1-pilot-scope.md` (concept alias) |
 | `[[pilot-readiness-deps]]` | `docs/specs/pilot-readiness-deps.md` |
 | `[[colombiatours-onboarding]]` | `docs/training/colombiatours-onboarding.md` |
 | `[[pilot-runbook-colombiatours]]` | `docs/ops/pilot-runbook-colombiatours.md` |

--- a/docs/ops/cutover-checklist.md
+++ b/docs/ops/cutover-checklist.md
@@ -150,3 +150,54 @@ Raise TTL back to 3600 s only after the +24 h cadence checkpoint passes.
 | Partner (ColombiaTours) |  |  |  |
 
 File a copy of this completed checklist under `docs/qa/pilot/sign-off-YYYY-MM-DD.md` per cutover (or rollback) event.
+
+---
+
+## Stage → Flow verification map (EPIC #214 W1→W6 deliverables)
+
+Added W7-b (2026-04-20) to map shipping stages to training Flows + acceptance verification. Complement to preflight / cutover / post-cutover rows above. Use on cutover day to assert each shipped capability is exercised at least once.
+
+| Stage | Wave / Issue | PR | Deliverable | Training Flow(s) | Verification row |
+|-------|--------------|-----|-------------|------------------|------------------|
+| Stage 1 | W1 #215 | [#225](https://github.com/weppa-cloud/bukeer-studio/pull/225) + [#227](https://github.com/weppa-cloud/bukeer-studio/pull/227) | Matrix pkg+act editable + Section P blog + hotels as-is + testid instrumentation | Flow 1 (pkg mkt), Flow 5.c (blog), Flow 6 (act), Flow 7 (hotel) | `/dashboard/<id>/products` lists pkg + act; hotel detail read-only |
+| Stage 2 | W2 #216 | [#229](https://github.com/weppa-cloud/bukeer-studio/pull/229) | Activities marketing parity — RPC `update_activity_marketing_field` + routes + editors | Flow 6 (Variant A) | Edit an activity marketing field → persists + reflects in public `/actividades/<slug>` ≤ 60 s |
+| Stage 2 | W3 #217 | — (DEFER) | Booking V1 scope decision → DEFER | Flow 2 (DEFER note) | WhatsApp + phone CTAs visible on pkg + act detail (PC-06 in preflight table) |
+| Stage 4 | W4 #218 | [#237](https://github.com/weppa-cloud/bukeer-studio/pull/237) | pilot-seed variant-factory + editor→render E2E | Flows 1, 3, 6 (editor surface) | `activity-parity.spec.ts` + `package-parity.spec.ts` green in CI |
+| Stage 4 | W5 #219 | [#238](https://github.com/weppa-cloud/bukeer-studio/pull/238) | Transcreate lifecycle E2E (pkg + act + blog; hreflang + canonical + inLanguage) | Flows 5.a / 5.b / 5.c + Flow 8 | `/en/paquetes/<slug>`, `/en/actividades/<slug>`, `/en/blog/<slug>` render applied variants with `<html lang="en">` + hreflang triple |
+| Stage 4 | W6 #220 | [#239](https://github.com/weppa-cloud/bukeer-studio/pull/239) | Matrix visual playbook — Playwright MCP + Lighthouse snapshots | Flows 1, 3, 4, 5, 6, 7 (UI parity) | Matrix visual E2E baseline present in `artifacts/qa/pilot/<date>/matrix-visual/` |
+| Stage 5 | W7-a | [#230](https://github.com/weppa-cloud/bukeer-studio/pull/230) | Onboarding skeleton (Flows 1-5) + pilot runbook + cutover checklist | Flows 1-5 | `docs/training/colombiatours-onboarding.md` + `docs/ops/pilot-runbook-colombiatours.md` + this file exist |
+| Stage 5 | W7-b | (this) | Training extension: Flows 6/7/8 + FAQ expansion + cutover Stage map | Flows 6, 7, 8 | Sign-off: partner has read Flows 6 + 7 + 8 before cutover T-0 |
+| Stage 5 | W7-c | pending | Screencasts | Flows 1-8 | **Deferred** — placeholder `{{screenshot-placeholder}}` markers in `colombiatours-onboarding.md` replaced post-UI-freeze |
+
+### Per-flow cutover day verification
+
+Add to cutover-day artifact bundle. Each flow must have at least one executed verification row before sign-off.
+
+| Flow | Minimum verification | Owner | Evidence |
+|------|---------------------|-------|----------|
+| Flow 1 — Pkg marketing | Edit 1 pkg description + cover → public URL reflects ≤ 60 s | Partner | Slug + screenshot |
+| Flow 2 — Booking DEFER | WhatsApp CTA click opens correct number on 1 pkg + 1 act | Partner | `whatsapp_cta_click` event in GA4 |
+| Flow 3 — Layout | Reorder 2 sections on 1 pkg; hide 1 section → public reflects | Partner | URL + screenshot |
+| Flow 4 — SEO per-page | Override meta title on 1 pkg → `<title>` in HTML matches | Partner | `curl -s <url> \| grep '<title>'` |
+| Flow 5 — Translation | Apply 1 pkg + 1 act + 1 blog → `/en/...` URLs render | Partner | 3 URLs + `<html lang="en">` grep |
+| Flow 6 — Activity Variant A | Edit 1 activity marketing field + 1 content field → public reflects | Partner | URL + screenshot |
+| Flow 7 — Hotel Flutter handoff | Open 1 hotel in Studio → editors disabled + banner Flutter-owner; edit SEO meta succeeds | Partner | Screenshot + updated `<title>` |
+| Flow 8 — SEO transcreate | 1 drift re-apply OR 1 bulk apply of 2 items → variants return to `applied` | Partner | `seo_localized_variants.status` query snapshot |
+
+### Booking-row exclusions (priority v2)
+
+Removed rows — do NOT re-add unless Booking V1 un-DEFER-s:
+
+- ~~Date picker smoke (pkg + act)~~ — Booking DEFERRED, [[ADR-024]].
+- ~~Lead form submit smoke~~ — endpoint `/api/leads` inactive.
+- ~~Lead row appears in DB~~ — N/A.
+- ~~Stripe webhook signature check~~ — N/A for pilot.
+
+Parity check kept: **WhatsApp + phone CTA** (PC-06 above) as the canonical conversion signal.
+
+---
+
+## Changelog
+
+- **2026-04-20** (W7-b #221): added Stage → Flow verification map (W1→W6 deliverables + Flows 1-8) + per-flow cutover day verification rows. Documented booking-row exclusions per priority v2. Cross-linked PRs #225/#227/#229/#237/#238/#239/#230.
+- **2026-04-19** (W7-a): initial standalone checklist (preflight / cutover / post-cutover / rollback + DNS TTL + SLA + sign-off template).

--- a/docs/training/colombiatours-onboarding.md
+++ b/docs/training/colombiatours-onboarding.md
@@ -4,9 +4,11 @@
 >
 > **Qué aprenderás:** cómo editar el contenido de tu sitio público (paquetes y actividades), cómo traducir contenido al inglés y cómo leer el tablero de cobertura SEO. Todo se hace desde Studio (interfaz web).
 
-**Última revisión:** 2026-04-19.
-**Versión doc:** W7-a skeleton (screencasts pendientes en W7-c).
+**Última revisión:** 2026-04-20.
+**Versión doc:** W7-b (Flows 6 / 7 / 8 + FAQ expansion; screencasts pendientes en W7-c).
 **Issue tracker:** [#221](https://github.com/weppa-cloud/bukeer-studio/issues/221) · EPIC [#214](https://github.com/weppa-cloud/bukeer-studio/issues/214).
+
+> **Nota de numeración (W7 spec vs. este doc):** el spec W7 (#221) numera los flows así — Flow 1 marketing, Flow 2 booking (DEFER), Flow 3 layout, Flow 4 traducción (3 sub-flows), Flow 5 coverage + drift, Flow 6 Activity Studio editor, Flow 7 Hotel Flutter handoff, Flow 8 SEO transcreate técnico. Este doc preserva la numeración histórica (W7-a) por compatibilidad de anchors existentes: "Flow 4" acá = **SEO personalizado** y "Flow 5" acá = **traducción (3 sub-flows)**. Los nuevos **Flows 6 / 7 / 8** (W7-b) sí siguen el spec.
 
 ---
 
@@ -18,10 +20,13 @@
 4. [Flow 3 — Layout de secciones: hero, video, orden, ocultar, custom](#flow-3--layout-de-secciones-hero-video-orden-ocultar-custom)
 5. [Flow 4 — SEO personalizado por página](#flow-4--seo-personalizado-por-página)
 6. [Flow 5 — Traducción es-CO → en-US (3 sub-flows)](#flow-5--traducción-es-co--en-us-3-sub-flows)
-7. [FAQ — preguntas frecuentes](#faq--preguntas-frecuentes)
-8. [Qué **NO** debes hacer](#qué-no-debes-hacer)
-9. [Cheat-sheet "Si ves X, haz Y"](#cheat-sheet-si-ves-x-haz-y)
-10. [Cómo pedir ayuda](#cómo-pedir-ayuda)
+7. [Flow 6 — Editar una actividad (Variant A — Studio native)](#flow-6--editar-una-actividad-variant-a--studio-native)
+8. [Flow 7 — Hotel Flutter handoff (Variant B — read-only Studio)](#flow-7--hotel-flutter-handoff-variant-b--read-only-studio)
+9. [Flow 8 — SEO transcreate (técnico: stream, estados, drift, bulk)](#flow-8--seo-transcreate-técnico-stream-estados-drift-bulk)
+10. [FAQ — preguntas frecuentes](#faq--preguntas-frecuentes)
+11. [Qué **NO** debes hacer](#qué-no-debes-hacer)
+12. [Cheat-sheet "Si ves X, haz Y"](#cheat-sheet-si-ves-x-haz-y)
+13. [Cómo pedir ayuda](#cómo-pedir-ayuda)
 
 ---
 
@@ -196,42 +201,54 @@ Alcance: **paquetes + actividades + blog** (hoteles NO están en scope de transc
 
 ### Flow 5.a — Traducir un paquete
 
-1. **Picker.** Abrir dashboard de traducciones → filtrar por tipo `Package` → seleccionar paquete.
-   [SCREENSHOT: Translations picker con filtro Package]
-2. **Stream.** Disparar transcreate → UI muestra stream en vivo (ADR-021 pipeline).
-   [SCREENSHOT: Transcreate stream en progreso]
+1. **Picker.** Abrir dashboard de traducciones (`/dashboard/<websiteId>/translations`) → filtrar por tipo `Package` → seleccionar paquete.
+   - Estado UI esperado: la raíz del dashboard tiene `data-testid="translations-dashboard-root"`. Los filtros (`translations-dashboard-filter-page-type`, `translations-dashboard-filter-status`, `translations-dashboard-filter-search`) están visibles; el KPI panel (`translations-dashboard-kpis`) muestra contadores por estado.
+   [SCREENSHOT: Translations picker con filtro Package {{screenshot-placeholder}}]
+2. **Stream.** Disparar transcreate → UI muestra stream en vivo (pipeline ADR-021, endpoint `POST /api/seo/content-intelligence/transcreate`).
+   - Estado esperado en DB: se crea fila en `seo_transcreation_jobs` con `status='draft'`; `seo_localized_variants` aparece con `status='draft'`.
+   [SCREENSHOT: Transcreate stream en progreso {{screenshot-placeholder}}]
 3. **Corregir draft.** Revisa línea por línea. Edita términos, tono, keywords locales.
-   [SCREENSHOT: Bilingual editor es-CO / en-US con diferencias resaltadas]
+   [SCREENSHOT: Bilingual editor es-CO / en-US con diferencias resaltadas {{screenshot-placeholder}}]
 4. **Reviewed.** Marcar estado `Reviewed` cuando esté listo (opcional: segundo par de ojos).
-   [SCREENSHOT: Estado Draft → Reviewed]
-5. **Applied.** Botón `Apply` publica a `en`. Coverage matrix refresca.
-   [SCREENSHOT: Apply action con confirmación]
+   - Transición DB: `seo_transcreation_jobs.status` pasa de `draft` → `reviewed`.
+   [SCREENSHOT: Estado Draft → Reviewed {{screenshot-placeholder}}]
+5. **Applied.** Botón `Apply` publica a `en-US`. Coverage matrix refresca.
+   - Transición DB: `seo_transcreation_jobs.status` pasa de `reviewed` → `applied`; `seo_localized_variants.status='applied'` y se dispara ISR fan-out (ver [Flow 8](#flow-8--seo-transcreate-técnico-stream-estados-drift-bulk)).
+   [SCREENSHOT: Apply action con confirmación {{screenshot-placeholder}}]
 6. **Verificar URL pública.** Abrir `/en/paquetes/<slug>` en nueva pestaña. Validar:
    - `<html lang="en">`
-   - `<link rel="alternate" hreflang="en">` y contraparte en español
+   - `<link rel="alternate" hreflang="en-US">` + contraparte `hreflang="es-CO"` + `hreflang="x-default"`
    - `<link rel="canonical" href="/en/paquetes/<slug>">`
    - JSON-LD con `inLanguage: "en"` en los campos traducibles
-   [SCREENSHOT: URL pública /en/paquetes/<slug>]
+   [SCREENSHOT: URL pública /en/paquetes/<slug> {{screenshot-placeholder — capture con URL /en/ visible}}]
+
+**Troubleshooting rápido (aplica también a 5.b + 5.c):**
+
+- **Stream se aborta / se corta.** El endpoint de stream puede cortarse por timeout edge o abort del cliente. No deja fila orfanada: `seo_transcreation_jobs` no se crea si el stream no llegó a `create_draft`. Relanzar el transcreate es seguro. QA ref: [`docs/qa/pilot/transcreate-playbook.md`](../qa/pilot/transcreate-playbook.md) §stream-abort.
+- **429 Rate-limited.** Esperado por priority v2 (la API real impone un límite diario 10 calls/locale/website). Payload: `{ "code": "RATE_LIMITED", "message": "Daily transcreate AI limit exceeded for this locale." }`. No es bug; esperar ~24 h o contactar al equipo si es urgente.
+- **409 `TARGET_RERESEARCH_REQUIRED` al crear draft.** El pipeline exige un keyword candidate "decision-grade" previo para la combinación (`website_id`, `content_type`, `target_locale`, `target_keyword`). Pedir al equipo sembrar el candidato o usar el flujo "sugerir keyword" del dashboard.
+- **409 `TRANSCREATE_REVIEW_REQUIRED` al re-aplicar.** Apply NO es idempotente. Si necesitas re-aplicar, primero vuelve a `Reviewed` (rollback — ver §"Common — Rollback").
 
 ### Flow 5.b — Traducir una actividad
 
-Mismo ciclo; solo cambia el filtro y el path público:
+Mismo ciclo que 5.a; cambian filtro, path de verificación y overlay (`activities`):
 
-1. Picker → filtro `Activity` → seleccionar.
-2. Stream → corregir → Reviewed → Applied.
-3. Verificar `/en/actividades/<slug>`.
+1. Picker → `translations-dashboard-filter-page-type` = `Activity` → seleccionar.
+2. Stream → corregir → `Reviewed` → `Applied` (transiciones DB iguales que 5.a; overlay en `seo_localized_variants` con `target_entity_type='activity'`).
+3. Verificar URL pública `/en/actividades/<slug>` con `<html lang="en">`, hreflang triple (`en-US` + `es-CO` + `x-default`), canonical, y JSON-LD `inLanguage: "en"`.
 
-[SCREENSHOT: Translations picker filtro Activity]
-[SCREENSHOT: URL pública /en/actividades/<slug>]
+[SCREENSHOT: Translations picker filtro Activity {{screenshot-placeholder}}]
+[SCREENSHOT: URL pública /en/actividades/<slug> {{screenshot-placeholder — capture con URL /en/ visible}}]
 
 ### Flow 5.c — Traducir un blog post
 
-1. Picker → filtro `Blog` → seleccionar post.
-2. Stream → corregir → Reviewed → Applied.
-3. Verificar `/en/blog/<slug>`.
+1. Picker → `translations-dashboard-filter-page-type` = `Blog` → seleccionar post.
+2. Stream → corregir → `Reviewed` → `Applied`.
+   - **Comportamiento blog-específico:** `applyTranscreateJob` crea una **nueva fila** en `website_blog_posts` con `locale='en-US'` + `canonical_post_id` apuntando al source. El slug se deriva del payload (`payload.slug`). Si el slug EN difiere del slug ES, la URL `/en/blog/<source-slug>` devuelve 404 — usa el slug EN devuelto por el apply response (la UI lo muestra en la confirmación).
+3. Verificar `/en/blog/<slug-en>` con las mismas assertions (`<html lang>`, hreflang, canonical, `inLanguage`).
 
-[SCREENSHOT: Translations picker filtro Blog]
-[SCREENSHOT: URL pública /en/blog/<slug>]
+[SCREENSHOT: Translations picker filtro Blog {{screenshot-placeholder}}]
+[SCREENSHOT: URL pública /en/blog/<slug-en> {{screenshot-placeholder — capture con URL /en/ visible}}]
 
 ### Common — Rollback de traducción
 
@@ -253,6 +270,195 @@ Si al hacer `Apply` algo sale mal:
 - URL pública `/en/paquetes/<slug>` (o `/en/actividades/<slug>`, o `/en/blog/<slug>`) renderiza contenido traducido.
 - Head incluye hreflang + canonical + `inLanguage` correctos (ADR-019, ADR-020).
 - Si desactivas en-US, el language switcher hace fallback según ADR-019 — ver [FAQ #4](#language-switcher-salta-al-homepage).
+
+---
+
+## Flow 6 — Editar una actividad (Variant A — Studio native)
+
+**Objetivo:** editar marketing + contenido + SEO de una actividad directamente desde Studio (mismo modelo que paquetes). Esta es la **Variant A** (Studio native editor), default del pilot post-W2.
+
+**Ruta Studio:**
+- Marketing → `/dashboard/<websiteId>/products/<slug>/marketing`
+- Contenido → `/dashboard/<websiteId>/products/<slug>/content`
+- SEO → `/dashboard/<websiteId>/seo/activity/<itemId>` (Flow 4)
+
+**Requisito:** feature flag `studio_editor_v2` **habilitado** en tu cuenta + sitio. Si aparece "Solo lectura", ver [FAQ #11](#flag-studio_editor_v2-off--por-qué-aparece-solo-lectura).
+
+Shipping ref: [PR #229](https://github.com/weppa-cloud/bukeer-studio/pull/229) (W2 #216 activities marketing parity — RPC `update_activity_marketing_field` + routes + editors) · [PR #237](https://github.com/weppa-cloud/bukeer-studio/pull/237) (W4 #218 editor→render E2E; test `activity-parity.spec.ts`).
+
+### Pasos — Marketing de actividad
+
+1. Sidebar → `Products` → buscar la actividad (filtrar por tipo `activity`) → clic en el nombre.
+   - Estado esperado: la ruta resuelve con `product_type=activity`; la query va contra la tabla `activities` (no `package_kits`).
+   [SCREENSHOT: Products list con actividad seleccionada {{screenshot-placeholder}}]
+2. Pestaña `Marketing` → bloques disponibles (mismos editores que paquetes, pero con RPC dedicada `update_activity_marketing_field`):
+   - `DescriptionEditor` (descripción rica).
+   - `HighlightsEditor` (lista ordenable).
+   - `InclusionsExclusionsEditor` (dos listas paralelas).
+   - `RecommendationsEditor` (texto libre + tips).
+   - `InstructionsEditor` (instrucciones operativas de la actividad — específico de activities, no de packages).
+   - `SocialImagePicker` (imagen OG / Twitter).
+   - `GalleryCurator` (subida + reorder + portada).
+   [SCREENSHOT: Activity marketing editor con los 7 bloques {{screenshot-placeholder}}]
+3. Cada edición guarda vía `update_activity_marketing_field` RPC. Si el RPC devuelve error (p. ej. permiso faltante), la UI muestra toast y el campo revierte al último valor guardado.
+
+### Pasos — Contenido de actividad
+
+1. Pestaña `Content` de la misma actividad → editores de contenido:
+   - `HeroOverrideEditor` (imagen / video del hero).
+   - `VideoUrlEditor` (URL de YouTube / Vimeo / MP4).
+   - `SectionVisibilityToggle` (ocultar secciones del render público).
+   - `SectionsReorderEditor` (reordenar via drag).
+   - `CustomSectionsEditor` (inyectar secciones custom del registry).
+   - `AiFlagsPanel` (ver qué campos fueron generados por IA + override).
+   [SCREENSHOT: Activity content editor con los 6 editores {{screenshot-placeholder}}]
+2. Al guardar, Studio dispara revalidate fan-out (ISR). Espera ≤ 60 s para ver cambios en público.
+
+### Resultado esperado
+
+- URL pública `/actividades/<slug>` renderiza los cambios tras la ventana ISR.
+- Banner `last_edited_by_surface=studio` visible en admin view.
+- AI badges se limpian al editar manualmente (si aparecía "Generado por IA" y lo reescribiste).
+- E2E ref (no corre desde este doc, lo corre QA): `activity-parity.spec.ts` valida editor → render para todos los campos.
+
+### Variant B (Flutter handoff) — contingencia solo
+
+Si por algún motivo W2 no hubiera entregado la RPC `update_activity_marketing_field`, actividades fallback a Variant B (Flutter handoff, igual que hoteles — ver [Flow 7](#flow-7--hotel-flutter-handoff-variant-b--read-only-studio)). **En el pilot ColombiaTours post-2026-04-20 esto NO aplica** — default es Variant A. Si ves "Solo lectura" en una actividad, NO es Variant B: es el flag `studio_editor_v2` off. Ver [FAQ #11](#flag-studio_editor_v2-off--por-qué-aparece-solo-lectura).
+
+---
+
+## Flow 7 — Hotel Flutter handoff (Variant B — read-only Studio)
+
+**Objetivo:** entender por qué los hoteles NO son editables en Studio para marketing / contenido, qué SÍ puedes hacer desde Studio (SEO meta), y cómo solicitar cambios de catálogo al equipo Flutter.
+
+**Política pilot:** hoteles son **Flutter-owner** por decisión explícita confirmada 2026-04-19 + [[ADR-025]]. Studio **no** es el editor canónico para marketing/contenido de hotel. Studio expone hoteles en **read-only** para el partner.
+
+Shipping ref: [[ADR-025]] `docs/architecture/ADR-025-studio-flutter-field-ownership.md` + `.claude/rules/cross-repo-flutter.md`.
+
+### Qué se edita dónde
+
+| Campo | Editor canónico | Ruta |
+|-------|----------------|------|
+| Marketing (descripción, highlights, inclusiones, galería, recomendaciones, cover) | **Flutter admin** (app `weppa-cloud/bukeer-flutter`) | Catálogo → Hoteles → detalle hotel |
+| Contenido (hero, video, sections layout, custom sections) | **Flutter admin** | Catálogo → Hoteles → detalle hotel |
+| Pricing + availability + inventory | **Flutter admin** (fuente canónica) | Catálogo operaciones |
+| **SEO meta** (title / description / FAQ / robots / canonical) | **Studio** (Flow 4) | `/dashboard/<websiteId>/seo/hotel/<itemId>` |
+| Traducción es-CO → en-US | **Fuera de scope pilot** | — (hoteles NO están en Flow 5) |
+
+### Pasos — Ver un hotel en Studio (read-only)
+
+1. Sidebar → `Products` (o `Hoteles` según el sidebar del sitio) → filtrar por tipo `hotel` → clic en el hotel.
+2. Estado esperado: el detalle del hotel **muestra** campos de marketing + contenido pero con los editores **deshabilitados** (mensaje "Solo lectura — este campo se edita en Flutter").
+   - Indicador visible: badge "Flutter-owner" + icono de candado.
+   [SCREENSHOT: Hotel detail en Studio — editores deshabilitados con banner "Flutter-owner" {{screenshot-placeholder}}]
+3. **SEO meta sí es editable:** ir a `/dashboard/<websiteId>/seo/hotel/<itemId>` para editar `custom_seo_title`, `custom_seo_description`, `custom_faq`, `robots_noindex` (Flow 4 aplica igual que pkg/act/blog).
+
+### Pasos — Solicitar un cambio de hotel al equipo Flutter
+
+1. Identificar el campo + valor deseado (p. ej. "cambiar hero image del hotel Playa Blanca").
+2. Abrir el handoff protocol (canal Slack `#pilot-colombiatours` o `#bukeer-catalog`).
+3. Incluir:
+   - Slug del hotel.
+   - URL pública `/hoteles/<slug>` (para referencia visual).
+   - Campo a cambiar + valor antiguo + valor nuevo.
+   - Screenshot si aplica.
+4. El equipo catálogo (Flutter) hace el cambio en Flutter admin → Supabase DB actualiza → Studio lee el cambio vía SSR + ISR fan-out (≤ 60 s en público).
+5. Verificar en `/hoteles/<slug>` (español) — si necesitas verificar en Studio, refresca la página del hotel y valida el banner `last_edited_by_surface=flutter`.
+   [SCREENSHOT: Flutter admin editando hotel — flecha apuntando a Studio read-only view {{screenshot-placeholder}}]
+
+### Drift entre Flutter y Studio
+
+Si un cambio de hotel en Flutter no aparece en Studio tras 60 s:
+
+1. Verifica `/dashboard/<websiteId>/ops/reconciliation` — debería mostrar el hotel con timestamp reciente si el cambio llegó a DB.
+2. Si llegó a DB pero Studio no actualiza → ISR cache stale → pedir al equipo correr `POST /api/revalidate`.
+3. Si NO llegó a DB → el cambio Flutter no se guardó; pedir al equipo catálogo reintentar.
+
+### Variant A (Studio editor hoteles) — post-pilot
+
+Si post-pilot se construye la RPC `update_hotel_marketing_field`, Studio podría adoptar la edición de marketing de hoteles (paridad con packages + activities). Eso NO está en scope W2 ni priority v2 — es una decisión post-pilot. Hasta entonces, Variant B (Flutter handoff) es el default.
+
+---
+
+## Flow 8 — SEO transcreate (técnico: stream, estados, drift, bulk)
+
+**Objetivo:** capa técnica del transcreate (complemento a Flow 5). Entiende qué pasa detrás del botón `Apply`, cómo interpretar `seo_localized_variants`, cómo detectar drift y cómo usar bulk review.
+
+**Alcance:** aplica a los 3 tipos traducibles — **paquetes + actividades + blog** (hoteles NO; ver [Flow 7](#flow-7--hotel-flutter-handoff-variant-b--read-only-studio)).
+
+Shipping ref: [PR #238](https://github.com/weppa-cloud/bukeer-studio/pull/238) (W5 #219 transcreate lifecycle E2E) + [`docs/qa/pilot/transcreate-playbook.md`](../qa/pilot/transcreate-playbook.md) (QA side, cross-ref no duplicado).
+
+### 8.1 Stream vs. manual override
+
+Hay dos rutas técnicas:
+
+| Ruta | Endpoint | Uso | Determinismo |
+|------|----------|-----|--------------|
+| **Stream** (UI default) | `POST /api/seo/content-intelligence/transcreate` (SSE) | Dashboard UI — lo que ves en Flow 5 | No determinístico (LLM) |
+| **Manual override** (avanzado) | Mismo endpoint, payload `payloadV2` con draft pre-computado | Bulk imports, QA E2E | Determinístico |
+
+Para 99% de tu operación usas Stream (Flow 5). Manual override es para el equipo cuando migra contenido desde un corpus externo.
+
+### 8.2 Interpretar `seo_localized_variants`
+
+Tabla clave: `seo_localized_variants`. Cada fila representa una overlay de un campo traducido para una tupla `(target_entity_type, target_entity_id, target_locale, field)`.
+
+Estados (`status`):
+
+| Estado | Significado | Acción siguiente |
+|--------|-------------|------------------|
+| `draft` | El LLM generó el campo, no revisado. | Revisar en dashboard (Flow 5) → Reviewed |
+| `reviewed` | Un humano aprobó el draft. | Apply para publicar |
+| `applied` | Publicado en `/en/...` (render público). | Ninguna. Drift puede marcarlo `stale`. |
+| `stale` | Contenido base (es-CO) cambió después del apply → re-traducir. | Re-entrar Flow 5 para refrescar |
+
+Relación con `seo_transcreation_jobs`: cada apply crea (o actualiza) un `seo_transcreation_jobs` row con el payload completo del LLM. `seo_localized_variants` es la overlay proyectada que el SSR renderiza.
+
+### 8.3 Drift detection (`status='stale'`)
+
+Cuando editas contenido es-CO de un paquete/actividad/blog que ya tiene traducción `applied` en en-US, el sistema marca el variant EN como `stale` ([[ADR-021]] drift policy).
+
+**Dónde ves drift:**
+- Dashboard `Coverage` → banner "N items con drift" (top del dashboard).
+- `/dashboard/<websiteId>/ops/reconciliation` → lista de stale items con link al editor.
+- Alertas opcionales en Slack (si el equipo configuró webhook de drift).
+
+**Cómo re-aplicar tras drift:**
+1. Abrir el item desde el drift banner (click → va directo al translation editor).
+2. Disparar transcreate de nuevo (mismo Flow 5.a/b/c).
+3. El nuevo draft refleja los cambios es-CO; revisar → Reviewed → Apply.
+4. Variant vuelve a `applied` (deja de estar `stale`).
+
+### 8.4 Bulk review (`/api/seo/translations/bulk`)
+
+Cuando tienes varias traducciones en `reviewed` listas para publicar en batch:
+
+1. Dashboard → seleccionar varios items con checkbox (todos en estado `reviewed`).
+2. Botón "Apply seleccionados" → llama a `POST /api/seo/translations/bulk`.
+3. El endpoint aplica los N jobs **atómicamente**: si uno falla, se revierten todos (salvaguarda contra apply parcial).
+4. Resultado esperado: todos los variants pasan a `applied` + ISR fan-out se dispara una sola vez por tenant.
+
+**Error común:** si uno de los items ya está `applied`, el endpoint devuelve 409 `TRANSCREATE_REVIEW_REQUIRED`. Deseleccionar el item ya aplicado y reintentar.
+
+### 8.5 Checklist SEO por tipo de contenido
+
+Tras aplicar una traducción, verifica estos campos en la URL `/en/...` correspondiente:
+
+| Elemento | Package | Activity | Blog | Fuente |
+|----------|---------|----------|------|--------|
+| `<title>` | ✔ | ✔ | ✔ | `seo_localized_variants.field='meta_title'` |
+| `<meta name="description">` | ✔ | ✔ | ✔ | `seo_localized_variants.field='meta_description'` |
+| Open Graph `og:title` + `og:description` + `og:image` | ✔ | ✔ | ✔ | Overlay + social_image |
+| Twitter card (`twitter:title` + `twitter:description`) | ✔ | ✔ | ✔ | Igual OG |
+| `<link rel="canonical">` → `/en/<tipo>/<slug>` | ✔ | ✔ | ✔ | ADR-019 routing |
+| `<link rel="alternate" hreflang="en-US">` + `hreflang="es-CO"` + `hreflang="x-default"` | ✔ | ✔ | ✔ | [[ADR-020]] |
+| JSON-LD con `inLanguage: "en"` | ✔ | ✔ | ✔ | `components/seo/product-schema.tsx` + `landing-page-schema.tsx` |
+| `FAQPage` JSON-LD (si definido) | ✔ | ✔ | ✔ | Flow 4 SEO editor |
+
+Si un item falla la checklist:
+- `inLanguage` mal → regresión #208 (threading). Reportar al equipo.
+- `hreflang="en-US"` falta → ADR-020 gate failed. Verificar que `seo_transcreation_jobs.status='applied'` para el item.
+- `x-default` falta → `websites.content.locale` o `default_locale` mal configurado. Ticket al equipo.
 
 ---
 
@@ -336,9 +542,17 @@ Post-pilot: si se construye `update_hotel_marketing_field` RPC, Studio podría a
 
 ### Error 429
 
-**Síntoma:** ves "429 Too Many Requests".
+**Síntoma:** ves "429 Too Many Requests" al disparar un transcreate.
 
-**Estado actual (pilot):** **no** debería ocurrir en operación normal. El cliente aceptó el uso directo de la API de transcreate sin mitigaciones de TM short-circuit. Si aparece, reportar al equipo.
+**Estado actual (pilot, priority v2):** **esperado, NO es bug**. La API real de transcreate impone un límite de 10 llamadas por día por combinación `(website × target_locale)`. El cliente aceptó esto explícitamente el 2026-04-19 (sin TM short-circuit, sin rate-limit mitigation).
+
+**Qué hacer:**
+1. Revisar el payload de respuesta: si `code = "RATE_LIMITED"`, es el límite diario.
+2. Esperar ~24 h y retry — el contador se resetea por día.
+3. Si el cliente necesita más traducciones el mismo día, escalar al equipo (decisión del release lead).
+4. El flujo alterno (manual override con payload pre-computado) es de uso interno del equipo, NO del partner.
+
+Ref QA: [`docs/qa/pilot/transcreate-playbook.md`](../qa/pilot/transcreate-playbook.md) §stream-abort — el spec E2E W5 acepta 429 como pass.
 
 ### Traducción parece no actualizarse
 
@@ -360,6 +574,45 @@ Post-pilot: si se construye `update_hotel_marketing_field` RPC, Studio podría a
 **Causa:** el flag `studio_editor_v2` está desactivado (globalmente, por cuenta o por sitio). Esto puede ser por un rollback preventivo post-incidente.
 
 **Resolución:** contactar al equipo; el runbook de rollback [`docs/ops/studio-editor-v2-rollback.md`](../ops/studio-editor-v2-rollback.md) §8 documenta el proceso de re-habilitación.
+
+**Diferencia importante:**
+- "Solo lectura" en **actividad** → flag off (ver arriba).
+- "Solo lectura" en **hotel** → comportamiento esperado (hotel es Flutter-owner, [Flow 7](#flow-7--hotel-flutter-handoff-variant-b--read-only-studio)). NO es bug ni flag off.
+
+### Variant A vs. Variant B — cómo distinguirlas
+
+**Pregunta:** "veo 'Solo lectura' en una actividad — ¿es Variant B?"
+
+**Respuesta corta:** NO. Actividades son Variant A default (Studio native, editable) post-W2 ([Flow 6](#flow-6--editar-una-actividad-variant-a--studio-native)). Solo hoteles son Variant B (Flutter handoff, read-only en Studio — [Flow 7](#flow-7--hotel-flutter-handoff-variant-b--read-only-studio)).
+
+| Tipo | Variant | Editor canónico | Expectativa Studio |
+|------|---------|----------------|--------------------|
+| **Package** | A | Studio | Editable (marketing + content + SEO + translation) |
+| **Activity** | A (post-W2) | Studio | Editable (marketing + content + SEO + translation) |
+| **Hotel** | B | Flutter | Read-only en Studio. Solo SEO meta editable. |
+| **Blog** | A | Studio | Editable (editor + translation) |
+
+Si ves "Solo lectura" en pkg / activity / blog → es el flag `studio_editor_v2` off. Reportar al equipo con SLA crítico si es cutover day.
+
+### Por qué veo hoteles pero no los puedo editar en Studio
+
+**Respuesta corta:** política de ownership. Hoteles son Flutter-owner por [[ADR-025]]; Studio los muestra en read-only para que el partner vea el catálogo pero los cambios van por Flutter.
+
+**Respuesta larga:** ver [Flow 7 — Hotel Flutter handoff](#flow-7--hotel-flutter-handoff-variant-b--read-only-studio) y [FAQ — Por qué los hoteles se editan en Flutter](#por-qué-los-hoteles-se-editan-en-flutter-y-no-en-studio).
+
+**Handoff protocol:** para solicitar un cambio de hotel, usar Slack `#pilot-colombiatours` con slug + campo + valor viejo/nuevo + screenshot (ver Flow 7).
+
+### Por qué mi transcreate bulk falló parcialmente
+
+**Síntoma:** seleccioné 5 items para bulk apply, 4 pasaron pero 1 falló — y me dicen que "se revirtieron todos".
+
+**Causa:** el endpoint `/api/seo/translations/bulk` es **atómico por diseño** (Flow 8.4). Si un item falla, los otros 4 también se revierten. Esto previene estados parciales (mitad en `applied`, mitad en `reviewed`).
+
+**Resolución:**
+1. Identificar cuál falló (el endpoint devuelve el ID + código de error en el payload de respuesta).
+2. Si el error es `TRANSCREATE_REVIEW_REQUIRED` → ese item ya estaba `applied`. Deseleccionarlo y reintentar.
+3. Si el error es 429 → esperar y reintentar (ver FAQ "Error 429").
+4. Si el error es 5xx inesperado → reportar al equipo.
 
 ### Cómo pedir ayuda
 
@@ -398,16 +651,22 @@ Esta sección es vinculante. Hacer cualquiera de estas cosas puede romper el sit
 
 | Si ves... | Haz... |
 |-----------|--------|
-| "Solo lectura" en un editor | [FAQ #11](#flag-studio_editor_v2-off--por-qué-aparece-solo-lectura) — contactar equipo |
-| Badge "Generado por IA" que no se va | [FAQ #2](#el-badge-de-ia-no-desaparece) — pedir override manual |
-| Cambio guardado pero invisible en público | [FAQ #7](#cambio-no-se-refleja) — esperar 60 s + refresh forzado |
-| Cover vieja en las cards del home | [FAQ #1](#cover-image-no-se-actualiza-en-cards) — probe `cf-cache-status` |
-| Sitemap incluye una página que oculté | [FAQ #3](#sitemap-incluye-páginas-ocultas) — usar `noindex` en Flow 4, no solo hide |
-| Language switcher salta al home | [FAQ #4](#language-switcher-salta-al-homepage) — traducir la página (Flow 5) |
-| Hotel no aparece en editor marketing | [FAQ #5](#por-qué-los-hoteles-se-editan-en-flutter-y-no-en-studio) — es Flutter-owner |
-| Cliente pregunta por botón "Reservar" | [FAQ #6](#por-qué-no-hay-date-picker-todavía) — Booking DEFERRED |
-| Error 429 | [FAQ #9](#error-429) — reportar (no debería ocurrir) |
-| Traducción aplicada pero público en español | [FAQ #10](#traducción-parece-no-actualizarse) — distinguir coverage cache vs render cache |
+| "Solo lectura" en un editor de pkg / act / blog | [FAQ Flag](#flag-studio_editor_v2-off--por-qué-aparece-solo-lectura) — contactar equipo (flag off) |
+| "Solo lectura" en hotel | Esperado — [Flow 7](#flow-7--hotel-flutter-handoff-variant-b--read-only-studio), usar handoff Flutter |
+| Badge "Generado por IA" que no se va | [FAQ IA](#el-badge-de-ia-no-desaparece) — pedir override manual |
+| Cambio guardado pero invisible en público | [FAQ ISR](#cambio-no-se-refleja) — esperar 60 s + refresh forzado |
+| Cover vieja en las cards del home | [FAQ cover](#cover-image-no-se-actualiza-en-cards) — probe `cf-cache-status` |
+| Sitemap incluye una página que oculté | [FAQ sitemap](#sitemap-incluye-páginas-ocultas) — usar `noindex` en Flow 4, no solo hide |
+| Language switcher salta al home | [FAQ switcher](#language-switcher-salta-al-homepage) — traducir la página (Flow 5) |
+| Hotel no aparece en editor marketing | [Flow 7](#flow-7--hotel-flutter-handoff-variant-b--read-only-studio) — es Flutter-owner |
+| Cliente pregunta por botón "Reservar" | [FAQ booking](#por-qué-no-hay-date-picker-todavía) — Booking DEFERRED |
+| Error 429 en transcreate | [FAQ 429](#error-429) — esperar 24 h, es el límite diario (no bug) |
+| Traducción aplicada pero público en español | [FAQ render](#traducción-parece-no-actualizarse) — distinguir coverage cache vs render cache |
+| Necesito editar una actividad (marketing/contenido) | [Flow 6](#flow-6--editar-una-actividad-variant-a--studio-native) — Variant A Studio native |
+| Necesito cambiar marketing de un hotel | [Flow 7](#flow-7--hotel-flutter-handoff-variant-b--read-only-studio) — handoff Slack al equipo Flutter |
+| Drift alert sobre traducción stale | [Flow 8.3](#83-drift-detection-statusstale) — re-disparar transcreate del item |
+| Quiero aplicar varias traducciones en batch | [Flow 8.4](#84-bulk-review-apiseotranslationsbulk) — bulk atómico |
+| Confundido entre Variant A y Variant B | [FAQ Variant](#variant-a-vs-variant-b--cómo-distinguirlas) — tabla de expectativas |
 
 ---
 
@@ -420,9 +679,17 @@ Esta sección es vinculante. Hacer cualquiera de estas cosas puede romper el sit
 
 ---
 
-**Cambios en este documento:** se versiona con el repo. Screencasts (W7-c) reemplazarán los `[SCREENSHOT: ...]` placeholders cuando se graben contra la UI final post-cutover.
+**Cambios en este documento:** se versiona con el repo. Screencasts (W7-c) reemplazarán los `{{screenshot-placeholder}}` + `[SCREENSHOT: ...]` markers cuando se graben contra la UI final post-cutover.
 
 **Referencias rápidas:**
 - [`docs/ops/pilot-runbook-colombiatours.md`](../ops/pilot-runbook-colombiatours.md) — runbook operacional cutover.
 - [`docs/ops/cutover-checklist.md`](../ops/cutover-checklist.md) — checklist cutover day.
-- [[ADR-019]] · [[ADR-020]] · [[ADR-021]] · [[ADR-024]] · [[ADR-025]].
+- [`docs/qa/pilot/transcreate-playbook.md`](../qa/pilot/transcreate-playbook.md) — playbook QA transcreate (W5 #219).
+- [[ADR-003]] · [[ADR-005]] · [[ADR-018]] · [[ADR-019]] · [[ADR-020]] · [[ADR-021]] · [[ADR-023]] · [[ADR-024]] · [[ADR-025]].
+
+**Shipping refs W7-b (docs-only):**
+- W2 #216 → [PR #229](https://github.com/weppa-cloud/bukeer-studio/pull/229) (activities RPC + editors — Flow 6).
+- W4 #218 → [PR #237](https://github.com/weppa-cloud/bukeer-studio/pull/237) (editor→render E2E).
+- W5 #219 → [PR #238](https://github.com/weppa-cloud/bukeer-studio/pull/238) (transcreate lifecycle — Flow 8).
+- W6 #220 → [PR #239](https://github.com/weppa-cloud/bukeer-studio/pull/239) (matrix visual playbook).
+- W7-a → [PR #230](https://github.com/weppa-cloud/bukeer-studio/pull/230) (onboarding Flows 1-5 + runbook + checklist).

--- a/docs/training/colombiatours-onboarding.md
+++ b/docs/training/colombiatours-onboarding.md
@@ -403,31 +403,32 @@ Para 99% de tu operación usas Stream (Flow 5). Manual override es para el equip
 
 Tabla clave: `seo_localized_variants`. Cada fila representa una overlay de un campo traducido para una tupla `(target_entity_type, target_entity_id, target_locale, field)`.
 
-Estados (`status`):
+Estados (`status`) — gated per [[ADR-021]] (no skipping de `draft` → `applied`):
 
 | Estado | Significado | Acción siguiente |
 |--------|-------------|------------------|
-| `draft` | El LLM generó el campo, no revisado. | Revisar en dashboard (Flow 5) → Reviewed |
+| `draft` | El LLM generó el campo, no revisado. | Revisar en dashboard (Flow 5) → marcar `reviewed` |
 | `reviewed` | Un humano aprobó el draft. | Apply para publicar |
-| `applied` | Publicado en `/en/...` (render público). | Ninguna. Drift puede marcarlo `stale`. |
-| `stale` | Contenido base (es-CO) cambió después del apply → re-traducir. | Re-entrar Flow 5 para refrescar |
+| `applied` | Publicado en `/en/...` (render público). | Ninguna. Puede caer en drift (ver 8.3). |
 
-Relación con `seo_transcreation_jobs`: cada apply crea (o actualiza) un `seo_transcreation_jobs` row con el payload completo del LLM. `seo_localized_variants` es la overlay proyectada que el SSR renderiza.
+Cada fila tiene además una flag booleana `drift` (independiente del `status`): cuando `true`, la fila está `applied` pero el contenido base (es-CO) cambió después del apply — UI la etiqueta como "stale" (etiqueta de presentación, no un estado adicional en el enum).
 
-### 8.3 Drift detection (`status='stale'`)
+Relación con `seo_transcreation_jobs`: cada apply crea (o actualiza) un `seo_transcreation_jobs` row con el payload completo del LLM ([[ADR-021]] audit trail). `seo_localized_variants` es la overlay proyectada que el SSR renderiza.
 
-Cuando editas contenido es-CO de un paquete/actividad/blog que ya tiene traducción `applied` en en-US, el sistema marca el variant EN como `stale` ([[ADR-021]] drift policy).
+### 8.3 Drift detection (flag `drift=true`)
+
+Cuando editas contenido es-CO de un paquete/actividad/blog que ya tiene traducción `applied` en en-US, el sistema marca la fila EN con `drift=true` (la UI la muestra como "stale"). Ver [[ADR-021]] drift policy.
 
 **Dónde ves drift:**
-- Dashboard `Coverage` → banner "N items con drift" (top del dashboard).
-- `/dashboard/<websiteId>/ops/reconciliation` → lista de stale items con link al editor.
+- Dashboard Translations → banner superior con contador de items en drift + toggle `translations-dashboard-filter-drift-toggle` para filtrar solo drifted items.
+- `/dashboard/<websiteId>/ops/reconciliation` → lista de items en drift con link al editor.
 - Alertas opcionales en Slack (si el equipo configuró webhook de drift).
 
 **Cómo re-aplicar tras drift:**
-1. Abrir el item desde el drift banner (click → va directo al translation editor).
+1. Filtrar dashboard por drift (toggle `Drift: on`) o abrir el item desde el drift banner (click → va directo al translation editor).
 2. Disparar transcreate de nuevo (mismo Flow 5.a/b/c).
-3. El nuevo draft refleja los cambios es-CO; revisar → Reviewed → Apply.
-4. Variant vuelve a `applied` (deja de estar `stale`).
+3. El nuevo draft refleja los cambios es-CO; revisar → `reviewed` → Apply.
+4. Variant vuelve a `applied` con `drift=false` (deja de estar marcado como "stale").
 
 ### 8.4 Bulk review (`/api/seo/translations/bulk`)
 
@@ -664,7 +665,7 @@ Esta sección es vinculante. Hacer cualquiera de estas cosas puede romper el sit
 | Traducción aplicada pero público en español | [FAQ render](#traducción-parece-no-actualizarse) — distinguir coverage cache vs render cache |
 | Necesito editar una actividad (marketing/contenido) | [Flow 6](#flow-6--editar-una-actividad-variant-a--studio-native) — Variant A Studio native |
 | Necesito cambiar marketing de un hotel | [Flow 7](#flow-7--hotel-flutter-handoff-variant-b--read-only-studio) — handoff Slack al equipo Flutter |
-| Drift alert sobre traducción stale | [Flow 8.3](#83-drift-detection-statusstale) — re-disparar transcreate del item |
+| Drift alert sobre traducción stale | [Flow 8.3](#83-drift-detection-flag-drifttrue) — re-disparar transcreate del item |
 | Quiero aplicar varias traducciones en batch | [Flow 8.4](#84-bulk-review-apiseotranslationsbulk) — bulk atómico |
 | Confundido entre Variant A y Variant B | [FAQ Variant](#variant-a-vs-variant-b--cómo-distinguirlas) — tabla de expectativas |
 


### PR DESCRIPTION
## Summary

Stage 5 W7-b of EPIC #214 Pilot Readiness — docs-only extension of the W7-a onboarding artefacts (shipped in PR #230) to cover the remaining acceptance criteria in #221.

Closes #221 **partially** — screencasts (W7-c) remain outstanding as a separate follow-up (manual video capture post-UI-freeze). See "Deferred" section below.

- Extends `docs/training/colombiatours-onboarding.md` with **Flow 6 (Activity Studio editor — Variant A default post-W2)**, **Flow 7 (Hotel Flutter handoff — Variant B)** and **Flow 8 (SEO transcreate technical layer — stream, drift, bulk, per-content SEO checklist)**. Enriches the existing Flow 5 (translation) sub-flows with `translations-dashboard-*` testid anchors, `seo_transcreation_jobs` status transitions, and stream-abort / 429 / 409 troubleshooting cross-ref to the W5 playbook (no content duplicated).
- Adds 4 new FAQ entries (Variant A vs B distinction, hoteles read-only vs flag-off, bulk partial failure, 429 as expected per priority v2) and 5 new cheat-sheet rows for the new flows.
- Updates `docs/ops/cutover-checklist.md` with a **Stage → Flow verification map** covering W1→W6 shipped deliverables (PRs #225/#227/#229/#237/#238/#239/#230) and a **per-flow cutover day verification table**. Booking-row exclusions documented as struck-through per priority v2.
- Updates `docs/INDEX.md` with a W7-b artefact line under the pilot-readiness concept, `colombiatours-onboarding` entry refreshed from "Flows 1-5" to "Flows 1-8", and new wikilink aliases for `[[field-ownership]]` + `[[booking-defer]]`.

## AC coverage (W7-b scope)

- [x] **AC-W7-1 — Flows 1-5 doc** (shipped W7-a; #230). This PR adds Flows 6/7/8 to the same doc.
- [x] **AC-W7-1 — Flow 4 (3 sub-flows)** enriched with testid anchors + DB transitions + troubleshooting cross-ref to QA playbook.
- [x] **AC-W7-1 — Flow 6 (Activity Variant A)** walkthrough with `update_activity_marketing_field` RPC + routes + editors; flag `studio_editor_v2` note.
- [x] **AC-W7-1 — Flow 7 (Hotel Variant B)** read-only Studio view + Flutter handoff protocol + SEO meta editable via SEO item detail.
- [x] **AC-W7-1 — Flow 8 (SEO transcreate)** stream vs manual override, `seo_localized_variants` interpretation, drift detection (`status='stale'`), bulk atomic review, per-content-type SEO checklist.
- [x] **AC-W7-2** expected state + testids documented; screenshot placeholders `{{screenshot-placeholder}}` track W7-c capture points (cross-locale `/en/...` anchors included per sub-flow).
- [ ] **AC-W7-3** screencasts — **deferred to W7-c** (explicit separate task per spec boundary).
- [x] **AC-W7-4** FAQ expanded with Variant A/B distinction, 429 as expected per priority v2, Studio vs Flutter boundary, bulk partial failure resolution.
- [x] **AC-W7-5** pilot runbook unchanged (W7-a shipped it). Cutover checklist extended with W1→W6 Stage map + per-flow verification table.
- [x] **AC-W7-6** cross-links to #207 / #213 / #214 / #215 / ADR-024 / ADR-025 present (W7-a baseline preserved; W7-b adds #216 / #218 / #219 / #220 / PRs).
- [x] **AC-W7-10** what-NOT-to-do unchanged (W7-a shipped the list).
- [x] **AC-W7-11** INDEX updated: new artefact line in pilot-readiness concept section + `colombiatours-onboarding` entry refresh + two new wikilink aliases; Last-updated line bumped to 2026-04-20.

## What remains open on #221

- **W7-c screencasts** (≤ 5 min each per flow, Loom primary + Drive mirror). Manual video work post-UI-freeze. Spec AC-W7-3 lists the required set: 3 transcreate sub-flows (4.a/b/c) + Activity editor (Flow 6) + Hotel handoff (Flow 7). Keep #221 OPEN until W7-c lands.
- **Partner sign-off sessions** (AC-W7-7 + AC-W7-8): scheduled per-tenant; not tied to code/docs delivery.

## Gates

- [x] `npm run build` passes (verified with env.local linked; see local build log). Docs-only change — no code path affected.
- [x] Wrong-ADR grep (`ADR-022|ADR-036|ADR-015|ADR-012`) against `docs/training/` + `docs/ops/` → no hits. Correct ADR refs used: ADR-003/005/018/019/020/021/023/024/025.
- [x] Shipping PRs referenced — all resolve: #225 #227 #229 #230 #237 #238 #239.
- [x] Training copy kept in Spanish (user is ColombiaTours partner).
- [x] No duplication of W5 playbook content — cross-ref only.

## Test plan

- [ ] Reviewer verifies new Flow 6/7/8 anchors from TOC + cheat-sheet resolve on GitHub rendering.
- [ ] Reviewer confirms Stage → Flow map in `cutover-checklist.md` mirrors shipped PRs and flags W7-c as deferred.
- [ ] tech-validator MODE:CODE verdict posted as PR comment before merge.

## References

- EPIC [#214](https://github.com/weppa-cloud/bukeer-studio/issues/214) Pilot Readiness
- Issue [#221](https://github.com/weppa-cloud/bukeer-studio/issues/221) W7 training
- Previous PR [#230](https://github.com/weppa-cloud/bukeer-studio/pull/230) W7-a onboarding skeleton
- QA playbook cross-ref: `docs/qa/pilot/transcreate-playbook.md`
- ADRs: [[ADR-019]] [[ADR-020]] [[ADR-021]] [[ADR-024]] [[ADR-025]]

Closes #221