### PR TITLE
fix(seo): #263 blog locale normalize + pilot data cleanup

### DIFF
--- a/__tests__/lib/seo/locale-routing.test.ts
+++ b/__tests__/lib/seo/locale-routing.test.ts
@@ -1,5 +1,6 @@
 import {
   CATEGORY_CANONICAL_SEGMENT,
+  normalizeBlogLocale,
   resolveCategorySegment,
   resolveLocaleFromPublicPath,
   translateCategoryPathname,
@@ -191,5 +192,42 @@ describe('generateHreflangLinksForLocales — segment localization', () => {
       expect(map['es-CO']).toBe(`${baseUrl}${expectedEs}`);
       expect(map['en-US']).toBe(`${baseUrl}${expectedEn}`);
     }
+  });
+});
+
+describe('normalizeBlogLocale', () => {
+  it('maps legacy ISO-639 es to canonical es-CO', () => {
+    expect(normalizeBlogLocale('es')).toBe('es-CO');
+  });
+
+  it('maps legacy ISO-639 en to canonical en-US', () => {
+    expect(normalizeBlogLocale('en')).toBe('en-US');
+  });
+
+  it('returns null for null/undefined input', () => {
+    expect(normalizeBlogLocale(null)).toBeNull();
+    expect(normalizeBlogLocale(undefined)).toBeNull();
+  });
+
+  it('returns null for empty or whitespace-only input', () => {
+    expect(normalizeBlogLocale('')).toBeNull();
+    expect(normalizeBlogLocale('   ')).toBeNull();
+    expect(normalizeBlogLocale('\t\n')).toBeNull();
+  });
+
+  it('passes canonical BCP-47 through unchanged', () => {
+    expect(normalizeBlogLocale('es-CO')).toBe('es-CO');
+    expect(normalizeBlogLocale('en-US')).toBe('en-US');
+    expect(normalizeBlogLocale('pt-BR')).toBe('pt-BR');
+  });
+
+  it('passes unknown codes through unchanged (no silent mutation)', () => {
+    expect(normalizeBlogLocale('fr')).toBe('fr');
+    expect(normalizeBlogLocale('ZZ-XX')).toBe('ZZ-XX');
+  });
+
+  it('trims surrounding whitespace before lookup', () => {
+    expect(normalizeBlogLocale(' es ')).toBe('es-CO');
+    expect(normalizeBlogLocale('\ten\n')).toBe('en-US');
   });
 });

--- a/lib/schema/generators.ts
+++ b/lib/schema/generators.ts
@@ -18,7 +18,7 @@ import type {
   ImageObject,
 } from './types';
 import type { WebsiteData, BlogPost, WebsiteSection } from '../supabase/get-website';
-import { localeToLanguage, normalizeLocale } from '@/lib/seo/locale-routing';
+import { localeToLanguage, normalizeBlogLocale, normalizeLocale } from '@/lib/seo/locale-routing';
 
 const VALID_LOCALE_PATTERN = /^[a-z]{2}(-[A-Z]{2})?$/;
 
@@ -39,7 +39,12 @@ function resolveSchemaLanguage(
     return normalizeLocale(requestLocale);
   }
 
-  if (post.locale) return normalizeLocale(post.locale);
+  // Wrap stored locale in legacy-code normalizer so rows with
+  // `locale='es'`/`'en'` (WordPress migration) emit canonical BCP-47.
+  if (post.locale) {
+    const canonical = normalizeBlogLocale(post.locale);
+    if (canonical) return normalizeLocale(canonical);
+  }
 
   const websiteWithLocale = website as unknown as Record<string, unknown>;
   const language = websiteWithLocale.language;

--- a/lib/seo/locale-routing.ts
+++ b/lib/seo/locale-routing.ts
@@ -1,5 +1,36 @@
 export const DEFAULT_PUBLIC_LOCALE = 'es-CO';
 
