### PR TITLE
Fix staging Worker deploy for growth smoke

### DIFF
--- a/app/api/growth/events/whatsapp-cta/route.ts
+++ b/app/api/growth/events/whatsapp-cta/route.ts
@@ -32,7 +32,8 @@
  *     500 { success: false, error: { code: 'INTERNAL_ERROR', ... } }
  *
  * Guarantees:
- *   - Edge-compatible (ADR-007): Web Crypto only, no Node APIs.
+ *   - OpenNext-compatible: this endpoint runs in the default Worker function
+ *     because OpenNext cannot bundle this API route as an Edge runtime route.
  *   - Idempotent (ADR-018): event_id is sha256(reference_code:event_name:occurred_at_s);
  *     duplicate POSTs (e.g. Beacon + onClick double-fire) dedupe at the DB layer
  *     via funnel_events.event_id PK + ON CONFLICT DO NOTHING.
@@ -69,8 +70,6 @@ import {
   type GrowthAttribution,
   type GrowthMarket,
 } from '@bukeer/website-contract';
-
-export const runtime = 'edge';
 
 const log = createLogger('api.growth.events.whatsapp-cta');
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -59,6 +59,9 @@ zone_name = "colombiatours.travel"
 
 [env.staging]
 name = "bukeer-web-public-staging"
+workers_dev = true
+preview_urls = true
+routes = []
 
 [[env.staging.services]]
 binding = "WORKER_SELF_REFERENCE"


### PR DESCRIPTION
## Summary
- Removes Edge runtime from the WhatsApp CTA growth event route so OpenNext can bundle it in the default Worker function.
- Explicitly isolates `env.staging` from production routes and enables workers.dev/preview URL for smoke validation.

## Verification
- `npm run build:worker` PASS.
- `npx wrangler deploy .open-next/worker.js --env staging --keep-vars` PASS.
- Staging URL: `https://bukeer-web-public-staging.yeison-gomez-me.workers.dev`
- WAFlow staging smoke PASS: `POST /api/waflow/lead` -> `201`.
- Supabase evidence: `meta_conversion_events.status=sent`, `funnel_events=waflow_submit`, `public_rate_limits.request_count=1`.

## Notes
- Production routes were not touched.
- This unblocks #310/#322/#330 staging certification evidence.