### PR TITLE
Fix legal page canonicals for SEO gate

### DIFF
--- a/app/site/[subdomain]/cancellation/page.tsx
+++ b/app/site/[subdomain]/cancellation/page.tsx
@@ -23,10 +23,15 @@ export async function generateMetadata({ params }: CancellationPageProps): Promi
   const siteName = website.content.account?.name || website.content.siteName;
   const localeContext = await resolvePublicMetadataLocale(website, '/cancellation');
   const messages = getPublicUiMessages(localeContext.resolvedLocale);
+  const baseUrl = website.custom_domain
+    ? `https://${website.custom_domain}`
+    : `https://${subdomain}.bukeer.com`;
+  const canonical = `${baseUrl}${localeContext.localizedPathname}`;
 
   return {
     title: messages.legalPages.cancellationTitle,
     description: `${messages.legalPages.cancellationDescriptionPrefix} ${siteName}`,
+    alternates: { canonical },
     robots: { index: false, follow: false },
   };
 }

--- a/app/site/[subdomain]/privacy/page.tsx
+++ b/app/site/[subdomain]/privacy/page.tsx
@@ -23,10 +23,15 @@ export async function generateMetadata({ params }: PrivacyPageProps): Promise<Me
   const siteName = website.content.account?.name || website.content.siteName;
   const localeContext = await resolvePublicMetadataLocale(website, '/privacy');
   const messages = getPublicUiMessages(localeContext.resolvedLocale);
+  const baseUrl = website.custom_domain
+    ? `https://${website.custom_domain}`
+    : `https://${subdomain}.bukeer.com`;
+  const canonical = `${baseUrl}${localeContext.localizedPathname}`;
 
   return {
     title: messages.legalPages.privacyTitle,
     description: `${messages.legalPages.privacyDescriptionPrefix} ${siteName}`,
+    alternates: { canonical },
     robots: { index: false, follow: false },
   };
 }

--- a/app/site/[subdomain]/terms/page.tsx
+++ b/app/site/[subdomain]/terms/page.tsx
@@ -23,10 +23,15 @@ export async function generateMetadata({ params }: TermsPageProps): Promise<Meta
   const siteName = website.content.account?.name || website.content.siteName;
   const localeContext = await resolvePublicMetadataLocale(website, '/terms');
   const messages = getPublicUiMessages(localeContext.resolvedLocale);
+  const baseUrl = website.custom_domain
+    ? `https://${website.custom_domain}`
+    : `https://${subdomain}.bukeer.com`;
+  const canonical = `${baseUrl}${localeContext.localizedPathname}`;
 
   return {
     title: messages.legalPages.termsTitle,
     description: `${messages.legalPages.termsDescriptionPrefix} ${siteName}`,
+    alternates: { canonical },
     robots: { index: false, follow: false },
   };
 }


### PR DESCRIPTION
## Summary

- Adds canonical metadata to tenant legal pages: `/privacy`, `/terms`, `/cancellation`.
- Uses the public custom domain when available and falls back to `{subdomain}.bukeer.com`.
- Keeps the existing `noindex,nofollow` behavior for legal pages.

## Epic / Issues

- Part of EPIC #310.
- Addresses the #313 live crawl finding: `missing_canonical` on legal pages.
- Supports #312 SEO gate remediation.

## Verification

- `npm run lint -- --file 'app/site/[subdomain]/privacy/page.tsx' --file 'app/site/[subdomain]/terms/page.tsx' --file 'app/site/[subdomain]/cancellation/page.tsx'`
  - PASS.
  - Existing warnings remain outside this change: `search-client.tsx`, `packages-listing-page.tsx`, `trust-bar-section.tsx`, `package-detail.client.tsx`.
- Production revalidation before fix: crawl of 39 URLs found 3 `missing_canonical` legal pages and 0 HTTP/fetch errors.