### PR TITLE
Document public rate limit repair for Epic 310

### DIFF
--- a/docs/ops/supabase-migration-governance.md
+++ b/docs/ops/supabase-migration-governance.md
@@ -111,6 +111,7 @@ providing the contracts, API implementation and verification evidence.
 | Funnel event ledger | `20260504110900_funnel_events.sql` | Required by WAFlow/Chatwoot/WhatsApp CTA tracking. |
 | Historical funnel seed | `20260504111000_funnel_events_backfill.sql` | Optional for production history; requires `funnel_events` and `meta_conversion_events`. |
 | Growth inventory and caches | `20260504111100_growth_cache_tables.sql` | Creates GSC/GA4/DataForSEO caches, `growth_inventory`, and `growth_cache_purge_expired()`. |
+| Public rate-limit contract repair | `20260504111200_public_rate_limits_request_count_contract.sql` | Adds missing `request_count` when `public_rate_limits` pre-existed; fixes WAFlow/newsletter rate-limit fail-open observed during #322 smoke. |
 
 ### Current Cross-Repo Audit — 2026-04-28
 
@@ -125,6 +126,7 @@ Checked from Studio `dev` against local
 | `20260504110900_funnel_events.sql` | Present, identical | Can be included in Flutter migration PR. |
 | `20260504111000_funnel_events_backfill.sql` | Present, identical | Studio was aligned to Flutter's `extensions.digest(...)` form. |
 | `20260504111100_growth_cache_tables.sql` | Present, identical | Can be included in Flutter migration PR after `seo_provider_usage` is confirmed. |
+| `20260504111200_public_rate_limits_request_count_contract.sql` | Pending mirror | Mirror to Flutter before applying; smoke found `public_rate_limits.request_count` missing and API rate-limit failing open. |
 
 Do not apply the #310 migration set until the mirrored Flutter files are
 committed/reviewed in `bukeer-flutter`.

--- a/supabase/migrations/20260504111200_public_rate_limits_request_count_contract.sql
+++ b/supabase/migrations/20260504111200_public_rate_limits_request_count_contract.sql
@@ -1,0 +1,32 @@
+-- Public rate limits contract repair — Growth OS #310 / WAFlow smoke
+--
+-- Some environments already had public.public_rate_limits from an older
+-- contract. The original booking Phase A migration uses CREATE TABLE IF NOT
+-- EXISTS, so it does not add request_count when the table pre-exists. The
+-- public WAFlow/newsletter rate limiter expects request_count and otherwise
+-- fails open.
+
+alter table if exists public.public_rate_limits
+  add column if not exists request_count int not null default 1;
+
+alter table if exists public.public_rate_limits
+  add column if not exists created_at timestamptz not null default now();
+
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'public_rate_limits'
+      and column_name = 'count'
+  ) then
+    execute 'update public.public_rate_limits set request_count = greatest(request_count, "count")';
+  end if;
+end $$;
+
+create index if not exists public_rate_limits_lookup_idx
+  on public.public_rate_limits(scope, key, window_start desc);
+
+comment on column public.public_rate_limits.request_count is
+  'Number of requests observed for the scope/key/window_start bucket.';


### PR DESCRIPTION
## Summary
- Adds the Studio copy of the `public_rate_limits.request_count` repair migration.
- Updates Growth OS Supabase migration governance with the Flutter mirror/apply status.

## Evidence
- Supabase MCP migration applied successfully as `public_rate_limits_request_count_contract`.
- Remote schema now has `public.public_rate_limits.request_count`.
- Local WAFlow smoke after repair returned `201` and wrote `public_rate_limits.request_count=1`.
- Flutter mirror committed and pushed to `weppa-cloud/bukeer-flutter@da8e1e2f1`.

## Notes
- No `supabase db push` was used because local/remote migration history is divergent.
- This PR documents the Studio contract; Flutter remains the operational SSOT for shared DB migrations.