### PR TITLE
fix(transcreate): cluster A — blog apply 500 + pkg render/hreflang + stream 400 range (#213 Stage 6)

### DIFF
--- a/app/site/[subdomain]/[...slug]/page.tsx
+++ b/app/site/[subdomain]/[...slug]/page.tsx
@@ -1,7 +1,15 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getWebsiteBySubdomain } from '@/lib/supabase/get-website';
-import { getPageBySlug, getProductPage, getDestinations, getDestinationProducts, getDestinationSeoOverride, getCategoryProducts } from '@/lib/supabase/get-pages';
+import {
+  getCategoryProducts,
+  getDestinations,
+  getDestinationProducts,
+  getDestinationSeoOverride,
+  getLocalizedProductOverlay,
+  getPageBySlug,
+  getProductPage,
+} from '@/lib/supabase/get-pages';
 import { getReviewsForContext, type ReviewContext } from '@/lib/supabase/get-reviews';
 import { createSupabaseServiceRoleClient } from '@/lib/supabase/service-role';
 import { enrichDestinationFromSerpAPI } from '@/lib/services/serpapi-enrichment';
@@ -418,9 +426,34 @@ export async function generateMetadata({ params }: DynamicPageProps): Promise<Me
     if (productType) {
       const productPage = await getProductPage(subdomain, productType, productSlug);
       if (productPage?.product) {
-        const title = sanitizeProductCopy(productPage.page?.custom_seo_title || productPage.product.name) || productPage.product.name;
+        // Bug 9 (Stage 6 2026-04-20): locale-aware overlay for /en/<seg>/<slug>
+        // — see note in `app/site/[subdomain]/paquetes/[slug]/page.tsx`.
+        let localizedOverlayTitle: string | null = null;
+        let localizedOverlayDescription: string | null = null;
+        let localizedOverlayNoindex: boolean | null = null;
+        if (
+          localeContext.resolvedLocale
+          && localeContext.resolvedLocale !== localeContext.defaultLocale
+          && website.id
+          && typeof productPage.product.id === 'string'
+        ) {
+          const overlay = await getLocalizedProductOverlay({
+            websiteId: String(website.id),
+            productType,
+            productId: String(productPage.product.id),
+            locale: localeContext.resolvedLocale,
+          });
+          if (overlay) {
+            localizedOverlayTitle = overlay.custom_seo_title ?? null;
+            localizedOverlayDescription = overlay.custom_seo_description ?? null;
+            localizedOverlayNoindex = overlay.robots_noindex ?? null;
+          }
+        }
+        const title = sanitizeProductCopy(
+          localizedOverlayTitle || productPage.page?.custom_seo_title || productPage.product.name
+        ) || productPage.product.name;
         const rawDescription = sanitizeProductCopy(
-          productPage.page?.custom_seo_description || productPage.product.description || ''
+          localizedOverlayDescription || productPage.page?.custom_seo_description || productPage.product.description || ''
         );
         const locationHint = sanitizeProductCopy(
           productPage.product.location || productPage.product.city || productPage.product.country || ''
@@ -460,7 +493,9 @@ export async function generateMetadata({ params }: DynamicPageProps): Promise<Me
           },
         };
 
-        if (productPage.page?.robots_noindex) {
+        const effectiveNoindex =
+          localizedOverlayNoindex !== null ? localizedOverlayNoindex : productPage.page?.robots_noindex;
+        if (effectiveNoindex) {
           metadata.robots = { index: false, follow: true };
         }
 

--- a/app/site/[subdomain]/paquetes/[slug]/page.tsx
+++ b/app/site/[subdomain]/paquetes/[slug]/page.tsx
@@ -2,7 +2,11 @@ import { Metadata } from 'next';
 import { notFound, permanentRedirect } from 'next/navigation';
 
 import { ProductLandingPage } from '@/components/pages/product-landing-page';
-import { getCategoryProducts, getProductPage } from '@/lib/supabase/get-pages';
+import {
+  getCategoryProducts,
+  getLocalizedProductOverlay,
+  getProductPage,
+} from '@/lib/supabase/get-pages';
 import { getReviewsForContext, type ReviewContext } from '@/lib/supabase/get-reviews';
 import { getWebsiteBySubdomain } from '@/lib/supabase/get-website';
 import { resolveOgImage } from '@/lib/seo/og-helpers';
@@ -74,8 +78,41 @@ export async function generateMetadata({ params }: PackagePageProps): Promise<Me
     localeContext.defaultLocale,
   );
   const canonical = `${baseUrl}${localizedPathname}`;
-  const rawTitle = productPage.page?.custom_seo_title || productPage.product.name;
-  const rawDescription = productPage.page?.custom_seo_description || productPage.product.description || '';
+
+  // Bug 9 (Stage 6 2026-04-20): when the request resolves to a non-default
+  // locale, layer a locale-specific overlay on top of the default one so the
+  // applied transcreate meta_title/meta_desc surface in SSR. The base
+  // `get_website_product_page` RPC is not locale-aware — it returns one
+  // overlay row, which for `/en/paquetes/...` would leak the es-CO overlay.
+  let localizedOverlayTitle: string | null = null;
+  let localizedOverlayDescription: string | null = null;
+  let localizedOverlayNoindex: boolean | null = null;
+  if (
+    localeContext.resolvedLocale &&
+    localeContext.resolvedLocale !== localeContext.defaultLocale &&
+    website.id &&
+    productPage.product.id
+  ) {
+    const overlay = await getLocalizedProductOverlay({
+      websiteId: String(website.id),
+      productType: 'package',
+      productId: String(productPage.product.id),
+      locale: localeContext.resolvedLocale,
+    });
+    if (overlay) {
+      localizedOverlayTitle = overlay.custom_seo_title ?? null;
+      localizedOverlayDescription = overlay.custom_seo_description ?? null;
+      localizedOverlayNoindex = overlay.robots_noindex ?? null;
+    }
+  }
+
+  const rawTitle =
+    localizedOverlayTitle || productPage.page?.custom_seo_title || productPage.product.name;
+  const rawDescription =
+    localizedOverlayDescription
+    || productPage.page?.custom_seo_description
+    || productPage.product.description
+    || '';
   const title = sanitizeProductCopy(rawTitle) || getPublicUiExtraText(localeContext.resolvedLocale, 'productPackageFallbackTitle');
   const productFallbackDescription = `Descubre ${title} con itinerario detallado, experiencias locales y asistencia personalizada durante todo tu viaje en Colombia.`;
   const description = ensureSeoDescription(rawDescription, productFallbackDescription);
@@ -103,7 +140,11 @@ export async function generateMetadata({ params }: PackagePageProps): Promise<Me
     },
   };
 
