### PR TITLE
Normalize public SEO title length

### DIFF
--- a/app/site/[subdomain]/[...slug]/page.tsx
+++ b/app/site/[subdomain]/[...slug]/page.tsx
@@ -17,6 +17,7 @@ import { getReviewsForContext, type ReviewContext } from '@/lib/supabase/get-rev
 import { createSupabaseServiceRoleClient } from '@/lib/supabase/service-role';
 import { enrichDestinationFromSerpAPI } from '@/lib/services/serpapi-enrichment';
 import { resolveOgImage } from '@/lib/seo/og-helpers';
+import { normalizePublicMetadataTitle } from '@/lib/seo/metadata-title';
 import {
   buildLocaleAwareAlternateLanguages,
   resolvePublicMetadataLocale,
@@ -395,7 +396,10 @@ export async function generateMetadata({ params }: DynamicPageProps): Promise<Me
     if (dest) {
       const siteName = website.content?.account?.name || website.content?.siteName || subdomain;
       const override = await getDestinationSeoOverride(website.id, dest.slug);
-      const title = override?.custom_seo_title || `${dest.name} | ${siteName}`;
+      const title = normalizePublicMetadataTitle(
+        override?.custom_seo_title || dest.name,
+        siteName,
+      );
       const description = override?.custom_seo_description || `Explora ${dest.name}: ${dest.hotel_count} hoteles y ${dest.activity_count} actividades. Reserva con ${siteName}.`;
       const pathname = `/destinos/${dest.slug}`;
       const metadata: Metadata = {
@@ -465,9 +469,12 @@ export async function generateMetadata({ params }: DynamicPageProps): Promise<Me
             localizedOverlayNoindex = overlay.robots_noindex ?? null;
           }
         }
-        const title = sanitizeProductCopy(
-          localizedOverlayTitle || productPage.page?.custom_seo_title || productPage.product.name
-        ) || productPage.product.name;
+        const title = normalizePublicMetadataTitle(
+          sanitizeProductCopy(
+            localizedOverlayTitle || productPage.page?.custom_seo_title || productPage.product.name
+          ) || productPage.product.name,
+          siteName,
+        );
         const rawDescription = sanitizeProductCopy(
           localizedOverlayDescription || productPage.page?.custom_seo_description || productPage.product.description || ''
         );
@@ -560,7 +567,7 @@ export async function generateMetadata({ params }: DynamicPageProps): Promise<Me
     };
   }
 
-  const title = page.seo_title || page.title;
+  const title = normalizePublicMetadataTitle(page.seo_title || page.title, siteName);
   const description = page.seo_description || '';
   const canonicalUrl = buildCanonicalUrl(baseUrl, `/${slugPath}`, localeContext);
 

--- a/app/site/[subdomain]/actividades/[slug]/page.tsx
+++ b/app/site/[subdomain]/actividades/[slug]/page.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/lib/supabase/get-pages';
 import { getReviewsForContext, type ReviewContext } from '@/lib/supabase/get-reviews';
 import { getWebsiteBySubdomain } from '@/lib/supabase/get-website';
+import { normalizePublicMetadataTitle } from '@/lib/seo/metadata-title';
 import { buildLocaleAwareAlternateLanguages, resolvePublicMetadataLocale } from '@/lib/seo/public-metadata';
 import { buildPublicLocalizedPath, localeToOgLocale } from '@/lib/seo/locale-routing';
 import { resolveOgImage } from '@/lib/seo/og-helpers';
@@ -91,7 +92,10 @@ export async function generateMetadata({ params }: ActivityPageProps): Promise<M
     localizedOverlayTitle ||
     (isDefaultLocale ? productPage.page?.custom_seo_title : null) ||
     productPage.product.name;
