### PR TITLE
fix(e2e): cluster C — replace networkidle with deterministic wait on pilot matrix (#213 Stage 6)

### DIFF
--- a/e2e/setup/matrix-helpers.ts
+++ b/e2e/setup/matrix-helpers.ts
@@ -22,6 +22,48 @@ import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import type { ContentType, MatrixBlock } from '../fixtures/product-matrix';
 
+// --- Navigation / readiness -----------------------------------------------
+
+/**
+ * Primary root selector per content type. Emitted by `ProductLandingPage` and
+ * the blog detail RSC — guaranteed present on first SSR flush, no hydration
+ * dependency. Used by {@link waitForDetailReady} to replace the flaky
+ * `networkidle` wait (see cluster-c fix: Turbopack dev mode continuously
+ * emits websocket pings → `networkidle` races the 90s spec timeout).
+ */
+const DETAIL_ROOT_SELECTOR: Record<ContentType, string> = {
+  pkg: '[data-testid="detail-hero"]',
+  act: '[data-testid="detail-hero"]',
+  hotel: '[data-testid="detail-hero"]',
+  blog: '[data-testid="detail-blog"]',
+};
+
+/**
+ * Deterministic "page is renderable" wait for pilot matrix specs.
+ *
+ * Replaces `page.goto(url, { waitUntil: 'networkidle' })` which races in
+ * Turbopack dev mode (HMR keeps emitting websocket frames, so networkidle
+ * never resolves and the 90s spec timeout fires).
+ *
+ * Contract:
+ *   1. DOMContentLoaded has fired (SSR HTML is parsed).
+ *   2. The canonical root element for the content type is visible (15s budget).
+ *
+ * Matches the production SSR hydration model — the root container is always
+ * in the first HTML flush, so this closes out well under 30s even with
+ * Turbopack overhead.
+ */
+export async function waitForDetailReady(
+  page: Page,
+  contentType: ContentType,
+  opts: { timeout?: number } = {},
+): Promise<void> {
+  const { timeout = 15_000 } = opts;
+  await page.waitForLoadState('domcontentloaded', { timeout });
+  const selector = DETAIL_ROOT_SELECTOR[contentType];
+  await page.waitForSelector(selector, { state: 'visible', timeout });
+}
+
 // --- Animation freeze -----------------------------------------------------
 
 /**

--- a/e2e/tests/pilot/matrix/pilot-matrix-public-activity.spec.ts
+++ b/e2e/tests/pilot/matrix/pilot-matrix-public-activity.spec.ts
@@ -4,6 +4,7 @@ import {
   assertMatrixRow,
   assertVisualSnapshot,
   freezeAnimations,
+  waitForDetailReady,
   type MatrixRowOutcome,
 } from '../../../setup/matrix-helpers';
 import {
@@ -38,12 +39,13 @@ test.describe('@pilot-w6 Pilot W6 · matrix · activity', () => {
     const subdomain = pilotSubdomain();
     const route = `/site/${subdomain}/actividades/${act.slug}`;
 
-    const response = await page.goto(route, { waitUntil: 'networkidle' });
+    const response = await page.goto(route, { waitUntil: 'domcontentloaded' });
     test.skip(
       !response || response.status() === 404 || response.status() >= 500,
       `Public activity page unreachable (status=${response?.status() ?? 'no-response'}).`,
     );
 
+    await waitForDetailReady(page, 'act');
     await freezeAnimations(page);
 
     const outcomes: MatrixRowOutcome[] = [];
@@ -86,12 +88,13 @@ test.describe('@pilot-w6 Pilot W6 · matrix · activity', () => {
     try {
       const subdomain = pilotSubdomain();
       const route = `/site/${subdomain}/actividades/${act.slug}`;
-      const response = await page.goto(route, { waitUntil: 'networkidle' });
+      const response = await page.goto(route, { waitUntil: 'domcontentloaded' });
       test.skip(
         !response || response.status() === 404 || response.status() >= 500,
         `Public activity page unreachable on mobile (status=${response?.status() ?? 'no-response'}).`,
       );
 
+      await waitForDetailReady(page, 'act');
       await freezeAnimations(page);
       const outcomes: MatrixRowOutcome[] = [];
       for (const row of applicableRows('act').filter((r) => r.viewports.includes('mobile'))) {
@@ -160,6 +163,8 @@ test.describe('@pilot-w6 Pilot W6 · matrix · activity', () => {
         !response || response.status() === 404 || response.status() >= 500,
         `Public activity page unreachable (status=${response?.status() ?? 'no-response'}).`,
       );
+
+      await waitForDetailReady(page, 'act');
 
       const description = page.getByTestId('detail-description');
       await expect(description).toBeVisible();

--- a/e2e/tests/pilot/matrix/pilot-matrix-public-blog.spec.ts
+++ b/e2e/tests/pilot/matrix/pilot-matrix-public-blog.spec.ts
@@ -4,6 +4,7 @@ import {
   assertMatrixRow,
   assertVisualSnapshot,
   freezeAnimations,
+  waitForDetailReady,
   type MatrixRowOutcome,
 } from '../../../setup/matrix-helpers';
 import { getPilotSeed, pilotSubdomain } from '../helpers';
@@ -35,12 +36,13 @@ test.describe('@pilot-w6 Pilot W6 · matrix · blog', () => {
 
     const subdomain = pilotSubdomain();
     const route = `/site/${subdomain}/blog/${blog.slug}`;
-    const response = await page.goto(route, { waitUntil: 'networkidle' });
+    const response = await page.goto(route, { waitUntil: 'domcontentloaded' });
     test.skip(
       !response || response.status() === 404 || response.status() >= 500,
       `Blog detail page unreachable (status=${response?.status() ?? 'no-response'}).`,
     );
 
+    await waitForDetailReady(page, 'blog');
     await freezeAnimations(page);
 
     const outcomes: MatrixRowOutcome[] = [];
@@ -129,7 +131,7 @@ test.describe('@pilot-w6 Pilot W6 · matrix · blog', () => {
 
     const subdomain = pilotSubdomain();
     const route = `/site/${subdomain}/en/blog/${blog.slug}`;
-    const response = await page.goto(route, { waitUntil: 'networkidle' });
+    const response = await page.goto(route, { waitUntil: 'domcontentloaded' });
 
     // Acceptable terminal states:
     //  - 200 → assert render + hreflang
@@ -147,6 +149,7 @@ test.describe('@pilot-w6 Pilot W6 · matrix · blog', () => {
       `Translated blog URL server error (status=${response.status()}).`,
     );
 
+    await waitForDetailReady(page, 'blog');
     await freezeAnimations(page);
 
     const outcomes: MatrixRowOutcome[] = [];

--- a/e2e/tests/pilot/matrix/pilot-matrix-public-hotel.spec.ts
+++ b/e2e/tests/pilot/matrix/pilot-matrix-public-hotel.spec.ts
@@ -4,6 +4,7 @@ import {
   assertMatrixRow,
   assertVisualSnapshot,
   freezeAnimations,
+  waitForDetailReady,
   type MatrixRowOutcome,
 } from '../../../setup/matrix-helpers';
 import { getPilotSeed, pilotSubdomain } from '../helpers';
@@ -30,12 +31,13 @@ test.describe('@pilot-w6 Pilot W6 · matrix · hotel (read-only)', () => {
     const subdomain = pilotSubdomain();
     const route = `/site/${subdomain}/hoteles/${HOTEL_SLUG}`;
 
-    const response = await page.goto(route, { waitUntil: 'networkidle' });
+    const response = await page.goto(route, { waitUntil: 'domcontentloaded' });
     test.skip(
       !response || response.status() === 404 || response.status() >= 500,
       `Hotel detail page unreachable (status=${response?.status() ?? 'no-response'}). Hotels are Flutter-owner — seed gap expected if \`${HOTEL_SLUG}\` missing. Seed warnings: ${seed.warnings.join(' | ')}`,
     );
 
+    await waitForDetailReady(page, 'hotel');
     await freezeAnimations(page);
 
     const outcomes: MatrixRowOutcome[] = [];
@@ -76,12 +78,13 @@ test.describe('@pilot-w6 Pilot W6 · matrix · hotel (read-only)', () => {
     });
     const page = await context.newPage();
     try {
-      const response = await page.goto(route, { waitUntil: 'networkidle' });
+      const response = await page.goto(route, { waitUntil: 'domcontentloaded' });
       test.skip(
         !response || response.status() === 404 || response.status() >= 500,
         `Hotel detail page unreachable on mobile (status=${response?.status() ?? 'no-response'}).`,
       );
 
+      await waitForDetailReady(page, 'hotel');
       await freezeAnimations(page);
       const outcomes: MatrixRowOutcome[] = [];
       for (const row of applicableRows('hotel').filter((r) => r.viewports.includes('mobile'))) {

--- a/e2e/tests/pilot/matrix/pilot-matrix-public-package.spec.ts
+++ b/e2e/tests/pilot/matrix/pilot-matrix-public-package.spec.ts
@@ -4,6 +4,7 @@ import {
   assertMatrixRow,
   assertVisualSnapshot,
   freezeAnimations,
+  waitForDetailReady,
   type MatrixRowOutcome,
 } from '../../../setup/matrix-helpers';
 import { getPilotSeed, pilotSubdomain } from '../helpers';
@@ -36,12 +37,13 @@ test.describe('@pilot-w6 Pilot W6 · matrix · package', () => {
     const subdomain = pilotSubdomain();
     const route = `/site/${subdomain}/paquetes/${pkg.slug}`;
 
-    const response = await page.goto(route, { waitUntil: 'networkidle' });
+    const response = await page.goto(route, { waitUntil: 'domcontentloaded' });
     test.skip(
       !response || response.status() === 404 || response.status() >= 500,
       `Public package page unreachable (status=${response?.status() ?? 'no-response'}) — seed → RPC gap.`,
     );
 
+    await waitForDetailReady(page, 'pkg');
     await freezeAnimations(page);
 
     const outcomes: MatrixRowOutcome[] = [];
@@ -87,12 +89,13 @@ test.describe('@pilot-w6 Pilot W6 · matrix · package', () => {
     try {
       const subdomain = pilotSubdomain();
       const route = `/site/${subdomain}/paquetes/${pkg.slug}`;
-      const response = await page.goto(route, { waitUntil: 'networkidle' });
+      const response = await page.goto(route, { waitUntil: 'domcontentloaded' });
       test.skip(
         !response || response.status() === 404 || response.status() >= 500,
         `Public package page unreachable on mobile (status=${response?.status() ?? 'no-response'}).`,
       );
 
+      await waitForDetailReady(page, 'pkg');
       await freezeAnimations(page);
 
       const outcomes: MatrixRowOutcome[] = [];


### PR DESCRIPTION
## Summary

Bug 15 (Stage 6): desktop pkg matrix spec timed out at 90s on
`page.goto(route, { waitUntil: 'networkidle' })` because Turbopack dev mode
continuously emits websocket HMR pings — the network never reaches idle, so
Playwright's spec budget fires before the row walk can even start.

## Root cause

`networkidle` is a dev-only trap for Next.js 15 + Turbopack. Production (OpenNext
Worker) SSR has no long-lived websocket, so `networkidle` resolves in ~1s. Dev
mode keeps the HMR channel chatty forever → 90s timeout on every matrix spec.

The task brief identified this as **cluster C**, and recommended replacing
`networkidle` with a deterministic selector wait that matches the production
SSR hydration model (option 1).

## Fix (option 1 from task brief)

- New helper `waitForDetailReady(page, contentType)` in
  `e2e/setup/matrix-helpers.ts`:
  - Waits for `domcontentloaded`.
  - Waits for the canonical root element per content type
    (`[data-testid=\"detail-hero\"]` for pkg/act/hotel,
    `[data-testid=\"detail-blog\"]` for blog). Both are emitted on the first SSR
    HTML flush — prod-accurate, no hydration dependency.
- Replace `waitUntil: 'networkidle'` with `'domcontentloaded'` + the new helper
  in all 4 matrix specs:
  - `e2e/tests/pilot/matrix/pilot-matrix-public-package.spec.ts` (desktop + mobile)
  - `e2e/tests/pilot/matrix/pilot-matrix-public-activity.spec.ts` (desktop + mobile + editable loop)
  - `e2e/tests/pilot/matrix/pilot-matrix-public-hotel.spec.ts` (desktop + mobile)
  - `e2e/tests/pilot/matrix/pilot-matrix-public-blog.spec.ts` (es-CO + en-US)

## Before / after timings (session s1, chromium pilot project)

| Spec                                     | Before                  | After              |
| ---------------------------------------- | ----------------------- | ------------------ |
| pkg desktop (matrix walk + snapshots)    | 90s TIMEOUT             | 27.9s (no timeout) |
| pkg mobile                               | 30s TIMEOUT             | 10.8s              |
| act desktop                              | 30s TIMEOUT             | 20.3s (before cap) |
| act mobile                               | 30s TIMEOUT             | 10.1s              |
| hotel mobile                             | ok (reference)          | 9.8s–11.2s         |

The primary bug — 90s networkidle hang on pkg desktop — is fixed. Remaining
desktop spec failures (missing `<title>` / `<meta name=\"description\"` in
the pilot seed's rendered `<head>`) are **pre-existing content gaps unrelated
to cluster C**; they were previously masked by the 90s timeout and are out
of scope here.

## Non-goals / deferred

- Lighthouse specs (`e2e/tests/pilot/lighthouse/*.spec.ts`) still use
  `networkidle` for the prewarm step; that's timing-sensitive for LCP and
  tolerates a long prewarm. Explicitly out of scope (task brief: keep fix
  localized to the 4 matrix specs + helpers).
- Did not increase the global test timeout.
- Did not disable the spec.
- Did not touch W4 editor-render / W5 transcreate specs (they already use
  `domcontentloaded`).

## Test plan

- [x] `npx tsc --noEmit` passes.
- [x] `npm run session:run -- --project=pilot --grep \"@pilot-w6 Pilot W6 · matrix\" --reporter=list` no longer times out on networkidle for any of the 4 matrix specs.
- [x] pkg desktop completes in <30s (27.9s measured).
- [ ] Full pilot matrix green once pre-existing SEO content gaps are addressed (tracked separately).

Relates to #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)