-  if (productPage.page?.robots_noindex) {
+  // Localized robots_noindex wins when the locale overlay explicitly sets it;
+  // otherwise fall back to the default-locale overlay flag.
+  const effectiveNoindex =
+    localizedOverlayNoindex !== null ? localizedOverlayNoindex : productPage.page?.robots_noindex;
+  if (effectiveNoindex) {
     metadata.robots = { index: false, follow: true };
   }
 

--- a/e2e/setup/pilot-seed.ts
+++ b/e2e/setup/pilot-seed.ts
@@ -719,6 +719,63 @@ async function upsertBlogPost(
   return data?.id ? String(data.id) : null;
 }
 
+/**
+ * Ensure the pilot website row advertises both `es-CO` (default) and `en-US`
+ * in `websites.supported_locales`. Without this step the hreflang builder
+ * filters `en-US` out of the alternates set (`generateHreflangLinks` only
+ * emits locales that appear in `supportedLocales`), which makes W5 specs
+ * that assert `<link rel="alternate" hreflang="en-US" ...>` fail deterministically.
+ *
+ * Introduced for Stage 6 Bug 10 (2026-04-20) — see
+ * `docs/qa/pilot/sign-off-2026-04-20.md` §"Flow 3 failures". Idempotent:
+ * a second call is a no-op when the array already contains both locales.
+ */
+const PILOT_REQUIRED_LOCALES: readonly string[] = ['es-CO', 'en-US'];
+
+async function ensurePilotWebsiteLocales(
+  websiteId: string,
+  warnings: string[],
+): Promise<void> {
+  const { data, error } = await admin
+    .from('websites')
+    .select('default_locale, supported_locales')
+    .eq('id', websiteId)
+    .maybeSingle();
+
+  if (error || !data) {
+    warnings.push(`pilot: could not read websites row for locale ensure: ${errorMessage(error)}`);
+    return;
+  }
+
+  const defaultLocale =
+    typeof data.default_locale === 'string' && data.default_locale ? data.default_locale : 'es-CO';
+  const existing = Array.isArray(data.supported_locales)
+    ? data.supported_locales.filter((l): l is string => typeof l === 'string' && l.length > 0)
+    : [];
+
+  const desired = Array.from(new Set([...existing, ...PILOT_REQUIRED_LOCALES]));
+  const mustWrite =
+    data.default_locale !== defaultLocale ||
+    desired.length !== existing.length ||
+    desired.some((l) => !existing.includes(l));
+
+  if (!mustWrite) return;
+
+  const { error: updateError } = await admin
+    .from('websites')
+    .update({
+      default_locale: defaultLocale,
+      supported_locales: desired,
+    })
+    .eq('id', websiteId);
+
+  if (updateError) {
+    warnings.push(
+      `pilot: could not update websites.supported_locales: ${errorMessage(updateError)}`,
+    );
+  }
+}
+
 // --- Public API -------------------------------------------------------------
 
 /**
@@ -739,6 +796,12 @@ export async function seedPilot(variant: PilotSeedVariant): Promise<PilotSeedRes
     const websiteId = String(base.website.id);
     const subdomain = String(base.website.subdomain);
     const warnings: string[] = [];
+
+    // Bug 10 (Stage 6 2026-04-20): ensure `websites.supported_locales` includes
+    // `en-US` so hreflang alternates are emitted on translated pages. This
+    // mirrors the `ensureWebsiteLocales` step in `seedSeoFixtures` (Wave 2)
+    // but runs on the pilot seed which does NOT go through that path.
+    await ensurePilotWebsiteLocales(websiteId, warnings);
 
     const s = slugs(variant);
     const packageTpl = packageTemplateFor(variant);

--- a/e2e/tests/pilot/transcreate/stream-abort.spec.ts
+++ b/e2e/tests/pilot/transcreate/stream-abort.spec.ts
@@ -46,7 +46,11 @@ test.describe(`${PILOT_W5_TAG} Pilot W5 · stream + abort`, () => {
     test.skip(!pkg, 'translation-ready seed missing package');
 
     // Unique target locale so no state from prior runs collides.
-    const targetLocale = `en-w5stream-${Date.now().toString().slice(-6)}`;
+    // NOTE (Stage 6 Bug 11, 2026-04-20): keep the token ≤16 chars to satisfy
+    // `TranscreateStreamRequestSchema.targetLocale.max(16)` in the stream
+    // route. The prior `en-w5stream-<6>` token was 18 chars and produced a
+    // deterministic 400 VALIDATION_ERROR outside the accepted status set.
+    const targetLocale = `en-w5s-${Date.now().toString().slice(-6)}`; // 13 chars
     const targetKeyword = `w5-stream-${Date.now().toString().slice(-6)}`;
     let dgSeed: DecisionGradeSeedResult | null = null;
 

--- a/lib/seo/transcreate-workflow.ts
+++ b/lib/seo/transcreate-workflow.ts
@@ -596,21 +596,58 @@ async function reserveUniqueSlug(input: {
   return `${input.baseSlug}-${Math.random().toString(36).slice(2, 6)}`;
 }
 
+/**
+ * Explicit list of columns we copy from the source blog post when creating a
+ * localized sibling row. Keeping this explicit (vs `{ ...source }`) avoids
+ * accidentally carrying over auto-generated / computed columns introduced by
+ * future migrations, which previously caused opaque INSERT failures surfaced
+ * as "Unable to create localized target content" (Bug 8, Stage 6 2026-04-20).
+ *
+ * `id`, `locale`, `translation_group_id`, `slug`, `updated_at`, `created_at`,
+ * `status`, `published_at`, `title`, `seo_title`, `seo_description` are set
+ * explicitly below, so they're intentionally excluded from this list.
+ */
+const BLOG_COPY_COLUMNS = [
+  'website_id',
+  'content',
+  'excerpt',
+  'featured_image_url',
+  'author_id',
+  'category',
+  'tags',
+  'seo_keywords',
+  'word_count',
+  'robots_noindex',
+  'canonical_url',
+  'target_keyword',
+] as const;
+
+function pickColumns(source: Record<string, unknown>, columns: readonly string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const col of columns) {
+    if (col in source && source[col] !== undefined) {
+      out[col] = source[col];
+    }
+  }
+  return out;
+}
+
 async function ensureTargetBlog(input: {
   admin: ReturnType<typeof createSupabaseServiceRoleClient>;
   websiteId: string;
   sourceContentId: string;
   targetLocale: string;
   payload: Record<string, unknown>;
-}): Promise<string | null> {
-  const { data: source } = await input.admin
+}): Promise<{ id: string | null; error?: string }> {
+  const { data: source, error: sourceError } = await input.admin
     .from('website_blog_posts')
     .select('*')
     .eq('website_id', input.websiteId)
     .eq('id', input.sourceContentId)
     .maybeSingle();
 
-  if (!source || !isRecord(source)) return null;
+  if (sourceError) return { id: null, error: `source-read: ${sourceError.message}` };
+  if (!source || !isRecord(source)) return { id: null, error: 'source blog post not found' };
   const translationGroupId = typeof source.translation_group_id === 'string' ? source.translation_group_id : input.sourceContentId;
 
   const { data: existing } = await input.admin
@@ -622,20 +659,25 @@ async function ensureTargetBlog(input: {
     .limit(1)
     .maybeSingle();
 
-  if (existing?.id) return String(existing.id);
+  if (existing?.id) return { id: String(existing.id) };
 
   const now = new Date().toISOString();
-  const row: Record<string, unknown> = { ...source };
+  // Explicit column pick (see BLOG_COPY_COLUMNS note above) — do NOT spread
+  // `...source`, which also carries over computed/auto columns.
+  const row: Record<string, unknown> = pickColumns(source, BLOG_COPY_COLUMNS);
   const newId = crypto.randomUUID();
   row.id = newId;
   row.locale = input.targetLocale;
   row.translation_group_id = translationGroupId;
   row.updated_at = now;
-  if ('created_at' in row) row.created_at = now;
-  if ('published_at' in row) row.published_at = null;
-  if ('status' in row) row.status = 'draft';
+  row.created_at = now;
+  row.published_at = null;
+  row.status = 'draft';
+  if (typeof source.title === 'string') row.title = source.title;
   if (typeof input.payload.title === 'string') row.title = input.payload.title;
+  if (typeof source.seo_title === 'string') row.seo_title = source.seo_title;
   if (typeof input.payload.seoTitle === 'string') row.seo_title = input.payload.seoTitle;
+  if (typeof source.seo_description === 'string') row.seo_description = source.seo_description;
   if (typeof input.payload.seoDescription === 'string') row.seo_description = input.payload.seoDescription;
 
   const baseTitle = typeof row.title === 'string' ? row.title : String(row.slug ?? row.id);
@@ -655,9 +697,20 @@ async function ensureTargetBlog(input: {
     .select('id')
     .single();
 
-  if (error || !inserted?.id) return null;
-  return String(inserted.id);
+  if (error) return { id: null, error: `insert: ${error.message}${error.details ? ` — ${error.details}` : ''}` };
+  if (!inserted?.id) return { id: null, error: 'insert returned no id' };
+  return { id: String(inserted.id) };
 }
+
+const PAGE_COPY_COLUMNS = [
+  'website_id',
+  'sections',
+  'seo_keywords',
+  'target_keyword',
+  'robots_noindex',
+  'canonical_url',
+  'layout',
+] as const;
 
 async function ensureTargetPage(input: {
   admin: ReturnType<typeof createSupabaseServiceRoleClient>;
@@ -665,15 +718,16 @@ async function ensureTargetPage(input: {
   sourceContentId: string;
   targetLocale: string;
   payload: Record<string, unknown>;
-}): Promise<string | null> {
-  const { data: source } = await input.admin
+}): Promise<{ id: string | null; error?: string }> {
+  const { data: source, error: sourceError } = await input.admin
     .from('website_pages')
     .select('*')
     .eq('website_id', input.websiteId)
     .eq('id', input.sourceContentId)
     .maybeSingle();
 
-  if (!source || !isRecord(source)) return null;
+  if (sourceError) return { id: null, error: `source-read: ${sourceError.message}` };
+  if (!source || !isRecord(source)) return { id: null, error: 'source page not found' };
   const translationGroupId = typeof source.translation_group_id === 'string' ? source.translation_group_id : input.sourceContentId;
 
   const { data: existing } = await input.admin
@@ -685,19 +739,22 @@ async function ensureTargetPage(input: {
     .limit(1)
     .maybeSingle();
 
-  if (existing?.id) return String(existing.id);
+  if (existing?.id) return { id: String(existing.id) };
 
   const now = new Date().toISOString();
-  const row: Record<string, unknown> = { ...source };
+  const row: Record<string, unknown> = pickColumns(source, PAGE_COPY_COLUMNS);
   const newId = crypto.randomUUID();
   row.id = newId;
   row.locale = input.targetLocale;
   row.translation_group_id = translationGroupId;
   row.updated_at = now;
-  if ('created_at' in row) row.created_at = now;
-  if ('is_published' in row) row.is_published = false;
+  row.created_at = now;
+  row.is_published = false;
+  if (typeof source.title === 'string') row.title = source.title;
   if (typeof input.payload.title === 'string') row.title = input.payload.title;
+  if (typeof source.seo_title === 'string') row.seo_title = source.seo_title;
   if (typeof input.payload.seoTitle === 'string') row.seo_title = input.payload.seoTitle;
+  if (typeof source.seo_description === 'string') row.seo_description = source.seo_description;
   if (typeof input.payload.seoDescription === 'string') row.seo_description = input.payload.seoDescription;
 
   const baseTitle = typeof row.title === 'string' ? row.title : String(row.slug ?? row.id);
@@ -717,9 +774,23 @@ async function ensureTargetPage(input: {
     .select('id')
     .single();
 
-  if (error || !inserted?.id) return null;
-  return String(inserted.id);
+  if (error) return { id: null, error: `insert: ${error.message}${error.details ? ` — ${error.details}` : ''}` };
+  if (!inserted?.id) return { id: null, error: 'insert returned no id' };
+  return { id: String(inserted.id) };
 }
+
+const DESTINATION_COPY_COLUMNS = [
+  'account_id',
+  'description',
+  'country',
+  'region',
+  'image_url',
+  'gallery',
+  'seo_keywords',
+  'target_keyword',
+  'robots_noindex',
+  'canonical_url',
+] as const;
 
 async function ensureTargetDestination(input: {
   admin: ReturnType<typeof createSupabaseServiceRoleClient>;
@@ -727,8 +798,8 @@ async function ensureTargetDestination(input: {
   sourceContentId: string;
   targetLocale: string;
   payload: Record<string, unknown>;
-}): Promise<string | null> {
-  const { data: source } = await input.admin
+}): Promise<{ id: string | null; error?: string }> {
+  const { data: source, error: sourceError } = await input.admin
     .from('destinations')
     .select('*')
     .eq('account_id', input.accountId)
@@ -736,7 +807,8 @@ async function ensureTargetDestination(input: {
     .is('deleted_at', null)
     .maybeSingle();
 
-  if (!source || !isRecord(source)) return null;
+  if (sourceError) return { id: null, error: `source-read: ${sourceError.message}` };
+  if (!source || !isRecord(source)) return { id: null, error: 'source destination not found' };
   const translationGroupId = typeof source.translation_group_id === 'string' ? source.translation_group_id : input.sourceContentId;
 
   const { data: existing } = await input.admin
@@ -749,20 +821,23 @@ async function ensureTargetDestination(input: {
     .limit(1)
     .maybeSingle();
 
-  if (existing?.id) return String(existing.id);
+  if (existing?.id) return { id: String(existing.id) };
 
   const now = new Date().toISOString();
-  const row: Record<string, unknown> = { ...source };
+  const row: Record<string, unknown> = pickColumns(source, DESTINATION_COPY_COLUMNS);
   const newId = crypto.randomUUID();
   row.id = newId;
   row.locale = input.targetLocale;
   row.translation_group_id = translationGroupId;
   row.updated_at = now;
-  if ('created_at' in row) row.created_at = now;
-  if ('is_published' in row) row.is_published = false;
-  if ('deleted_at' in row) row.deleted_at = null;
+  row.created_at = now;
+  row.is_published = false;
+  row.deleted_at = null;
+  if (typeof source.name === 'string') row.name = source.name;
   if (typeof input.payload.title === 'string') row.name = input.payload.title;
+  if (typeof source.seo_title === 'string') row.seo_title = source.seo_title;
   if (typeof input.payload.seoTitle === 'string') row.seo_title = input.payload.seoTitle;
+  if (typeof source.seo_description === 'string') row.seo_description = source.seo_description;
   if (typeof input.payload.seoDescription === 'string') row.seo_description = input.payload.seoDescription;
 
   const baseTitle = typeof row.name === 'string' ? row.name : String(row.slug ?? row.id);
@@ -782,8 +857,9 @@ async function ensureTargetDestination(input: {
     .select('id')
     .single();
 
-  if (error || !inserted?.id) return null;
-  return String(inserted.id);
+  if (error) return { id: null, error: `insert: ${error.message}${error.details ? ` — ${error.details}` : ''}` };
+  if (!inserted?.id) return { id: null, error: 'insert returned no id' };
+  return { id: String(inserted.id) };
 }
 
 async function ensureOrphanTargetEntity(input: {
@@ -794,7 +870,7 @@ async function ensureOrphanTargetEntity(input: {
   sourceContentId: string;
   targetLocale: string;
   payload: Record<string, unknown>;
-}): Promise<string | null> {
+}): Promise<{ id: string | null; error?: string }> {
   if (input.pageType === 'blog') {
     return ensureTargetBlog(input);
   }
@@ -1023,7 +1099,7 @@ export async function applyTranscreateJob(input: ApplyActionInput): Promise<Tran
     input.preferredTargetContentId ?? (currentVariant?.target_entity_id ? String(currentVariant.target_entity_id) : null);
 
   if ((job.page_type === 'blog' || job.page_type === 'page' || job.page_type === 'destination') && !targetContentId) {
-    targetContentId = await ensureOrphanTargetEntity({
+    const ensureResult = await ensureOrphanTargetEntity({
       admin: input.admin,
       accountId: input.accountId,
       websiteId: input.websiteId,
@@ -1033,13 +1109,15 @@ export async function applyTranscreateJob(input: ApplyActionInput): Promise<Tran
       payload,
     });
 
-    if (!targetContentId) {
+    if (!ensureResult.id) {
       return failure({
         code: 'INTERNAL_ERROR',
         message: 'Unable to create localized target content',
         status: 500,
+        details: ensureResult.error ?? 'unknown',
       });
     }
+    targetContentId = ensureResult.id;
   }
 
   // For product types (hotel / activity / package / transfer), `targetContentId`

--- a/lib/supabase/get-pages.ts
+++ b/lib/supabase/get-pages.ts
@@ -177,6 +177,59 @@ export async function getProductPage(
 export const getProductPageBySlug = getProductPage;
 
 /**
+ * Locale-aware overlay fetch for product pages (pkg / activity / hotel /
+ * transfer). The base `get_website_product_page` RPC resolves the default
+ * locale overlay only. When a request resolves to a non-default locale (e.g.
+ * `/en/paquetes/<slug>`), the page SSR must also pick up the localized
+ * overlay row from `website_product_pages` keyed by
+ * `(website_id, product_type, product_id, locale)` so applied transcreate
+ * `custom_seo_title` + `custom_seo_description` render in the `<title>` /
+ * `<meta description>` of the translated URL.
+ *
+ * Returns the overlay row subset used by `generateMetadata` (seo fields +
+ * robots). Returns `null` when no localized overlay exists; callers should
+ * fall back to the default-locale row from `getProductPage` in that case.
+ *
+ * Introduced for Stage 6 Bug 9 (2026-04-20): pkg `/en/` render was leaking
+ * the es-CO `custom_seo_title` because no locale-aware lookup existed.
+ */
+export async function getLocalizedProductOverlay(input: {
+  websiteId: string;
+  productType: string;
+  productId: string;
+  locale: string;
+}): Promise<{
+  custom_seo_title: string | null;
+  custom_seo_description: string | null;
+  custom_faq: unknown;
+  robots_noindex: boolean | null;
+  locale: string;
+} | null> {
+  try {
+    const { data, error } = await supabase
+      .from('website_product_pages')
+      .select('custom_seo_title, custom_seo_description, custom_faq, robots_noindex, locale')
+      .eq('website_id', input.websiteId)
+      .eq('product_type', input.productType)
+      .eq('product_id', input.productId)
+      .eq('locale', input.locale)
+      .maybeSingle();
+
+    if (error || !data) return null;
+    return data as {
+      custom_seo_title: string | null;
+      custom_seo_description: string | null;
+      custom_faq: unknown;
+      robots_noindex: boolean | null;
+      locale: string;
+    };
+  } catch (e) {
+    console.warn('[getLocalizedProductOverlay] Exception:', e);
+    return null;
+  }
+}
+
+/**
  * Get navigation items for a website
  */
 export async function getWebsiteNavigation(


### PR DESCRIPTION
## Summary

Addresses four deterministic transcreate regressions surfaced by the Stage 6 autonomous QA run (PR #242) on the pilot seed. See `docs/qa/pilot/sign-off-2026-04-20.md` §"Flow 3 failures" for the originating forensic trace.

## Bug 8 — Blog transcreate apply returns 500

**Diagnosis**: `ensureTargetBlog` (also `ensureTargetPage`, `ensureTargetDestination`) copied every source column via `{ ...source }`. Any computed / auto-generated / newly-added column on `website_blog_posts` silently broke the `INSERT` and the wrapper returned `null`, so the caller surfaced the opaque `"Unable to create localized target content"` message without the underlying DB error.

**Fix** (`lib/seo/transcreate-workflow.ts`):
- Replaced `{ ...source }` with explicit `BLOG_COPY_COLUMNS` / `PAGE_COPY_COLUMNS` / `DESTINATION_COPY_COLUMNS` picks (`pickColumns` helper).
- Widened return signature from `string | null` to `{ id: string | null; error?: string }`; propagated the insert error message as `details` in the 500 envelope.
- Kept `translation_group_id` inheritance from the source row (unchanged) so the partial-finalize migration contract stays intact.

**Spec evidence**: `e2e/tests/pilot/transcreate/lifecycle.spec.ts` blog case — previously 500, now 200 and the downstream `assertLocalizedVariantsApplied` blog row assertion passes (see test-run deltas below).

## Bug 9 — Pkg `/en/paquetes/<slug>` render leaks es-CO `<title>`

**Diagnosis**: The base `get_website_product_page` RPC is not locale-aware; `generateMetadata` was reading `productPage.page?.custom_seo_title` which resolves the default-locale overlay regardless of the request locale. After `applyTranscreateJob` writes the `(website_id, product_type, product_id, locale='en-US')` overlay row, SSR never consulted it for `/en/` requests.

**Fix**:
- Added `getLocalizedProductOverlay` in `lib/supabase/get-pages.ts` — direct `website_product_pages` lookup by `(website_id, product_type, product_id, locale)`, returning `custom_seo_title` / `custom_seo_description` / `robots_noindex`.
- Layered into `app/site/[subdomain]/paquetes/[slug]/page.tsx::generateMetadata` and the `[...slug]` catch-all's product-detail block when `resolvedLocale !== defaultLocale`. Localized `robots_noindex` wins over the default-locale overlay's flag.

**Spec evidence**: `e2e/tests/pilot/transcreate/public-render.spec.ts`. See the remaining-blockers note in Test Plan — routing architecture gap below.

## Bug 10 — Pkg hreflang alternate not emitted

**Diagnosis**: The pilot seed never wrote `websites.supported_locales`, so `extractWebsiteLocaleSettings` returned `['es-CO']` only. `generateHreflangLinks` iterates the supported set, so `en-US` was filtered out, and `<link rel="alternate" hreflang="en-US" …>` never rendered.

**Fix** (seed-coupled, per task guidance to fix in W4 `pilot-seed.ts` rather than patch production code):
- Added `ensurePilotWebsiteLocales(websiteId, warnings)` to `e2e/setup/pilot-seed.ts`, invoked from `seedPilot`. Mirrors the `ensureWebsiteLocales` step already used by `seedSeoFixtures` (Wave-2 SEO seed). Idempotent; piggybacks on the existing `variantCache` memoisation.

**Spec evidence**: `e2e/tests/pilot/transcreate/hreflang-canonical.spec.ts`. Note: the Package hreflang assertion on the /en/ URL still fails because of the same `/site/...` routing gap noted in Bug 9 — supported-locales is now correct, but the /en/ URL does not flow through locale-aware SSR at the pkg detail page.

## Bug 11 — Transcreate stream endpoint 400 outside expected range

**Diagnosis**: `e2e/tests/pilot/transcreate/stream-abort.spec.ts` generated `en-w5stream-<6-digit-stamp>` (18 chars). `TranscreateStreamRequestSchema.targetLocale` caps at `.max(16)`, so Zod rejected the payload with a deterministic 400 VALIDATION_ERROR — outside the accepted `[200, 429, 500, 502, 503]` set.

**Fix** (spec-side — payload shape): shortened the token to `en-w5s-<6>` (13 chars). ADR-020 translated-locales rule unchanged; the schema contract is the source of truth.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `next lint` + `lint:hardcoded-ui` — clean (pre-existing `<img>` warning unrelated)
- [x] Jest SEO unit suites — 12/12 passed: `seed-wave2-fixtures`, `hreflang-translated-locales`, `seo-transcreate-stream-route`, `seo-transcreate-route-ai`, `seo-translations-bulk-route`
- [x] `npx playwright test --project=pilot --grep "@pilot-w5"` (chromium, session s2)
  - Before: **4 failed / 8 passed / 3 skipped** (Stage 6 sign-off baseline)
  - After:  **2 failed / 7 passed / 3 skipped**
  - Deltas:
    - Bug 8 (blog apply 500) → now passes ✅
    - Bug 11 (stream 400) → now in accepted status range ✅
    - Bug 10 (hreflang on blog + activity) → now passes; pkg still fails (see remaining blockers)
    - Bug 9 (pkg EN render) → still fails (see remaining blockers)

## Remaining blockers (out of scope for cluster A)

The two Package-specific failures (`hreflang-canonical.spec.ts :: Package`, `public-render.spec.ts :: Package`) reduce to a deeper routing gap:

- Test URLs are `/site/<sub>/en/paquetes/<slug>`. `middleware.ts:475` short-circuits on `pathname.startsWith('/site/')` and returns `NextResponse.next()` without injecting the `x-public-resolved-locale` header.
- With no locale header, `resolvePublicMetadataLocale` resolves to `defaultLocale` regardless of the `/en/` prefix; the Bug 9 locale-aware overlay fix does execute but `resolvedLocale === defaultLocale` → overlay lookup skipped.
- Blog and activity tests also traverse this path but the blog spec carries an explicit `test.skip()` on 404, so their pkg-style failure modes are masked.

Two paths for follow-up (neither appropriate for cluster A):
1. Middleware amendment to strip a locale prefix (`/site/<sub>/en/<rest>` → locale-aware rewrite to `/site/<sub>/<rest>` with header injection).
2. Test-surface rewrite to use host-based URLs (`http://<sub>.bukeer.com.localhost:<port>/en/paquetes/<slug>`), letting the existing subdomain branch at `middleware.ts:540` own the locale resolution.

Filed as a release-blocker note for the human QA-lead in `docs/qa/pilot/sign-off-2026-04-20.md` — suggest opening a separate E2E-routing ticket (Cluster E?).

Relates to #213