### PR TITLE
fix(pilot): cluster F — residuales pkg-meta-title + hotel SEO + desktop timeout + firefox mobile

### DIFF
--- a/e2e/tests/pilot/matrix/pilot-matrix-public-activity.spec.ts
+++ b/e2e/tests/pilot/matrix/pilot-matrix-public-activity.spec.ts
@@ -78,10 +78,14 @@ test.describe('@pilot-w6 Pilot W6 · matrix · activity', () => {
     const act = seed.activities[0];
     test.skip(!act, 'Pilot baseline missing activity');
 
+    // Firefox throws `options.isMobile is not supported in Firefox`
+    // (ffBrowser.js). Omit the chromium-only `isMobile`/`hasTouch` flags for
+    // firefox so the mobile viewport walk still exercises narrow layout
+    // assertions. See Stage 6 Cluster F — Bug F4.
+    const isFirefox = browser.browserType().name() === 'firefox';
     const context = await browser.newContext({
       viewport: { width: 390, height: 844 },
-      isMobile: true,
-      hasTouch: true,
+      ...(isFirefox ? {} : { isMobile: true, hasTouch: true }),
       reducedMotion: 'reduce',
     });
     const page = await context.newPage();

--- a/e2e/tests/pilot/matrix/pilot-matrix-public-hotel.spec.ts
+++ b/e2e/tests/pilot/matrix/pilot-matrix-public-hotel.spec.ts
@@ -70,10 +70,14 @@ test.describe('@pilot-w6 Pilot W6 · matrix · hotel (read-only)', () => {
     const subdomain = pilotSubdomain();
     const route = `/site/${subdomain}/hoteles/${HOTEL_SLUG}`;
 
+    // Firefox throws `options.isMobile is not supported in Firefox`
+    // (ffBrowser.js). Omit the chromium-only `isMobile`/`hasTouch` flags for
+    // firefox so the mobile viewport walk still exercises narrow layout
+    // assertions. See Stage 6 Cluster F — Bug F4.
+    const isFirefox = browser.browserType().name() === 'firefox';
     const context = await browser.newContext({
       viewport: { width: 390, height: 844 },
-      isMobile: true,
-      hasTouch: true,
+      ...(isFirefox ? {} : { isMobile: true, hasTouch: true }),
       reducedMotion: 'reduce',
     });
     const page = await context.newPage();

--- a/e2e/tests/pilot/matrix/pilot-matrix-public-package.spec.ts
+++ b/e2e/tests/pilot/matrix/pilot-matrix-public-package.spec.ts
@@ -79,10 +79,15 @@ test.describe('@pilot-w6 Pilot W6 · matrix · package', () => {
     const pkg = seed.packages[0];
     test.skip(!pkg, 'Pilot baseline missing package');
 
+    // Firefox throws `options.isMobile is not supported in Firefox`
+    // (ffBrowser.js). Omit the chromium-only `isMobile`/`hasTouch` flags for
+    // firefox so the mobile viewport walk still exercises narrow layout
+    // assertions (mobile-chrome + chromium projects cover the full
+    // mobile-emulation matrix). See Stage 6 Cluster F — Bug F4.
+    const isFirefox = browser.browserType().name() === 'firefox';
     const context = await browser.newContext({
       viewport: { width: 390, height: 844 },
-      isMobile: true,
-      hasTouch: true,
+      ...(isFirefox ? {} : { isMobile: true, hasTouch: true }),
       reducedMotion: 'reduce',
     });
     const page = await context.newPage();


### PR DESCRIPTION
## Summary

Closes 4 residual autonomous bugs surfaced by Stage 6 final re-validation (PR #248, commit `ec381ae`). All clusters A–E shipping; this PR addresses the remaining post-fix issues.

### Bug F1 — Pkg EN render `meta_title` still FAIL (all browsers) — FIXED
- **Root cause**: ID mismatch between `get_website_product_page` RPC (returns `itineraries.id` as `product.id` for packages) and `applyTranscreateJob` (writes overlay row with `product_id = job.page_id` = `package_kits.id`). `getLocalizedProductOverlay` used only the itinerary id → miss → fallback to default-locale overlay → ES title rendered on EN URL.
- **Fix**: mirror the RPC's dual-id lookup at the reader. If the `(product_id=itinerary_id, locale)` primary misses, reverse-resolve kit id via `itineraries.source_package_id` (anon-readable; `package_kits` is not) and retry. Non-package types unchanged.
- **Delta**: EN URL now renders applied overlay `custom_seo_title` + `custom_seo_description`. ES URL still renders es-CO overlay (primary hits). Verified locally on the pilot translation-ready package.

### Bug F2 — Hotel SEO Lighthouse 1.00 → 0.92 — FLAKE (not a code regression)
- **Investigation**: re-ran Lighthouse on `/site/colombiatours/hoteles/aloft-bogota-airport` twice → SEO = 1.00 each time. SSR emits `<meta name="description">`. The Cluster B `data-testid` change affected only the breadcrumb wrapper (body content), never head meta. The 0.92 in final-revalidation came from dev-mode hydration timing where Lighthouse sampled DOM before React inserted the description meta tag.
- **No code fix**; `scripts/lighthouse-pilot.sh` already defaults to prod mode — the final-revalidation run used `next dev --turbo` which is known to produce Lighthouse flakes. Flagged in follow-up to ensure pilot Lighthouse runs honor the default prod mode.

### Bug F3 — Pkg desktop timeout occasional — ALREADY FIXED
- Landed upstream in commit `13677fb` (add `waitForDetailReady` + `domcontentloaded` to pilot lighthouse tests). Scope closed — no further action needed in this PR.

### Bug F4 — Firefox `isMobile` edge case — FIXED
- **Root cause**: pilot matrix mobile-viewport specs pass `isMobile: true, hasTouch: true` to `browser.newContext()`. Playwright throws `options.isMobile is not supported in Firefox` (`ffBrowser.js:93`) → firefox project errored on every pkg/act/hotel mobile walk.
- **Fix**: conditionally spread `isMobile`/`hasTouch` only when browser is not firefox. Mobile viewport 390x844 still exercises narrow layout assertions under firefox; chromium + mobile-chrome projects still run the full mobile-emulation matrix.

## Test plan

- [x] `npx tsc --noEmit` ✓
- [x] Manual SSR verification for F1:
  - `GET /site/colombiatours/en/paquetes/pilot-colombiatours-pkg-translation-ready` → `<title>` uses applied en-US overlay title, `<meta name="description">` uses applied en-US overlay description (with seeded verification row).
  - `GET /site/colombiatours/paquetes/pilot-colombiatours-pkg-translation-ready` → still renders es-CO overlay (primary lookup).
- [x] Lighthouse reproduction (hotel) → SEO = 1.00 in two consecutive runs → F2 confirmed flake.
- [ ] Pilot W5/W6 re-run on chromium + firefox + mobile-chrome post-merge (session pool).

Relates to #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)