+/**
+ * Legacy ISO-639 → canonical BCP-47 locale normalization.
+ *
+ * Production has 500+ `website_blog_posts` rows stored with legacy `es`/`en`
+ * (ISO-639 short codes) from the WordPress migration. Stage 6 middleware +
+ * hreflang emission assume canonical `es-CO`/`en-US`. Read-time normalize so
+ * legacy rows resolve cleanly without DB writes. NEVER update
+ * `website_blog_posts.locale` directly — middleware-layer only.
+ */
+const LEGACY_BLOG_LOCALE_MAP: Record<string, string> = {
+  es: 'es-CO',
+  en: 'en-US',
+};
+
+/**
+ * Normalize a stored locale value, mapping legacy ISO-639 short codes to
+ * canonical BCP-47. Passes through canonical codes (`es-CO`, `en-US`,
+ * `pt-BR`, etc.) unchanged. Returns `null` for empty/whitespace input.
+ *
+ * Use this at the data-access boundary for any resource whose `locale`
+ * column may still contain legacy values (blog posts being the main case).
+ */
+export function normalizeBlogLocale(
+  stored: string | null | undefined,
+): string | null {
+  if (!stored) return null;
+  const trimmed = stored.trim();
+  if (!trimmed) return null;
+  return LEGACY_BLOG_LOCALE_MAP[trimmed] ?? trimmed;
+}
+
 export const PUBLIC_LOCALE_HEADER_NAMES = {
   resolvedLocale: 'x-public-locale',
   defaultLocale: 'x-public-default-locale',

--- a/supabase/migrations/20260504000000_pilot_data_cleanup_orphan_rare_locale.sql
+++ b/supabase/migrations/20260504000000_pilot_data_cleanup_orphan_rare_locale.sql
@@ -1,0 +1,93 @@
+-- Pilot data cleanup: orphan pkg overlays + rare locale rows.
+--
+-- Context: audit 2026-04-20 on pilot website `894545b7-…` revealed:
+--  - 14 orphan `website_product_pages` rows with `product_type='package'`
+--    pointing to `product_id` values not in `package_kits` (deleted kits).
+--  - 1 `website_product_pages` row with rare locale matching `^en-v\d`
+--    (test artifact `en-v21-7569`).
+--  - 4 `seo_transcreation_jobs` rows with target_locale matching `^en-v\d`.
+--
+-- These pollute downstream rendering + transcreate pipelines. Cleanup is:
+--  - Idempotent (safe to rerun; snapshot rows guarded by NOT EXISTS).
+--  - Reversible via `pilot_data_cleanup_snapshots.snapshot` JSONB
+--    (JSONB per-operation; restore with INSERT from jsonb_to_recordset).
+--  - Scoped strictly to pilot website_id + account_id.
+--
+-- Related: EPIC #262 child-1 (#263). Parent docs:
+-- `docs/ops/pilot-runbook-colombiatours.md`.
+
+create table if not exists pilot_data_cleanup_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  table_name text not null,
+  operation text not null,
+  snapshot jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+-- Snapshot + delete orphan package overlays
+with orphans as (
+  select p.*
+  from website_product_pages p
+  where p.website_id = '894545b7-73ca-4dae-b76a-da5b6a3f8441'
+    and p.product_type = 'package'
+    and p.product_id not in (
+      select id from package_kits
+      where account_id = '9fc24733-b127-4184-aa22-12f03b98927a'
+    )
+)
+insert into pilot_data_cleanup_snapshots (table_name, operation, snapshot)
+select 'website_product_pages', 'orphan_delete', jsonb_agg(row_to_json(orphans.*))
+from orphans
+having count(*) > 0
+  and not exists (
+    select 1 from pilot_data_cleanup_snapshots s
+    where s.table_name = 'website_product_pages' and s.operation = 'orphan_delete'
+  );
+
+delete from website_product_pages
+where website_id = '894545b7-73ca-4dae-b76a-da5b6a3f8441'
+  and product_type = 'package'
+  and product_id not in (
+    select id from package_kits
+    where account_id = '9fc24733-b127-4184-aa22-12f03b98927a'
+  );
+
+-- Snapshot + delete rare locale rows in website_product_pages
+with rare_pages as (
+  select p.*
+  from website_product_pages p
+  where p.website_id = '894545b7-73ca-4dae-b76a-da5b6a3f8441'
+    and p.locale ~ '^en-v\d'
+)
+insert into pilot_data_cleanup_snapshots (table_name, operation, snapshot)
+select 'website_product_pages', 'rare_locale_prune', jsonb_agg(row_to_json(rare_pages.*))
+from rare_pages
+having count(*) > 0
+  and not exists (
+    select 1 from pilot_data_cleanup_snapshots s
+    where s.table_name = 'website_product_pages' and s.operation = 'rare_locale_prune'
+  );
+
+delete from website_product_pages
+where website_id = '894545b7-73ca-4dae-b76a-da5b6a3f8441'
+  and locale ~ '^en-v\d';
+
+-- Snapshot + delete rare locale rows in seo_transcreation_jobs
+with rare_jobs as (
+  select j.*
+  from seo_transcreation_jobs j
+  where j.website_id = '894545b7-73ca-4dae-b76a-da5b6a3f8441'
+    and j.target_locale ~ '^en-v\d'
+)
+insert into pilot_data_cleanup_snapshots (table_name, operation, snapshot)
+select 'seo_transcreation_jobs', 'rare_locale_prune', jsonb_agg(row_to_json(rare_jobs.*))
+from rare_jobs
+having count(*) > 0
+  and not exists (
+    select 1 from pilot_data_cleanup_snapshots s
+    where s.table_name = 'seo_transcreation_jobs' and s.operation = 'rare_locale_prune'
+  );
+
+delete from seo_transcreation_jobs
+where website_id = '894545b7-73ca-4dae-b76a-da5b6a3f8441'
+  and target_locale ~ '^en-v\d';


### PR DESCRIPTION
## Summary

Add read-time legacy-locale normalizer for blog posts migrated from WordPress. Production `website_blog_posts` has 520+ rows with legacy ISO-639 `es`/`en` from the WP migration — Stage 6 middleware + hreflang emission assume canonical BCP-47 (`es-CO`/`en-US`). Without normalization these rows emit wrong `inLanguage` in JSON-LD + break hreflang pairs.

Zero DB writes to `website_blog_posts.locale` — middleware-layer only, reversible via git revert.

## Changes

### Code

| File | Change |
|---|---|
| `lib/seo/locale-routing.ts` | Export `normalizeBlogLocale()` + `LEGACY_BLOG_LOCALE_MAP` (`es→es-CO`, `en→en-US`) |
| `lib/schema/generators.ts:42` | `resolveSchemaLanguage` wraps `post.locale` in `normalizeBlogLocale` before `normalizeLocale` |

### Tests

7 unit tests in `__tests__/lib/seo/locale-routing.test.ts`:
- Legacy `es→es-CO`, `en→en-US`
- `null`/`undefined` → `null`
- Empty/whitespace → `null`
- Canonical BCP-47 passthrough (`es-CO`, `en-US`, `pt-BR`)
- Unknown code passthrough (`fr`, `ZZ-XX`)
- Whitespace trimming

`npx jest --testPathPattern locale-routing` → **24/24 green**.

### Migration `20260504000000_pilot_data_cleanup_orphan_rare_locale.sql`

- Creates `pilot_data_cleanup_snapshots` table (JSONB, reversible).
- Deletes 14 orphan `website_product_pages` rows (package overlays pointing to deleted `package_kits`) for website `894545b7-73ca-4dae-b76a-da5b6a3f8441`.
- Deletes 1 rare-locale row (`locale ~ '^en-v\d'`) from `website_product_pages`.
- Deletes 4 rare-locale rows (`target_locale ~ '^en-v\d'`) from `seo_transcreation_jobs`.
- Idempotent (snapshot rows guarded by NOT EXISTS). Reversible via snapshot JSONB.

**Applied to prod 2026-04-20** via Supabase MCP. Post-apply verify:

| Metric | Before | After |
|---|---|---|
| Orphan package overlays | 14 | **0** |
| Rare-locale pages | 1 | **0** |
| Rare-locale jobs | 4 | **0** |
| Snapshots captured | 0 | **3** |

## E2E assertion

Existing `e2e/tests/pilot/transcreate/public-render.spec.ts` asserts metadata via poll-based pattern (refactored in `a8ad07a`). Adding a dedicated legacy-locale blog row assertion requires seeding a legacy-locale blog via `matrix-helpers.ts` — deferred to follow-up (EPIC #262 integration pass).

## Verification

- `npx tsc --noEmit` → zero errors
- `npx jest --testPathPattern locale-routing` → 24/24 green
- Supabase MCP post-apply counts → all cleanup targets = 0

## Rollback

- Middleware: `git revert f4b56ea`
- DB: restore from `pilot_data_cleanup_snapshots` JSONB (3 snapshots captured pre-delete)

## Closes

Closes #263

Relates to EPIC #262, #208, #213 Flow 3 translation smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)