-  const title = sanitizeProductCopy(rawTitle) || productPage.product.name;
+  const title = normalizePublicMetadataTitle(
+    sanitizeProductCopy(rawTitle) || productPage.product.name,
+    siteName,
+  );
   const locationHint = sanitizeProductCopy(
     productPage.product.location ||
       productPage.product.city ||

--- a/app/site/[subdomain]/blog/[slug]/page.tsx
+++ b/app/site/[subdomain]/blog/[slug]/page.tsx
@@ -17,6 +17,7 @@ import {
   resolvePublicMetadataLocale,
 } from '@/lib/seo/public-metadata';
 import { localeToOgLocale } from '@/lib/seo/locale-routing';
+import { normalizePublicMetadataTitle } from '@/lib/seo/metadata-title';
 import { getPublicUiMessages } from '@/lib/site/public-ui-messages';
 
 interface BlogPostPageProps {
@@ -51,7 +52,10 @@ export async function generateMetadata({ params }: BlogPostPageProps): Promise<M
   const canonical = `${baseUrl}${localizedBlogPath}`;
   const languages = buildLocaleAwareAlternateLanguages(baseUrl, blogPath, localizedLocaleContext);
   const siteName = website.content?.account?.name || website.content?.siteName || subdomain;
-  const title = post.seo_title || post.title || localizedMessages.blogPost.notFoundTitle;
+  const title = normalizePublicMetadataTitle(
+    post.seo_title || post.title || localizedMessages.blogPost.notFoundTitle,
+    siteName,
+  );
   const description = (
     post.seo_description ||
     post.excerpt ||

--- a/app/site/[subdomain]/paquetes/[slug]/page.tsx
+++ b/app/site/[subdomain]/paquetes/[slug]/page.tsx
@@ -16,6 +16,7 @@ import { getReviewsForContext, type ReviewContext } from '@/lib/supabase/get-rev
 import { getPlanners } from '@/lib/supabase/get-planners';
 import { getWebsiteBySubdomain } from '@/lib/supabase/get-website';
 import { resolveOgImage } from '@/lib/seo/og-helpers';
+import { normalizePublicMetadataTitle } from '@/lib/seo/metadata-title';
 import {
   buildLocaleAwareAlternateLanguages,
   resolvePublicMetadataLocale,
@@ -129,7 +130,10 @@ export async function generateMetadata({ params }: PackagePageProps): Promise<Me
     || (isDefaultLocale ? productPage.page?.custom_seo_description : null)
     || productPage.product.description
     || '';
-  const title = sanitizeProductCopy(rawTitle) || getPublicUiExtraText(localeContext.resolvedLocale, 'productPackageFallbackTitle');
+  const title = normalizePublicMetadataTitle(
+    sanitizeProductCopy(rawTitle) || getPublicUiExtraText(localeContext.resolvedLocale, 'productPackageFallbackTitle'),
+    siteName,
+  );
   const productFallbackDescription = `Descubre ${title} con itinerario detallado, experiencias locales y asistencia personalizada durante todo tu viaje en Colombia.`;
   const description = ensureSeoDescription(rawDescription, productFallbackDescription);
   const ogImage = resolveOgImage(website, productPage.product.social_image || productPage.product.image);

--- a/lib/seo/metadata-title.ts
+++ b/lib/seo/metadata-title.ts
@@ -1,0 +1,50 @@
+const DEFAULT_MAX_TITLE_LENGTH = 65;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function stripTrailingBrand(title: string, siteName: string): string {
+  const trimmedSiteName = siteName.trim();
+  if (!trimmedSiteName) return title.trim();
+
+  const brandPattern = escapeRegExp(trimmedSiteName);
+  const trailingBrand = new RegExp(`\\s*[|\\-–—:]\\s*${brandPattern}\\s*$`, 'iu');
+  let normalized = title.trim();
+
+  while (trailingBrand.test(normalized)) {
+    normalized = normalized.replace(trailingBrand, '').trim();
+  }
+
+  return normalized;
+}
+
+function trimToWordBoundary(value: string, maxLength: number): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= maxLength) return trimmed;
+
+  const slice = trimmed.slice(0, maxLength + 1);
+  const lastSpace = slice.lastIndexOf(' ');
+  const candidate = lastSpace >= Math.floor(maxLength * 0.6)
+    ? slice.slice(0, lastSpace)
+    : slice.slice(0, maxLength);
+
+  return candidate.replace(/[|,\-–—:;.\s]+$/u, '').trim();
+}
+
+export function normalizePublicMetadataTitle(
+  title: string | null | undefined,
+  siteName: string | null | undefined,
+  maxLength = DEFAULT_MAX_TITLE_LENGTH,
+): string {
+  const fallback = (siteName || '').trim();
+  const rawTitle = (title || fallback).trim();
+  if (!rawTitle) return '';
+
+  const cleanSiteName = fallback;
+  const withoutBrand = cleanSiteName ? stripTrailingBrand(rawTitle, cleanSiteName) : rawTitle;
+  const templateReserve = cleanSiteName ? ` | ${cleanSiteName}`.length : 0;
+  const available = Math.max(24, maxLength - templateReserve);
+
+  return trimToWordBoundary(withoutBrand, available);
+}


### PR DESCRIPTION
## Summary

- Adds `normalizePublicMetadataTitle` for public metadata titles.
- Strips already-appended site brand before the layout template adds it again.
- Trims child titles to fit the final `title | siteName` length budget.
- Applies normalization to dynamic pages, blog posts, package detail pages, and activity detail pages.

## Epic / Issues

- Part of EPIC #310.
- Addresses #313 `long_title` findings from the 2026-04-28 production crawl.
- Supports #312 moving from `BLOCKED` toward `PASS-WITH-WATCH`.

## Data updates applied separately in Supabase

Updated SEO overlays only, not source product/activity truth tables:

- `website_pages`:
  - `agencia-de-viajes-a-colombia-para-mexicanos` → `Viajes a Colombia para Mexicanos` final length 55.
  - `agencia-de-viajes-a-colombia-para-espanoles` → `Viajes a Colombia para Españoles` final length 55.
  - `paquetes-a-colombia-todo-incluido-en-9-dias` → `Colombia Todo Incluido 9 Días` final length 52.
  - `los-mejores-paquetes-de-viajes-a-colombia` → `Paquetes de Viajes a Colombia 2026` final length 57.
- `website_blog_posts`:
  - `guia-completa-para-viajar-a-colombia` → `Guía para Viajar a Colombia` final length 50.
  - `viajar-por-colombia-en-15-dias` → `Circuito por Colombia en 15 Días` final length 55.
- `website_product_pages`:
  - `colombia-en-familia-15-dias-aventura-y-confort` → `Vacaciones Familiares en Colombia` final length 56.
  - `city-tour-por-bogot-duraci-n-de-6-horas-grupal--c5e58907-be49-4185-9c26-fcee67322074` → `City Tour Bogotá 6 Horas` final length 47.
  - `city-tour-por-medellin-ciudad-de-la-eterna-primavera` → `City Tour Medellín Primavera` final length 51.

## Verification

- `npm run lint -- --file 'lib/seo/metadata-title.ts' --file 'app/site/[subdomain]/paquetes/[slug]/page.tsx' --file 'app/site/[subdomain]/actividades/[slug]/page.tsx' --file 'app/site/[subdomain]/blog/[slug]/page.tsx' --file 'app/site/[subdomain]/[...slug]/page.tsx'` PASS, with existing unrelated warnings.
- `npm run typecheck` PASS.
- Supabase verification query confirms all updated final title lengths are <= 57, under the 65-char crawl gate.