### PR TITLE
fix(middleware): cluster E — /site/<sub>/<locale>/... locale header injection

### DIFF
--- a/__tests__/middleware/locale-site-route.test.ts
+++ b/__tests__/middleware/locale-site-route.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Cluster-E regression — middleware locale header injection for
+ * already-internal `/site/<sub>/<lang>/...` routes (handoff from PR #243,
+ * Stage 6 of #213).
+ *
+ * Background: `middleware.ts` short-circuits when `pathname.startsWith('/site/')`
+ * because the rewrite has already happened in the subdomain-first path. But
+ * when E2E specs (and staging smoke tests) hit the internal URL directly
+ * — `/site/colombiatours/en/paquetes/<slug>` — the pass-through skipped the
+ * `x-public-locale` header injection, so SSR generateMetadata fell back to
+ * the tenant default locale even though the URL contained `/en/`.
+ *
+ * The fix parses the locale segment from the internal pathname and applies
+ * the same `applyLocaleAwareTenantRewrite` path used by the subdomain-first
+ * flow. These tests cover the pure-function bits (`parseInternalSitePath`
+ * + `resolveLocaleFromPublicPath`) that together determine whether the
+ * middleware intervenes. The NextRequest/NextResponse wiring is exercised
+ * by the pilot W5 Playwright suite (`public-render.spec.ts` +
+ * `hreflang-canonical.spec.ts`).
+ */
+
+import { parseInternalSitePath } from '@/middleware';
+import {
+  PUBLIC_LOCALE_HEADER_NAMES,
+  extractWebsiteLocaleSettings,
+  resolveLocaleFromPublicPath,
+} from '@/lib/seo/locale-routing';
+
+describe('parseInternalSitePath', () => {
+  it('extracts subdomain + inner pathname from /site/<sub>/<lang>/<segment>/<slug>', () => {
+    const parsed = parseInternalSitePath('/site/colombiatours/en/paquetes/amazon-adventure');
+    expect(parsed).toEqual({
+      subdomain: 'colombiatours',
+      innerPathname: '/en/paquetes/amazon-adventure',
+    });
+  });
+
+  it('handles /site/<sub>/<segment>/<slug> (no locale segment)', () => {
+    const parsed = parseInternalSitePath('/site/colombiatours/paquetes/amazon-adventure');
+    expect(parsed).toEqual({
+      subdomain: 'colombiatours',
+      innerPathname: '/paquetes/amazon-adventure',
+    });
+  });
+
+  it('treats root site route as a bare subdomain request', () => {
+    const parsed = parseInternalSitePath('/site/colombiatours');
+    expect(parsed).toEqual({
+      subdomain: 'colombiatours',
+      innerPathname: '/',
+    });
+  });
+
+  it('lowercases the subdomain for DB lookup parity', () => {
+    const parsed = parseInternalSitePath('/site/ColombiaTours/en/paquetes/x');
+    expect(parsed?.subdomain).toBe('colombiatours');
+  });
+
+  it('returns null for non-/site/ paths', () => {
+    expect(parseInternalSitePath('/paquetes/x')).toBeNull();
+    expect(parseInternalSitePath('/domain/foo.com/paquetes/x')).toBeNull();
+    expect(parseInternalSitePath('/dashboard')).toBeNull();
+  });
+
+  it('returns null when /site/ has no subdomain segment', () => {
+    expect(parseInternalSitePath('/site')).toBeNull();
+    expect(parseInternalSitePath('/site/')).toBeNull();
+  });
+});
+
+/**
+ * Integration-ish contract: the three facts the middleware relies on when
+ * deciding whether to intervene on `/site/<sub>/<lang>/...`:
+ *
+ *   1. `hasLanguageSegment` is true only when first segment is a 2-letter
+ *      language that maps to a supported locale.
+ *   2. `resolvedLocale` is a real translated locale (!== defaultLocale) so
+ *      we don't redundantly emit headers for the default-locale path.
+ *   3. `canonicalPathname` strips the locale segment AND re-translates
+ *      category segments into Spanish-canonical form, which is what
+ *      `applyLocaleAwareTenantRewrite` needs for the internal rewrite.
+ */
+describe('locale resolution for /site/<sub>/<lang>/... (contract)', () => {
+  const localeSettings = extractWebsiteLocaleSettings({
+    default_locale: 'es-CO',
+    supported_locales: ['es-CO', 'en-US'],
+  });
+
+  it('injects en-US locale when inner path has /en/packages/<slug>', () => {
+    const internal = parseInternalSitePath(
+      '/site/colombiatours/en/packages/amazon-adventure',
+    );
+    expect(internal).not.toBeNull();
+
+    const resolution = resolveLocaleFromPublicPath(
+      internal!.innerPathname,
+      localeSettings,
+    );
+
+    expect(resolution.hasLanguageSegment).toBe(true);
+    expect(resolution.resolvedLocale).toBe('en-US');
+    expect(resolution.defaultLocale).toBe('es-CO');
+    expect(resolution.resolvedLocale).not.toBe(resolution.defaultLocale);
+    // Category segment translated back to Spanish-canonical for the
+    // internal rewrite target (there is no `/packages` route file).
+    expect(resolution.canonicalPathname).toBe('/paquetes/amazon-adventure');
+    expect(resolution.pathnameWithoutLang).toBe('/packages/amazon-adventure');
+  });
+
+  it('injects en-US locale when inner path has /en/paquetes/<slug>', () => {
+    // URL in pilot spec shape: `/site/<sub>/en/paquetes/<slug>` (Spanish
+    // category segment after the locale prefix is still valid under
+    // [[ADR-019]] amendment — both forms resolve to the same overlay).
+    const internal = parseInternalSitePath(
+      '/site/colombiatours/en/paquetes/amazon-adventure',
+    );
+    expect(internal).not.toBeNull();
+
+    const resolution = resolveLocaleFromPublicPath(
+      internal!.innerPathname,
+      localeSettings,
+    );
+
+    expect(resolution.hasLanguageSegment).toBe(true);
+    expect(resolution.resolvedLocale).toBe('en-US');
+    expect(resolution.resolvedLanguage).toBe('en');
+    expect(resolution.canonicalPathname).toBe('/paquetes/amazon-adventure');
+  });
+
+  it('does NOT intervene when inner path is default-locale (no /<lang>/ segment)', () => {
+    const internal = parseInternalSitePath(
+      '/site/colombiatours/paquetes/amazon-adventure',
+    );
+    const resolution = resolveLocaleFromPublicPath(
+      internal!.innerPathname,
+      localeSettings,
+    );
+
+    expect(resolution.hasLanguageSegment).toBe(false);
+    // Middleware guard: only intervene when resolvedLocale !== defaultLocale.
+    expect(resolution.resolvedLocale).toBe(resolution.defaultLocale);
+    expect(resolution.resolvedLocale).toBe('es-CO');
+  });
+
+  it('does NOT intervene when leading segment is 2 letters but unsupported locale', () => {
+    // Tenant only supports es-CO + en-US. A `/pt/` prefix must NOT be
+    // interpreted as Portuguese — leave pass-through semantics intact.
+    const internal = parseInternalSitePath(
+      '/site/colombiatours/pt/paquetes/amazon-adventure',
+    );
+    const resolution = resolveLocaleFromPublicPath(
+      internal!.innerPathname,
+      localeSettings,
+    );
+
+    expect(resolution.hasLanguageSegment).toBe(false);
+    expect(resolution.resolvedLocale).toBe(resolution.defaultLocale);
+  });
+
+  it('header names exported by locale-routing match what the SSR page reads', () => {
+    // Sanity-check: the middleware writes the canonical keys and the SSR
+    // helper `resolvePublicMetadataLocale` reads the same canonical keys.
+    expect(PUBLIC_LOCALE_HEADER_NAMES.resolvedLocale).toBe('x-public-locale');
+    expect(PUBLIC_LOCALE_HEADER_NAMES.defaultLocale).toBe('x-public-default-locale');
+    expect(PUBLIC_LOCALE_HEADER_NAMES.lang).toBe('x-public-lang');
+    expect(PUBLIC_LOCALE_HEADER_NAMES.localeSegment).toBe('x-public-locale-segment');
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -62,6 +62,32 @@ function getRequestHost(request: NextRequest): string {
   return hostHeader.split(':')[0].toLowerCase().replace(/\.$/, '');
 }
 
+/**
+ * Parse an already-internal `/site/<subdomain>/<rest>` pathname into its
+ * component parts. Returns null if the pathname is not in the expected
+ * shape (e.g. `/site/` alone, `/site/<sub>` with no trailing path).
+ *
+ * Used by the `/site/` branch of the middleware to detect translated-locale
+ * segments such as `/site/colombiatours/en/paquetes/<slug>` so the locale
+ * headers + canonical rewrite get applied even when the browser hit the
+ * internal route directly (E2E fixtures, staging smoke tests, etc).
+ */
+export function parseInternalSitePath(pathname: string): {
+  subdomain: string;
+  innerPathname: string;
+} | null {
+  if (!pathname.startsWith('/site/')) return null;
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments.length < 2) return null;
+  const [marker, subdomainRaw, ...rest] = segments;
+  if (marker !== 'site' || !subdomainRaw) return null;
+  const innerPathname = rest.length > 0 ? `/${rest.join('/')}` : '/';
+  return {
+    subdomain: subdomainRaw.toLowerCase(),
+    innerPathname,
+  };
+}
+
 function getPotentialProductRoute(pathname: string): {
   categorySlug: string;
   productType: string;
@@ -471,8 +497,54 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Already-internal tenant routes should pass through untouched.
-  if (pathname.startsWith('/site/') || pathname.startsWith('/domain/')) {
+  // Already-internal tenant routes normally pass through untouched. One
+  // exception: direct requests to `/site/<subdomain>/<lang>/...` (used by
+  // E2E specs and internal tooling) must still receive the locale headers
+  // + canonical rewrite that the subdomain-first flow applies. Without
+  // this, SSR falls back to the tenant default locale even though the URL
+  // contains a translated-locale segment. See [[ADR-019]] + Cluster-E of
+  // Stage 6 (#213) for the handoff from PR #243.
+  if (pathname.startsWith('/site/')) {
+    const internalMatch = parseInternalSitePath(pathname);
+    if (
+      internalMatch &&
+      internalMatch.innerPathname !== '/' &&
+      /^[a-z]{2}$/.test(internalMatch.innerPathname.split('/').filter(Boolean)[0] || '')
+    ) {
+      const website = await getWebsiteBySubdomain(internalMatch.subdomain);
+      const localeSettings = extractWebsiteLocaleSettings(website);
+      const localeResolution = resolveLocaleFromPublicPath(
+        internalMatch.innerPathname,
+        localeSettings,
+      );
+
+      // Only intervene when the leading segment resolved to an actual
+      // supported non-default locale. If the leading two-letter segment
+      // did not map to a locale, fall back to pass-through so we don't
+      // accidentally break unrelated routes.
+      if (
+        localeResolution.hasLanguageSegment &&
+        localeResolution.resolvedLocale !== localeResolution.defaultLocale
+      ) {
+        return applyLocaleAwareTenantRewrite({
+          request,
+          sourceUrl: url,
+          pathnameWithoutLang: localeResolution.pathnameWithoutLang,
+          canonicalPathname: localeResolution.canonicalPathname,
+          originalPathname: localeResolution.originalPathname,
+          subdomain: internalMatch.subdomain,
+          resolvedLocale: localeResolution.resolvedLocale,
+          defaultLocale: localeResolution.defaultLocale,
+          resolvedLanguage: localeResolution.resolvedLanguage,
+          hasLanguageSegment: localeResolution.hasLanguageSegment,
+        });
+      }
+    }
+
+    return NextResponse.next();
+  }
+
+  if (pathname.startsWith('/domain/')) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Summary

Closes Stage 6 Cluster-E handoff from PR #243 (A transcreate).

### Problem

`middleware.ts` short-circuited on `pathname.startsWith('/site/')`, skipping `x-public-locale` header injection. E2E specs navigating directly to `/site/colombiatours/en/paquetes/<slug>` got pass-through → SSR `generateMetadata` fell back to tenant default locale (`es-CO`) even though URL contained `/en/` segment.

### Fix

- New `parseInternalSitePath()` helper splits `/site/<sub>/<rest>`.
- `/site/` branch detects 2-letter locale segment prefix and runs `resolveLocaleFromPublicPath` + `applyLocaleAwareTenantRewrite` (same path as subdomain-first flow).
- Falls back to `NextResponse.next()` when segment is default-locale or unsupported — preserves pass-through for unrelated routes.

### Tests

- 11 unit tests in `__tests__/middleware/locale-site-route.test.ts` — `parseInternalSitePath` + locale-resolution contract + header names parity. **All 11 pass locally.**
- Unblocks 2 remaining pkg E2E failures flagged by Cluster A (`public-render.spec.ts::Package EN` + `hreflang-canonical.spec.ts::Package`).

## Test plan

- [x] `npx jest __tests__/middleware/locale-site-route.test.ts` → 11/11 pass
- [x] `npx tsc --noEmit` → 0 errors
- [ ] Pilot W5 chromium re-run post-merge (Cluster E followup — Stage 6 final revalidation)

Relates to #213 · Closes Cluster-E from #243 handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)