### PR TITLE
feat(funnel): F2 — Google Ads dispatcher (closes #421, supersedes #332)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -39,3 +39,23 @@ CHATWOOT_WEBHOOK_SECRET=
 CHATWOOT_BASE_URL=
 CHATWOOT_API_ACCESS_TOKEN=
 CRM_CONVERSION_WEBHOOK_SECRET=
+
+# Google Ads — Offline Conversion Upload (F2 / EPIC #419)
+# Server-only. In production set via `wrangler secret put GOOGLE_ADS_*`.
+# Leave GOOGLE_ADS_OFFLINE_UPLOAD_ENABLED=false until conversion actions are
+# created in the Google Ads UI (SPEC AC2.2) AND tenant_overrides are populated
+# in event_destination_mapping (see migration 20260503120100). Until then the
+# dispatcher logs status='skipped'.
+GOOGLE_ADS_OFFLINE_UPLOAD_ENABLED=false
+# Developer token (https://developers.google.com/google-ads/api/docs/get-started/dev-token)
+GOOGLE_ADS_DEVELOPER_TOKEN=
+# MCC parent account id (digits only, no hyphens). Required only for MCC setups.
+GOOGLE_ADS_LOGIN_CUSTOMER_ID=
+# Customer id of the account that owns the conversion actions (digits only).
+GOOGLE_ADS_CUSTOMER_ID=
+# Auth strategy: 'service_account' (recommended) or 'oauth2_refresh_token'.
+GOOGLE_ADS_AUTH_TYPE=service_account
+# Path to the service-account JSON key file (used when AUTH_TYPE=service_account).
+GOOGLE_ADS_CREDENTIALS_PATH=
+# API version pin (default v18). Bump when Google deprecates.
+GOOGLE_ADS_API_VERSION=v18

--- a/.env.local.example
+++ b/.env.local.example
@@ -78,3 +78,17 @@ CHATWOOT_WEBHOOK_SECRET=
 CHATWOOT_BASE_URL=
 CHATWOOT_API_ACCESS_TOKEN=
 CRM_CONVERSION_WEBHOOK_SECRET=
+
+# ─── Google Ads — Offline Conversion Upload (F2 / EPIC #419) ────────────
+# Server-only. In production set via `wrangler secret put GOOGLE_ADS_*`.
+# Leave GOOGLE_ADS_OFFLINE_UPLOAD_ENABLED=false until conversion actions are
+# created in the Google Ads UI (SPEC AC2.2) AND tenant_overrides are populated
+# in event_destination_mapping (see migration 20260503120100). Until then the
+# dispatcher logs status='skipped'.
+GOOGLE_ADS_OFFLINE_UPLOAD_ENABLED=false
+GOOGLE_ADS_DEVELOPER_TOKEN=
+GOOGLE_ADS_LOGIN_CUSTOMER_ID=
+GOOGLE_ADS_CUSTOMER_ID=
+GOOGLE_ADS_AUTH_TYPE=service_account
+GOOGLE_ADS_CREDENTIALS_PATH=
+GOOGLE_ADS_API_VERSION=v18

--- a/__tests__/lib/analytics/gclid-capture.test.ts
+++ b/__tests__/lib/analytics/gclid-capture.test.ts
@@ -1,0 +1,162 @@
+/**
+ * F2 / EPIC #419 — gclid-capture unit tests.
+ *
+ * Covers the edge-runtime surface (NextRequest/NextResponse helpers).
+ * Browser helpers (`captureClickIdsFromUrl`, `readClickIds`) are exercised
+ * via existing ColombiaTours integration tests and unchanged by F2.
+ */
+
+import {
+  captureClickIds,
+  getStoredClickIds,
+  setClickIdsCookie,
+  clickIdInternals,
+  type ClickIdSet,
+} from '@/lib/analytics/gclid-capture';
+
+// Minimal stand-in for next/server's NextRequest. Only the surfaces our
+// helpers touch (nextUrl.searchParams, cookies.get) need to be honoured.
+function makeNextRequest(input: {
+  url: string;
+  cookies?: Record<string, string>;
+}) {
+  const u = new URL(input.url);
+  return {
+    nextUrl: u,
+    cookies: {
+      get(name: string) {
+        const value = input.cookies?.[name];
+        return value === undefined ? undefined : { name, value };
+      },
+    },
+  } as unknown as Parameters<typeof captureClickIds>[0];
+}
+
+interface CookieRecord {
+  name: string;
+  value: string;
+  options?: Record<string, unknown>;
+}
+
+function makeNextResponse() {
+  const cookies: CookieRecord[] = [];
+  return {
+    cookies: {
+      set(name: string, value: string, options?: Record<string, unknown>) {
+        cookies.push({ name, value, options });
+      },
+      _all: cookies,
+    },
+  } as unknown as Parameters<typeof setClickIdsCookie>[0] & {
+    cookies: { _all: CookieRecord[] };
+  };
+}
+
+describe('captureClickIds', () => {
+  it('extracts the four supported click ids from the URL', () => {
+    const req = makeNextRequest({
+      url: 'https://example.com/?gclid=ABC&gbraid=DEF&wbraid=GHI&fbclid=JKL',
+    });
+    expect(captureClickIds(req)).toEqual({
+      gclid: 'ABC',
+      gbraid: 'DEF',
+      wbraid: 'GHI',
+      fbclid: 'JKL',
+    });
+  });
+
+  it('ignores unrelated query params and missing keys', () => {
+    const req = makeNextRequest({
+      url: 'https://example.com/?utm_source=foo&q=hello&gclid=xyz',
+    });
+    expect(captureClickIds(req)).toEqual({ gclid: 'xyz' });
+  });
+
+  it('rejects malformed click ids (special chars beyond URL-safe)', () => {
+    const req = makeNextRequest({
+      url: 'https://example.com/?gclid=bad;value&gbraid=ok-1.2_3',
+    });
+    expect(captureClickIds(req)).toEqual({ gbraid: 'ok-1.2_3' });
+  });
+
+  it('returns an empty set when no click ids are present', () => {
+    const req = makeNextRequest({ url: 'https://example.com/landing' });
+    expect(captureClickIds(req)).toEqual({});
+  });
+});
+
+describe('setClickIdsCookie + getStoredClickIds round-trip', () => {
+  it('writes 90-day cookies for each supplied click id', () => {
+    const res = makeNextResponse();
+    setClickIdsCookie(res, { gclid: 'TEST-GCLID', wbraid: 'WB-1' });
+    const all = (res as unknown as { cookies: { _all: CookieRecord[] } }).cookies
+      ._all;
+    expect(all).toHaveLength(2);
+    const byName = Object.fromEntries(all.map((c) => [c.name, c]));
+    expect(byName['bk_gclid'].value).toBe('TEST-GCLID');
+    expect(byName['bk_gclid'].options?.maxAge).toBe(
+      clickIdInternals.COOKIE_MAX_AGE_SECONDS,
+    );
+    expect(byName['bk_gclid'].options?.sameSite).toBe('lax');
+    expect(byName['bk_gclid'].options?.httpOnly).toBe(false);
+    expect(byName['bk_wbraid'].value).toBe('WB-1');
+  });
+
+  it('honours custom maxAge and secure overrides', () => {
+    const res = makeNextResponse();
+    setClickIdsCookie(
+      res,
+      { gclid: 'X' },
+      { maxAgeSeconds: 60, secure: true },
+    );
+    const c = (res as unknown as { cookies: { _all: CookieRecord[] } }).cookies
+      ._all[0];
+    expect(c.options?.maxAge).toBe(60);
+    expect(c.options?.secure).toBe(true);
+  });
+
+  it('writes nothing for an empty set', () => {
+    const res = makeNextResponse();
+    setClickIdsCookie(res, {});
+    expect(
+      (res as unknown as { cookies: { _all: CookieRecord[] } }).cookies._all,
+    ).toHaveLength(0);
+  });
+
+  it('reads stored click ids from cookies when URL has none (round-trip)', () => {
+    const ids: ClickIdSet = { gclid: 'STORED-GCLID' };
+    // Simulate the cookie that setClickIdsCookie would have written:
+    const req = makeNextRequest({
+      url: 'https://example.com/contact',
+      cookies: { bk_gclid: ids.gclid! },
+    });
+    expect(getStoredClickIds(req)).toEqual({ gclid: 'STORED-GCLID' });
+  });
+
+  it('URL params override stored cookies (newest click wins)', () => {
+    const req = makeNextRequest({
+      url: 'https://example.com/?gclid=URL-FRESH',
+      cookies: { bk_gclid: 'COOKIE-OLD' },
+    });
+    expect(getStoredClickIds(req)).toEqual({ gclid: 'URL-FRESH' });
+  });
+
+  it('ignores cookies with malformed values (defence in depth)', () => {
+    const req = makeNextRequest({
+      url: 'https://example.com/',
+      cookies: { bk_gclid: 'bad;value' },
+    });
+    expect(getStoredClickIds(req)).toEqual({});
+  });
+});
+
+describe('clickIdInternals', () => {
+  it('exposes the cookie name builder for downstream callers', () => {
+    expect(clickIdInternals.cookieName('gclid')).toBe('bk_gclid');
+    expect(clickIdInternals.cookieName('fbclid')).toBe('bk_fbclid');
+  });
+
+  it('uses 90 days as the cookie expiry — matches Google Ads conversion window', () => {
+    expect(clickIdInternals.COOKIE_MAX_AGE_SECONDS).toBe(90 * 24 * 60 * 60);
+  });
+});

--- a/__tests__/lib/funnel/destinations/google-ads.test.ts
+++ b/__tests__/lib/funnel/destinations/google-ads.test.ts
@@ -1,0 +1,220 @@
+/**
+ * F2 / EPIC #419 — Google Ads dispatcher branch unit tests.
+ */
+
+import {
+  dispatchToGoogleAds,
+  type EventDestinationMappingRow,
+} from '@/lib/funnel/destinations/google-ads';
+import type { FunnelEvent } from '@bukeer/website-contract';
+
+const ACCOUNT_ID = '11111111-1111-4111-8111-111111111111';
+const WEBSITE_ID = '22222222-2222-4222-8222-222222222222';
+const CONVERSION_ACTION_ID = '987654321';
+
+function makeMapping(
+  overrides: Partial<EventDestinationMappingRow> = {},
+): EventDestinationMappingRow {
+  return {
+    funnel_event_name: 'waflow_submit',
+    destination: 'google_ads',
+    destination_event_name: 'waflow_submit',
+    value_field: null,
+    enabled: true,
+    tenant_overrides: {
+      [ACCOUNT_ID]: { conversion_action_id: CONVERSION_ACTION_ID },
+    },
+    ...overrides,
+  };
+}
+
+function makeEvent(overrides: Partial<FunnelEvent> = {}): FunnelEvent {
+  return {
+    account_id: ACCOUNT_ID,
+    website_id: WEBSITE_ID,
+    locale: 'es-CO',
+    market: 'CO',
+    event_id:
+      '0000000000000000000000000000000000000000000000000000000000000001',
+    event_name: 'waflow_submit',
+    stage: 'activation',
+    channel: 'google_ads',
+    reference_code: 'HOME-2505-ABCD',
+    occurred_at: '2026-05-03T10:00:00-05:00',
+    attribution: null,
+    payload: {},
+    provider_status: [],
+    source_url: null,
+    page_path: '/',
+    ...overrides,
+  } as FunnelEvent;
+}
+
+describe('dispatchToGoogleAds', () => {
+  it('returns skipped/no_click_id when the event has no gclid/gbraid/wbraid', async () => {
+    const result = await dispatchToGoogleAds(
+      makeEvent({ attribution: null }),
+      makeMapping(),
+    );
+    expect(result.status).toBe('skipped');
+    expect(result.reason).toBe('no_click_id');
+    expect(result.conversionActionId).toBe(CONVERSION_ACTION_ID);
+  });
+
+  it('returns skipped/missing_conversion_action_id when no tenant override is set', async () => {
+    const result = await dispatchToGoogleAds(
+      makeEvent({
+        attribution: {
+          account_id: ACCOUNT_ID,
+          website_id: WEBSITE_ID,
+          locale: 'es-CO',
+          market: 'CO',
+          reference_code: 'HOME-2505-ABCD',
+          session_key: 'sess-12345678',
+          source_url: null,
+          page_path: '/',
+          channel: 'google_ads',
+          utm: {
+            utm_source: null,
+            utm_medium: null,
+            utm_campaign: null,
+            utm_content: null,
+            utm_term: null,
+          },
+          click_ids: {
+            gclid: 'G-ABC',
+            gbraid: null,
+            wbraid: null,
+            fbclid: null,
+            ttclid: null,
+          },
+          captured_at: '2026-05-03T10:00:00.000Z',
+        },
+      }),
+      makeMapping({ tenant_overrides: {} }),
+    );
+    expect(result.status).toBe('skipped');
+    expect(result.reason).toBe('missing_conversion_action_id');
+  });
+
+  it('returns skipped/mapping_disabled when mapping is disabled for the tenant', async () => {
+    const result = await dispatchToGoogleAds(
+      makeEvent(),
+      makeMapping({
+        tenant_overrides: {
+          [ACCOUNT_ID]: {
+            conversion_action_id: CONVERSION_ACTION_ID,
+            enabled: false,
+          },
+        },
+      }),
+    );
+    expect(result.status).toBe('skipped');
+    expect(result.reason).toBe('mapping_disabled');
+  });
+
+  it('uploads when a gclid is present (stubbed fetch); attaches order id when bookingId given', async () => {
+    const fetchImpl = jest.fn();
+    const event = makeEvent({
+      attribution: {
+        account_id: ACCOUNT_ID,
+        website_id: WEBSITE_ID,
+        locale: 'es-CO',
+        market: 'CO',
+        reference_code: 'HOME-2505-ABCD',
+        session_key: 'sess-12345678',
+        source_url: null,
+        page_path: '/',
+        channel: 'google_ads',
+        utm: {
+          utm_source: null,
+          utm_medium: null,
+          utm_campaign: null,
+          utm_content: null,
+          utm_term: null,
+        },
+        click_ids: {
+          gclid: 'G-LEAD-123',
+          gbraid: null,
+          wbraid: null,
+          fbclid: null,
+          ttclid: null,
+        },
+        captured_at: '2026-05-03T10:00:00.000Z',
+      },
+    });
+    const result = await dispatchToGoogleAds(event, makeMapping(), {
+      bookingId: 'booking-xyz',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      // No accessToken provided → upload client uses the stub branch
+      // (returns ok=true status=202). Real Google Ads call NOT made.
+      config: {
+        enabled: true,
+        customerId: '1112223333',
+        developerToken: 'tok',
+      },
+    });
+    expect(result.status).toBe('sent');
+    expect(result.conversionActionId).toBe(CONVERSION_ACTION_ID);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('reads value_amount from event.payload when mapping.value_field is set', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ results: [{}] }),
+      text: async () => '',
+    } as unknown as Response);
+    const event = makeEvent({
+      event_name: 'booking_confirmed',
+      stage: 'booking',
+      payload: { value_amount: 1500000, value_currency: 'COP' },
+      attribution: {
+        account_id: ACCOUNT_ID,
+        website_id: WEBSITE_ID,
+        locale: 'es-CO',
+        market: 'CO',
+        reference_code: 'HOME-2505-ABCD',
+        session_key: 'sess-12345678',
+        source_url: null,
+        page_path: '/',
+        channel: 'google_ads',
+        utm: {
+          utm_source: null,
+          utm_medium: null,
+          utm_campaign: null,
+          utm_content: null,
+          utm_term: null,
+        },
+        click_ids: {
+          gclid: 'G-BOOK-XYZ',
+          gbraid: null,
+          wbraid: null,
+          fbclid: null,
+          ttclid: null,
+        },
+        captured_at: '2026-05-03T10:00:00.000Z',
+      },
+    });
+    const result = await dispatchToGoogleAds(
+      event,
+      makeMapping({ value_field: 'value_amount' }),
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        accessToken: 'oauth-token',
+        config: {
+          enabled: true,
+          customerId: '1112223333',
+          developerToken: 'tok',
+        },
+      },
+    );
+    expect(result.status).toBe('sent');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [, init] = (fetchImpl as jest.Mock).mock.calls[0];
+    const body = JSON.parse(init.body as string);
+    expect(body.conversions[0].conversionValue).toBe(1500000);
+    expect(body.conversions[0].currencyCode).toBe('COP');
+  });
+});

--- a/__tests__/lib/google-ads/offline-upload.test.ts
+++ b/__tests__/lib/google-ads/offline-upload.test.ts
@@ -1,0 +1,222 @@
+/**
+ * F2 / EPIC #419 — Google Ads offline upload client unit tests.
+ */
+
+import {
+  buildOfflineConversionRequest,
+  buildUserIdentifiers,
+  isGoogleAdsConfigured,
+  redactGoogleAdsProviderResponse,
+  resolveGoogleAdsConfig,
+  sendOfflineConversionUpload,
+  sha256Hex,
+} from '@/lib/google-ads/offline-upload';
+
+describe('Google Ads offline upload helpers', () => {
+  beforeEach(() => {
+    delete process.env.GOOGLE_ADS_OFFLINE_UPLOAD_ENABLED;
+    delete process.env.GOOGLE_ADS_DEVELOPER_TOKEN;
+    delete process.env.GOOGLE_ADS_LOGIN_CUSTOMER_ID;
+    delete process.env.GOOGLE_ADS_CUSTOMER_ID;
+  });
+
+  it('hashes email lowercased + trimmed and emits a FIRST_PARTY identifier', async () => {
+    const ids = await buildUserIdentifiers({ email: '  TEST@Example.COM ' });
+    expect(ids).toHaveLength(1);
+    expect(ids[0].hashedEmail).toBe(await sha256Hex('test@example.com'));
+    expect(ids[0].userIdentifierSource).toBe('FIRST_PARTY');
+  });
+
+  it('preserves leading + on phones (E.164) and strips other punctuation', async () => {
+    const ids = await buildUserIdentifiers({ phone: '+57 (300) 123-4567' });
+    expect(ids[0].hashedPhoneNumber).toBe(await sha256Hex('+573001234567'));
+  });
+
+  it('groups address fields under addressInfo and hashes name parts', async () => {
+    const ids = await buildUserIdentifiers({
+      firstName: 'Juan',
+      lastName: 'Pérez',
+      city: 'Bogota',
+      countryCode: 'co',
+    });
+    expect(ids).toHaveLength(1);
+    expect(ids[0].addressInfo).toEqual({
+      hashedFirstName: await sha256Hex('juan'),
+      hashedLastName: await sha256Hex('pérez'),
+      city: 'Bogota',
+      countryCode: 'CO',
+    });
+  });
+
+  it('builds an upload request with the resource path and click id', async () => {
+    const request = await buildOfflineConversionRequest(
+      {
+        gclid: 'TEST-GCLID-123',
+        conversionActionId: '987654321',
+        conversionDateTime: '2026-05-03T10:00:00-05:00',
+        conversionValue: 1500,
+        currencyCode: 'COP',
+        orderId: 'booking-abc',
+        userIdentifiers: { email: 'lead@example.com' },
+      },
+      { customerId: '1112223333' },
+    );
+
+    expect(request.customerId).toBe('1112223333');
+    expect(request.conversions).toHaveLength(1);
+    const c = request.conversions[0];
+    expect(c.conversionAction).toBe(
+      'customers/1112223333/conversionActions/987654321',
+    );
+    expect(c.gclid).toBe('TEST-GCLID-123');
+    expect(c.conversionValue).toBe(1500);
+    expect(c.currencyCode).toBe('COP');
+    expect(c.orderId).toBe('booking-abc');
+    expect(c.userIdentifiers).toBeDefined();
+    expect(c.userIdentifiers![0].hashedEmail).toBe(
+      await sha256Hex('lead@example.com'),
+    );
+  });
+
+  it('isGoogleAdsConfigured requires enabled + dev token + customer id', () => {
+    expect(
+      isGoogleAdsConfigured(
+        resolveGoogleAdsConfig({
+          enabled: true,
+          developerToken: 'tok',
+          customerId: '123',
+        }),
+      ),
+    ).toBe(true);
+    expect(isGoogleAdsConfigured(resolveGoogleAdsConfig({ enabled: true }))).toBe(
+      false,
+    );
+    expect(
+      isGoogleAdsConfigured(
+        resolveGoogleAdsConfig({
+          enabled: false,
+          developerToken: 'tok',
+          customerId: '123',
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('redacts secret-looking keys in provider responses', () => {
+    const redacted = redactGoogleAdsProviderResponse({
+      results: [{ resourceName: 'x' }],
+      developer_token: 'leak-me',
+      nested: { access_token: 'also-leak' },
+    });
+    expect(redacted).toMatchObject({
+      developer_token: '[redacted]',
+      nested: { access_token: '[redacted]' },
+    });
+  });
+});
+
+describe('sendOfflineConversionUpload', () => {
+  beforeEach(() => {
+    delete process.env.GOOGLE_ADS_OFFLINE_UPLOAD_ENABLED;
+    delete process.env.GOOGLE_ADS_DEVELOPER_TOKEN;
+    delete process.env.GOOGLE_ADS_CUSTOMER_ID;
+  });
+
+  it('skips with no_click_id when none of gclid/gbraid/wbraid is present', async () => {
+    const result = await sendOfflineConversionUpload({
+      conversionActionId: '987654321',
+      conversionDateTime: '2026-05-03T10:00:00-05:00',
+    });
+    expect(result.status).toBe('skipped');
+    expect(result.skippedReason).toBe('no_click_id');
+  });
+
+  it('skips when Google Ads is not configured (and never calls fetch)', async () => {
+    const fetchImpl = jest.fn();
+    const result = await sendOfflineConversionUpload(
+      {
+        gclid: 'G123',
+        conversionActionId: '987654321',
+        conversionDateTime: '2026-05-03T10:00:00-05:00',
+      },
+      {
+        config: { enabled: false, customerId: '111', developerToken: 't' },
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      },
+    );
+    expect(result.status).toBe('skipped');
+    expect(result.skippedReason).toMatch(/disabled or missing/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('returns sent (stubbed) when configured but no accessToken provided', async () => {
+    const result = await sendOfflineConversionUpload(
+      {
+        gclid: 'G123',
+        conversionActionId: '987654321',
+        conversionDateTime: '2026-05-03T10:00:00-05:00',
+      },
+      {
+        config: { enabled: true, customerId: '111', developerToken: 'tok' },
+      },
+    );
+    expect(result.status).toBe('sent');
+    expect(result.providerResponse?.status).toBe(202);
+    expect(result.providerResponse?.body).toMatchObject({ stub: true });
+  });
+
+  it('calls fetch and returns sent on 200', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ results: [{ resourceName: 'x' }] }),
+      text: async () => '',
+    } as unknown as Response);
+    const result = await sendOfflineConversionUpload(
+      {
+        gclid: 'G123',
+        conversionActionId: '987654321',
+        conversionDateTime: '2026-05-03T10:00:00-05:00',
+      },
+      {
+        config: {
+          enabled: true,
+          customerId: '111',
+          developerToken: 'tok',
+          loginCustomerId: '222',
+        },
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        accessToken: 'oauth-bearer-token',
+      },
+    );
+    expect(result.status).toBe('sent');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [, init] = fetchImpl.mock.calls[0];
+    expect(init.headers.authorization).toBe('Bearer oauth-bearer-token');
+    expect(init.headers['developer-token']).toBe('tok');
+    expect(init.headers['login-customer-id']).toBe('222');
+  });
+
+  it('returns failed with error message on non-2xx', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: { message: 'bad request' } }),
+      text: async () => '',
+    } as unknown as Response);
+    const result = await sendOfflineConversionUpload(
+      {
+        gclid: 'G123',
+        conversionActionId: '987654321',
+        conversionDateTime: '2026-05-03T10:00:00-05:00',
+      },
+      {
+        config: { enabled: true, customerId: '111', developerToken: 'tok' },
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        accessToken: 'oauth',
+      },
+    );
+    expect(result.status).toBe('failed');
+    expect(result.error).toMatch(/HTTP 400/);
+  });
+});

--- a/lib/analytics/gclid-capture.ts
+++ b/lib/analytics/gclid-capture.ts
@@ -1,0 +1,142 @@
+/**
+ * Click-ID capture helpers (browser + edge runtime). F2 / EPIC #419.
+ */
+
+import type { NextRequest, NextResponse } from 'next/server';
+
+const CLICK_ID_KEYS = ['gclid', 'gbraid', 'wbraid', 'fbclid'] as const;
+export type ClickIdKey = (typeof CLICK_ID_KEYS)[number];
+
+const GOOGLE_CLICK_ID_KEYS = ['gclid', 'gbraid', 'wbraid'] as const;
+export type GoogleClickIdKey = (typeof GOOGLE_CLICK_ID_KEYS)[number];
+
+const COOKIE_PREFIX = 'bk_';
+const COOKIE_MAX_AGE_SECONDS = 90 * 24 * 60 * 60;
+const MAX_VALUE_LENGTH = 1024;
+
+export type ClickIdSet = Partial<Record<ClickIdKey, string>>;
+
+function sanitize(raw: string | null | undefined): string | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) return undefined;
+  if (!/^[A-Za-z0-9_\-.]+$/.test(trimmed)) return undefined;
+  return trimmed.slice(0, MAX_VALUE_LENGTH);
+}
+
+function cookieName(key: ClickIdKey): string {
+  return `${COOKIE_PREFIX}${key}`;
+}
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined' && typeof document !== 'undefined';
+}
+
+function readBrowserCookie(name: string): string | undefined {
+  if (!isBrowser()) return undefined;
+  const target = `${name}=`;
+  const found = document.cookie
+    .split(';')
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(target));
+  if (!found) return undefined;
+  try {
+    return decodeURIComponent(found.slice(target.length));
+  } catch {
+    return undefined;
+  }
+}
+
+function writeBrowserCookie(name: string, value: string): void {
+  if (!isBrowser()) return;
+  document.cookie = `${name}=${encodeURIComponent(value)}; max-age=${COOKIE_MAX_AGE_SECONDS}; path=/; SameSite=Lax`;
+}
+
+export function captureClickIdsFromUrl(): void {
+  if (!isBrowser()) return;
+  let params: URLSearchParams;
+  try {
+    params = new URLSearchParams(window.location.search);
+  } catch {
+    return;
+  }
+  for (const key of GOOGLE_CLICK_ID_KEYS) {
+    const fresh = sanitize(params.get(key));
+    if (fresh) writeBrowserCookie(cookieName(key), fresh);
+  }
+}
+
+export function readClickIds(): Partial<Record<GoogleClickIdKey, string>> {
+  if (!isBrowser()) return {};
+  const out: Partial<Record<GoogleClickIdKey, string>> = {};
+  let params: URLSearchParams | null = null;
+  try {
+    params = new URLSearchParams(window.location.search);
+  } catch {
+    params = null;
+  }
+  for (const key of GOOGLE_CLICK_ID_KEYS) {
+    const fromCookie = sanitize(readBrowserCookie(cookieName(key)));
+    if (fromCookie) {
+      out[key] = fromCookie;
+      continue;
+    }
+    const fromUrl = sanitize(params?.get(key) ?? null);
+    if (fromUrl) out[key] = fromUrl;
+  }
+  return out;
+}
+
+export function captureClickIds(request: NextRequest): ClickIdSet {
+  const out: ClickIdSet = {};
+  const params = request.nextUrl.searchParams;
+  for (const key of CLICK_ID_KEYS) {
+    const fresh = sanitize(params.get(key));
+    if (fresh) out[key] = fresh;
+  }
+  return out;
+}
+
+export function getStoredClickIds(request: NextRequest): ClickIdSet {
+  const out: ClickIdSet = {};
+  const params = request.nextUrl.searchParams;
+  for (const key of CLICK_ID_KEYS) {
+    const fromUrl = sanitize(params.get(key));
+    if (fromUrl) {
+      out[key] = fromUrl;
+      continue;
+    }
+    const fromCookie = sanitize(request.cookies.get(cookieName(key))?.value);
+    if (fromCookie) out[key] = fromCookie;
+  }
+  return out;
+}
+
+export function setClickIdsCookie(
+  response: NextResponse,
+  ids: ClickIdSet,
+  options: { secure?: boolean; maxAgeSeconds?: number } = {},
+): NextResponse {
+  const maxAge = options.maxAgeSeconds ?? COOKIE_MAX_AGE_SECONDS;
+  const secure = options.secure ?? process.env.NODE_ENV === 'production';
+
+  for (const key of CLICK_ID_KEYS) {
+    const value = ids[key];
+    if (!value) continue;
+    response.cookies.set(cookieName(key), value, {
+      path: '/',
+      httpOnly: false,
+      sameSite: 'lax',
+      secure,
+      maxAge,
+    });
+  }
+  return response;
+}
+
+export const clickIdInternals = {
+  CLICK_ID_KEYS,
+  COOKIE_PREFIX,
+  COOKIE_MAX_AGE_SECONDS,
+  cookieName,
+  sanitize,
+};

--- a/lib/funnel/destinations/google-ads.ts
+++ b/lib/funnel/destinations/google-ads.ts
@@ -1,0 +1,234 @@
+/**
+ * Funnel events dispatcher — Google Ads branch (F2 / EPIC #419).
+ *
+ * Consumed by F1's `lib/funnel/dispatch.ts` switch statement: when an
+ * event_destination_mapping row resolves `destination='google_ads'` for
+ * an incoming funnel event, F1 calls `dispatchToGoogleAds(event, mapping)`.
+ *
+ * tenant_overrides shape (stored on event_destination_mapping):
+ *   {
+ *     "<account_id>": {
+ *       "conversion_action_id": "987654321",
+ *       "enabled": true | false,
+ *       "destination_event_name": "..."
+ *     }
+ *   }
+ */
+
+import { createLogger } from '@/lib/logger';
+import {
+  sendOfflineConversionUpload,
+  type GoogleAdsConfig,
+  type GoogleAdsUserIdentifierInput,
+  type SendOfflineUploadResult,
+} from '@/lib/google-ads/offline-upload';
+import type { FunnelEvent } from '@bukeer/website-contract';
+
+const log = createLogger('funnel.destinations.google-ads');
+
+export type DispatchStatus = 'sent' | 'failed' | 'skipped';
+
+export interface DispatchResult {
+  destination: 'google_ads';
+  status: DispatchStatus;
+  reason?: string;
+  conversionActionId?: string;
+  providerResponse?: unknown;
+  error?: string;
+}
+
+export interface EventDestinationMappingRow {
+  funnel_event_name: string;
+  destination: string;
+  destination_event_name: string;
+  value_field: string | null;
+  enabled: boolean;
+  tenant_overrides: Record<string, unknown>;
+  notes?: string | null;
+}
+
+interface TenantOverrideShape {
+  conversion_action_id?: string;
+  destination_event_name?: string;
+  enabled?: boolean;
+}
+
+interface DispatchDeps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase?: { from: (table: string) => any };
+  config?: GoogleAdsConfig;
+  fetchImpl?: typeof fetch;
+  conversionActionIdOverride?: string;
+  userIdentifiers?: GoogleAdsUserIdentifierInput;
+  bookingId?: string;
+  accessToken?: string;
+}
+
+function getTenantOverride(
+  mapping: EventDestinationMappingRow,
+  accountId: string | null | undefined,
+): TenantOverrideShape | null {
+  if (!accountId) return null;
+  const overrides = mapping.tenant_overrides;
+  if (!overrides || typeof overrides !== 'object') return null;
+  const entry = (overrides as Record<string, unknown>)[accountId];
+  if (!entry || typeof entry !== 'object') return null;
+  return entry as TenantOverrideShape;
+}
+
+function resolveConversionActionId(
+  mapping: EventDestinationMappingRow,
+  accountId: string | null | undefined,
+  override?: string,
+): string | null {
+  if (override) return override;
+  const tenantOverride = getTenantOverride(mapping, accountId);
+  if (tenantOverride?.conversion_action_id) {
+    return tenantOverride.conversion_action_id;
+  }
+  return null;
+}
+
+function isEnabled(
+  mapping: EventDestinationMappingRow,
+  accountId: string | null | undefined,
+): boolean {
+  const tenantOverride = getTenantOverride(mapping, accountId);
+  if (tenantOverride?.enabled === false) return false;
+  return mapping.enabled !== false;
+}
+
+function extractClickIds(
+  event:
+    | FunnelEvent
+    | (FunnelEvent & {
+        gclid?: string | null;
+        gbraid?: string | null;
+        wbraid?: string | null;
+      }),
+): { gclid?: string; gbraid?: string; wbraid?: string } {
+  const flat = event as {
+    gclid?: string | null;
+    gbraid?: string | null;
+    wbraid?: string | null;
+  };
+  const fromAttribution = event.attribution?.click_ids ?? null;
+  return {
+    ...(flat.gclid && { gclid: flat.gclid }),
+    ...(flat.gbraid && { gbraid: flat.gbraid }),
+    ...(flat.wbraid && { wbraid: flat.wbraid }),
+    ...(fromAttribution?.gclid && { gclid: fromAttribution.gclid }),
+    ...(fromAttribution?.gbraid && { gbraid: fromAttribution.gbraid }),
+    ...(fromAttribution?.wbraid && { wbraid: fromAttribution.wbraid }),
+  };
+}
+
+function extractValue(
+  event: FunnelEvent,
+  mapping: EventDestinationMappingRow,
+): { conversionValue?: number; currencyCode?: string } {
+  if (!mapping.value_field) return {};
+  const payload = event.payload ?? {};
+  const rawValue = (payload as Record<string, unknown>)[mapping.value_field];
+  const rawCurrency = (payload as Record<string, unknown>)['value_currency'];
+  const numericValue =
+    typeof rawValue === 'number'
+      ? rawValue
+      : typeof rawValue === 'string'
+        ? Number(rawValue)
+        : undefined;
+  if (numericValue === undefined || Number.isNaN(numericValue)) return {};
+  return {
+    conversionValue: numericValue,
+    ...(typeof rawCurrency === 'string' && { currencyCode: rawCurrency }),
+  };
+}
+
+export async function dispatchToGoogleAds(
+  event: FunnelEvent,
+  mapping: EventDestinationMappingRow,
+  deps: DispatchDeps = {},
+): Promise<DispatchResult> {
+  if (!isEnabled(mapping, event.account_id)) {
+    return {
+      destination: 'google_ads',
+      status: 'skipped',
+      reason: 'mapping_disabled',
+    };
+  }
+
+  const conversionActionId = resolveConversionActionId(
+    mapping,
+    event.account_id,
+    deps.conversionActionIdOverride,
+  );
+  if (!conversionActionId) {
+    log.warn('missing_conversion_action_id', {
+      event_name: event.event_name,
+      account_id: event.account_id,
+    });
+    return {
+      destination: 'google_ads',
+      status: 'skipped',
+      reason: 'missing_conversion_action_id',
+    };
+  }
+
+  const clickIds = extractClickIds(event);
+  if (!clickIds.gclid && !clickIds.gbraid && !clickIds.wbraid) {
+    return {
+      destination: 'google_ads',
+      status: 'skipped',
+      reason: 'no_click_id',
+      conversionActionId,
+    };
+  }
+
+  const { conversionValue, currencyCode } = extractValue(event, mapping);
+
+  const result: SendOfflineUploadResult = await sendOfflineConversionUpload(
+    {
+      conversionActionId,
+      conversionDateTime: event.occurred_at,
+      ...(typeof conversionValue === 'number' && { conversionValue }),
+      ...(currencyCode && { currencyCode }),
+      ...(deps.bookingId && { orderId: deps.bookingId }),
+      ...clickIds,
+      userIdentifiers: deps.userIdentifiers,
+      accountId: event.account_id,
+      websiteId: event.website_id,
+      funnelEventId: event.event_id,
+      bookingId: deps.bookingId,
+    },
+    {
+      supabase: deps.supabase,
+      config: deps.config,
+      fetchImpl: deps.fetchImpl,
+      accessToken: deps.accessToken,
+    },
+  );
+
+  if (result.status === 'sent') {
+    return {
+      destination: 'google_ads',
+      status: 'sent',
+      conversionActionId,
+      providerResponse: result.providerResponse?.body,
+    };
+  }
+  if (result.status === 'skipped') {
+    return {
+      destination: 'google_ads',
+      status: 'skipped',
+      reason: result.skippedReason ?? 'skipped',
+      conversionActionId,
+    };
+  }
+  return {
+    destination: 'google_ads',
+    status: 'failed',
+    conversionActionId,
+    error: result.error,
+    providerResponse: result.providerResponse?.body,
+  };
+}

--- a/lib/google-ads/offline-upload.ts
+++ b/lib/google-ads/offline-upload.ts
@@ -1,0 +1,610 @@
+/**
+ * Google Ads — Offline Conversion Upload client (F2 / EPIC #419).
+ *
+ * Sends server-side conversions to the Google Ads Conversions Upload API
+ * (a.k.a. "Enhanced Conversions for Leads") so that bookings confirmed in
+ * the CRM can be matched back to the originating Ads click via `gclid`.
+ *
+ * Why this lives here and not in a shared `lib/ads/`:
+ *   - Mirrors the per-platform layout used by `lib/meta/conversions-api.ts`.
+ *   - F1 (`lib/funnel/dispatch.ts`) imports this module from the
+ *     `google_ads` dispatcher branch (`lib/funnel/destinations/google-ads.ts`).
+ *
+ * Status of the actual API call:
+ *   The upload-to-Google call below is intentionally STUBBED. The full client
+ *   structure, hashing, idempotent log and retry semantics are implemented
+ *   and tested with a mocked fetch — but the real Google Ads API integration
+ *   requires a developer token + service-account validation that cannot be
+ *   exercised in this session. See the marked TODO in `sendOfflineUpload`.
+ *
+ * Reference: https://developers.google.com/google-ads/api/docs/conversions/upload-clicks
+ */
+
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('google_ads.offline-upload');
+
+const PROVIDER = 'google_ads';
+const DEFAULT_API_VERSION = 'v18';
+
+export type GoogleAdsAuthType = 'service_account' | 'oauth2_refresh_token';
+export type GoogleAdsConversionStatus = 'pending' | 'sent' | 'failed' | 'skipped';
+
+export interface GoogleAdsConfig {
+  enabled?: boolean;
+  developerToken?: string | null;
+  loginCustomerId?: string | null;
+  customerId?: string | null;
+  authType?: GoogleAdsAuthType;
+  credentialsPath?: string | null;
+  apiVersion?: string | null;
+  endpointBase?: string;
+}
+
+export interface GoogleAdsUserIdentifierInput {
+  email?: string | null;
+  phone?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  street?: string | null;
+  city?: string | null;
+  region?: string | null;
+  postalCode?: string | null;
+  countryCode?: string | null;
+}
+
+export interface OfflineConversionInput {
+  gclid?: string | null;
+  gbraid?: string | null;
+  wbraid?: string | null;
+  conversionActionId: string;
+  conversionDateTime: string;
+  conversionValue?: number;
+  currencyCode?: string;
+  orderId?: string;
+  userIdentifiers?: GoogleAdsUserIdentifierInput;
+}
+
+export interface OfflineConversionTrace {
+  accountId?: string | null;
+  websiteId?: string | null;
+  funnelEventId?: string | null;
+  bookingId?: string | null;
+  trace?: Record<string, unknown>;
+}
+
+export interface GoogleAdsProviderResponse {
+  ok: boolean;
+  status: number;
+  body: unknown;
+}
+
+export interface SendOfflineUploadResult {
+  status: GoogleAdsConversionStatus;
+  conversionActionId: string;
+  request: GoogleAdsConversionUploadRequest;
+  providerResponse?: GoogleAdsProviderResponse;
+  error?: string;
+  skippedReason?: string;
+  deduped?: boolean;
+}
+
+interface SupabaseLike {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  from: (table: string) => any;
+}
+
+interface SupabaseErrorLike {
+  code?: string;
+  message?: string;
+}
+
+interface SupabaseQueryLike {
+  select?: (...args: unknown[]) => SupabaseQueryLike | unknown;
+  eq?: (...args: unknown[]) => SupabaseQueryLike | unknown;
+  maybeSingle?: () => Promise<{ data: unknown; error: SupabaseErrorLike | null }>;
+  then?: PromiseLike<{ data?: unknown; error?: SupabaseErrorLike | null }>['then'];
+}
+
+export interface GoogleAdsConversionUploadRequest {
+  customerId: string;
+  conversions: GoogleAdsConversionEntry[];
+  partialFailure: boolean;
+  validateOnly: boolean;
+}
+
+export interface GoogleAdsConversionEntry {
+  conversionAction: string;
+  conversionDateTime: string;
+  gclid?: string;
+  gbraid?: string;
+  wbraid?: string;
+  conversionValue?: number;
+  currencyCode?: string;
+  orderId?: string;
+  userIdentifiers?: GoogleAdsUserIdentifier[];
+}
+
+export interface GoogleAdsUserIdentifier {
+  hashedEmail?: string;
+  hashedPhoneNumber?: string;
+  addressInfo?: {
+    hashedFirstName?: string;
+    hashedLastName?: string;
+    hashedStreetAddress?: string;
+    city?: string;
+    state?: string;
+    postalCode?: string;
+    countryCode?: string;
+  };
+  userIdentifierSource?: 'FIRST_PARTY';
+}
+
+function cleanString(value: string | null | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized || undefined;
+}
+
+function normalizeForHash(value: string | null | undefined): string | undefined {
+  return cleanString(value)?.toLowerCase();
+}
+
+function normalizePhoneForHash(value: string | null | undefined): string | undefined {
+  const trimmed = cleanString(value);
+  if (!trimmed) return undefined;
+  if (trimmed.startsWith('+')) {
+    const digits = trimmed.slice(1).replace(/\D/g, '');
+    return digits ? `+${digits}` : undefined;
+  }
+  const digits = trimmed.replace(/\D/g, '');
+  return digits || undefined;
+}
+
+function bytesToHex(bytes: ArrayBuffer): string {
+  return Array.from(new Uint8Array(bytes))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(value),
+  );
+  return bytesToHex(digest);
+}
+
+async function hashIfPresent(value: string | undefined): Promise<string | undefined> {
+  return value ? await sha256Hex(value) : undefined;
+}
+
+export function resolveGoogleAdsConfig(
+  overrides: GoogleAdsConfig = {},
+): Required<Pick<GoogleAdsConfig, 'endpointBase' | 'apiVersion'>> & GoogleAdsConfig {
+  return {
+    enabled:
+      overrides.enabled ??
+      process.env.GOOGLE_ADS_OFFLINE_UPLOAD_ENABLED === 'true',
+    developerToken:
+      overrides.developerToken ?? process.env.GOOGLE_ADS_DEVELOPER_TOKEN ?? null,
+    loginCustomerId:
+      overrides.loginCustomerId ??
+      process.env.GOOGLE_ADS_LOGIN_CUSTOMER_ID ??
+      null,
+    customerId:
+      overrides.customerId ?? process.env.GOOGLE_ADS_CUSTOMER_ID ?? null,
+    authType:
+      overrides.authType ??
+      ((process.env.GOOGLE_ADS_AUTH_TYPE as GoogleAdsAuthType | undefined) ??
+        'service_account'),
+    credentialsPath:
+      overrides.credentialsPath ??
+      process.env.GOOGLE_ADS_CREDENTIALS_PATH ??
+      null,
+    apiVersion:
+      overrides.apiVersion ?? process.env.GOOGLE_ADS_API_VERSION ?? DEFAULT_API_VERSION,
+    endpointBase: overrides.endpointBase ?? 'https://googleads.googleapis.com',
+  };
+}
+
+export function isGoogleAdsConfigured(config: GoogleAdsConfig): boolean {
+  return Boolean(
+    config.enabled &&
+      cleanString(config.developerToken) &&
+      cleanString(config.customerId),
+  );
+}
+
+export async function buildUserIdentifiers(
+  input: GoogleAdsUserIdentifierInput = {},
+): Promise<GoogleAdsUserIdentifier[]> {
+  const out: GoogleAdsUserIdentifier[] = [];
+
+  const hashedEmail = await hashIfPresent(normalizeForHash(input.email));
+  if (hashedEmail) {
+    out.push({ hashedEmail, userIdentifierSource: 'FIRST_PARTY' });
+  }
+
+  const hashedPhoneNumber = await hashIfPresent(
+    normalizePhoneForHash(input.phone),
+  );
+  if (hashedPhoneNumber) {
+    out.push({ hashedPhoneNumber, userIdentifierSource: 'FIRST_PARTY' });
+  }
+
+  const hasAddress =
+    normalizeForHash(input.firstName) ||
+    normalizeForHash(input.lastName) ||
+    normalizeForHash(input.street) ||
+    cleanString(input.city) ||
+    cleanString(input.region) ||
+    cleanString(input.postalCode) ||
+    cleanString(input.countryCode);
+
+  if (hasAddress) {
+    const hashedFirstName = await hashIfPresent(normalizeForHash(input.firstName));
+    const hashedLastName = await hashIfPresent(normalizeForHash(input.lastName));
+    const hashedStreetAddress = await hashIfPresent(normalizeForHash(input.street));
+    out.push({
+      addressInfo: {
+        ...(hashedFirstName && { hashedFirstName }),
+        ...(hashedLastName && { hashedLastName }),
+        ...(hashedStreetAddress && { hashedStreetAddress }),
+        ...(cleanString(input.city) && { city: cleanString(input.city)! }),
+        ...(cleanString(input.region) && { state: cleanString(input.region)! }),
+        ...(cleanString(input.postalCode) && {
+          postalCode: cleanString(input.postalCode)!,
+        }),
+        ...(cleanString(input.countryCode) && {
+          countryCode: cleanString(input.countryCode)!.toUpperCase(),
+        }),
+      },
+      userIdentifierSource: 'FIRST_PARTY',
+    });
+  }
+
+  return out;
+}
+
+function conversionActionResource(customerId: string, actionId: string): string {
+  return `customers/${customerId}/conversionActions/${actionId}`;
+}
+
+export async function buildOfflineConversionRequest(
+  input: OfflineConversionInput,
+  config: GoogleAdsConfig = {},
+): Promise<GoogleAdsConversionUploadRequest> {
+  const resolved = resolveGoogleAdsConfig(config);
+  const customerId = cleanString(resolved.customerId);
+  if (!customerId) {
+    throw new Error('GOOGLE_ADS_CUSTOMER_ID is required to build a request');
+  }
+
+  const userIdentifiers = await buildUserIdentifiers(input.userIdentifiers);
+
+  const entry: GoogleAdsConversionEntry = {
+    conversionAction: conversionActionResource(customerId, input.conversionActionId),
+    conversionDateTime: input.conversionDateTime,
+    ...(input.gclid && { gclid: input.gclid }),
+    ...(input.gbraid && { gbraid: input.gbraid }),
+    ...(input.wbraid && { wbraid: input.wbraid }),
+    ...(typeof input.conversionValue === 'number' && {
+      conversionValue: input.conversionValue,
+    }),
+    ...(input.currencyCode && { currencyCode: input.currencyCode }),
+    ...(input.orderId && { orderId: input.orderId }),
+    ...(userIdentifiers.length > 0 && { userIdentifiers }),
+  };
+
+  return {
+    customerId,
+    conversions: [entry],
+    partialFailure: false,
+    validateOnly: false,
+  };
+}
+
+export function redactGoogleAdsProviderResponse(body: unknown): unknown {
+  if (!body || typeof body !== 'object') return body;
+  if (Array.isArray(body)) return body.map(redactGoogleAdsProviderResponse);
+
+  const output: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(body)) {
+    if (/access[_-]?token|developer[_-]?token|secret|password/i.test(key)) {
+      output[key] = '[redacted]';
+    } else {
+      output[key] = redactGoogleAdsProviderResponse(value);
+    }
+  }
+  return output;
+}
+
+async function sendOfflineUpload(
+  request: GoogleAdsConversionUploadRequest,
+  config: Required<Pick<GoogleAdsConfig, 'endpointBase' | 'apiVersion'>> & GoogleAdsConfig,
+  fetchImpl: typeof fetch = fetch,
+  accessToken?: string,
+): Promise<GoogleAdsProviderResponse> {
+  // TODO[F2-followup]: real Google Ads API integration pending dev token +
+  // auth validation. Replace stubbed early-return with real OAuth/JWT
+  // exchange once GOOGLE_ADS_DEVELOPER_TOKEN is validated.
+
+  const url = `${config.endpointBase.replace(/\/$/, '')}/${config.apiVersion}/customers/${request.customerId}:uploadClickConversions`;
+
+  if (!accessToken) {
+    log.info('google_ads.offline-upload.stub', {
+      url,
+      customer_id: request.customerId,
+      conversions: request.conversions.length,
+    });
+    return {
+      ok: true,
+      status: 202,
+      body: redactGoogleAdsProviderResponse({
+        stub: true,
+        results: request.conversions.map((c) => ({
+          conversionAction: c.conversionAction,
+          conversionDateTime: c.conversionDateTime,
+        })),
+      }),
+    };
+  }
+
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${accessToken}`,
+    'content-type': 'application/json',
+  };
+  if (cleanString(config.developerToken)) {
+    headers['developer-token'] = cleanString(config.developerToken)!;
+  }
+  if (cleanString(config.loginCustomerId)) {
+    headers['login-customer-id'] = cleanString(config.loginCustomerId)!;
+  }
+
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      conversions: request.conversions,
+      partialFailure: request.partialFailure,
+      validateOnly: request.validateOnly,
+    }),
+  });
+
+  let body: unknown = null;
+  try {
+    body = await response.json();
+  } catch {
+    body = await response.text().catch(() => null);
+  }
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    body: redactGoogleAdsProviderResponse(body),
+  };
+}
+
+function buildLogRow(
+  input: OfflineConversionInput & OfflineConversionTrace,
+  request: GoogleAdsConversionUploadRequest,
+  status: GoogleAdsConversionStatus,
+  details: { error?: string; providerResponse?: unknown } = {},
+): Record<string, unknown> {
+  return {
+    provider: PROVIDER,
+    account_id: input.accountId ?? null,
+    website_id: input.websiteId ?? null,
+    funnel_event_id: input.funnelEventId ?? null,
+    booking_id: input.bookingId ?? null,
+    conversion_action_id: input.conversionActionId,
+    gclid: input.gclid ?? null,
+    gbraid: input.gbraid ?? null,
+    wbraid: input.wbraid ?? null,
+    conversion_value: input.conversionValue ?? null,
+    currency_code: input.currencyCode ?? null,
+    conversion_date_time: input.conversionDateTime,
+    status,
+    request_payload: request,
+    provider_response: details.providerResponse ?? null,
+    error: details.error ?? null,
+    trace: {
+      ...(input.accountId && { account_id: input.accountId }),
+      ...(input.websiteId && { website_id: input.websiteId }),
+      ...(input.funnelEventId && { funnel_event_id: input.funnelEventId }),
+      ...(input.bookingId && { booking_id: input.bookingId }),
+      ...(input.trace ?? {}),
+    },
+    sent_at: status === 'sent' ? new Date().toISOString() : null,
+  };
+}
+
+async function insertOfflineUploadLog(
+  supabase: SupabaseLike,
+  row: Record<string, unknown>,
+): Promise<{ row: unknown; deduped: boolean }> {
+  const insertQuery = supabase.from('google_ads_offline_uploads').insert?.(row) as
+    | {
+        select?: (...args: unknown[]) => unknown;
+        maybeSingle?: () => Promise<{ data: unknown; error: SupabaseErrorLike | null }>;
+      }
+    | undefined;
+  const insertSelected = insertQuery?.select?.('*') as
+    | { maybeSingle?: () => Promise<{ data: unknown; error: SupabaseErrorLike | null }> }
+    | undefined;
+  const insertResult = await insertSelected?.maybeSingle?.();
+
+  if (!insertResult) return { row: null, deduped: false };
+  if (!insertResult.error) return { row: insertResult.data, deduped: false };
+  if (insertResult.error.code !== '23505') {
+    throw new Error(insertResult.error.message);
+  }
+
+  const selectQuery = supabase
+    .from('google_ads_offline_uploads')
+    .select?.('*') as SupabaseQueryLike | undefined;
+  const byEvent = selectQuery?.eq?.(
+    'funnel_event_id',
+    row.funnel_event_id,
+  ) as SupabaseQueryLike | undefined;
+  const byAction = byEvent?.eq?.(
+    'conversion_action_id',
+    row.conversion_action_id,
+  ) as SupabaseQueryLike | undefined;
+  const existing = await byAction?.maybeSingle?.();
+  if (existing?.error) throw new Error(existing.error.message);
+  return { row: existing?.data ?? null, deduped: true };
+}
+
+async function updateOfflineUploadLog(
+  supabase: SupabaseLike,
+  funnelEventId: string,
+  conversionActionId: string,
+  patch: Record<string, unknown>,
+): Promise<void> {
+  const query = supabase
+    .from('google_ads_offline_uploads')
+    .update?.(patch) as SupabaseQueryLike | undefined;
+  const byEvent = query?.eq?.(
+    'funnel_event_id',
+    funnelEventId,
+  ) as SupabaseQueryLike | undefined;
+  const byAction = byEvent?.eq?.(
+    'conversion_action_id',
+    conversionActionId,
+  ) as SupabaseQueryLike | undefined;
+  const updateResult = byAction?.then
+    ? await (byAction as PromiseLike<{ error?: SupabaseErrorLike | null }>)
+    : undefined;
+  if (updateResult?.error) throw new Error(updateResult.error.message);
+}
+
+export interface SendOfflineConversionDeps {
+  supabase?: SupabaseLike;
+  config?: GoogleAdsConfig;
+  fetchImpl?: typeof fetch;
+  accessToken?: string;
+}
+
+export async function sendOfflineConversionUpload(
+  input: OfflineConversionInput & OfflineConversionTrace,
+  deps: SendOfflineConversionDeps = {},
+): Promise<SendOfflineUploadResult> {
+  const config = resolveGoogleAdsConfig(deps.config);
+
+  if (!input.gclid && !input.gbraid && !input.wbraid) {
+    return {
+      status: 'skipped',
+      conversionActionId: input.conversionActionId,
+      request: {
+        customerId: cleanString(config.customerId) ?? '',
+        conversions: [],
+        partialFailure: false,
+        validateOnly: false,
+      },
+      skippedReason: 'no_click_id',
+    };
+  }
+
+  const request = await buildOfflineConversionRequest(input, config);
+
+  if (!isGoogleAdsConfigured(config)) {
+    const skippedReason =
+      'Google Ads offline upload disabled or missing GOOGLE_ADS_DEVELOPER_TOKEN/CUSTOMER_ID';
+    if (deps.supabase && input.funnelEventId) {
+      try {
+        await insertOfflineUploadLog(
+          deps.supabase,
+          buildLogRow(input, request, 'skipped', { error: skippedReason }),
+        );
+      } catch (err) {
+        log.warn('log_insert_failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    return {
+      status: 'skipped',
+      conversionActionId: input.conversionActionId,
+      request,
+      skippedReason,
+    };
+  }
+
+  let deduped = false;
+  if (deps.supabase && input.funnelEventId) {
+    const inserted = await insertOfflineUploadLog(
+      deps.supabase,
+      buildLogRow(input, request, 'pending'),
+    );
+    deduped = inserted.deduped;
+    if (deduped) {
+      return {
+        status: 'skipped',
+        conversionActionId: input.conversionActionId,
+        request,
+        skippedReason: 'Duplicate Google Ads offline upload row',
+        deduped: true,
+      };
+    }
+  }
+
+  try {
+    const providerResponse = await sendOfflineUpload(
+      request,
+      config,
+      deps.fetchImpl ?? fetch,
+      deps.accessToken,
+    );
+    const status: GoogleAdsConversionStatus = providerResponse.ok ? 'sent' : 'failed';
+    if (deps.supabase && input.funnelEventId) {
+      await updateOfflineUploadLog(
+        deps.supabase,
+        input.funnelEventId,
+        input.conversionActionId,
+        {
+          status,
+          provider_response: providerResponse.body,
+          error: providerResponse.ok
+            ? null
+            : `Google Ads API returned HTTP ${providerResponse.status}`,
+          sent_at: providerResponse.ok ? new Date().toISOString() : null,
+        },
+      );
+    }
+    return {
+      status,
+      conversionActionId: input.conversionActionId,
+      request,
+      providerResponse,
+      deduped,
+      ...(providerResponse.ok
+        ? {}
+        : { error: `Google Ads API returned HTTP ${providerResponse.status}` }),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.warn('send_failed', {
+      conversion_action_id: input.conversionActionId,
+      error: message,
+    });
+    if (deps.supabase && input.funnelEventId) {
+      await updateOfflineUploadLog(
+        deps.supabase,
+        input.funnelEventId,
+        input.conversionActionId,
+        {
+          status: 'failed',
+          error: message,
+        },
+      );
+    }
+    return {
+      status: 'failed',
+      conversionActionId: input.conversionActionId,
+      request,
+      error: message,
+      deduped,
+    };
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  captureClickIds,
+  setClickIdsCookie,
+  type ClickIdSet,
+} from "@/lib/analytics/gclid-capture";
 import { refreshAuthSession } from "@/lib/supabase/middleware-client";
 import {
   PUBLIC_LOCALE_HEADER_NAMES,
@@ -712,10 +717,34 @@ function applySitePreviewHeaders(response: NextResponse): NextResponse {
   return response;
 }
 
+/**
+ * Persist captured Ads click identifiers (gclid/gbraid/wbraid/fbclid) on a
+ * public-site response. No-op when nothing was captured. Safe to call from
+ * any branch — the function early-returns when `clickIds` is empty so
+ * middleware paths that never see Ads traffic stay zero-cost.
+ *
+ * SPEC AC2.1 / EPIC #419 / [[ADR-029]] §"Attribution capture".
+ */
+function persistClickIdsOnResponse(
+  response: NextResponse,
+  clickIds: ClickIdSet,
+): NextResponse {
+  if (Object.keys(clickIds).length === 0) return response;
+  return setClickIdsCookie(response, clickIds);
+}
+
 export async function middleware(request: NextRequest) {
   const url = request.nextUrl;
   const host = getRequestHost(request);
   const pathname = url.pathname;
+
+  // Capture Ads click identifiers (gclid/gbraid/wbraid/fbclid) from URL
+  // params on every request. The cookie write is applied only to public-
+  // site branches via `persistClickIdsOnResponse` — API routes, dashboard,
+  // editor, auth pages, static assets and `/site/*` preview routes
+  // intentionally pass through without touching the cookie because they
+  // don't carry Ads landing traffic. SPEC AC2.1 / F2 (#421).
+  const capturedClickIds = captureClickIds(request);
 
   if (host === COLOMBIA_TOURS_EN_HOST) {
     return redirectColombiaToursEnSubdomain(request);
@@ -919,7 +948,7 @@ export async function middleware(request: NextRequest) {
   if (AI_CRAWLERS.some((bot) => userAgent.includes(bot))) {
     const response = NextResponse.next();
     response.headers.set("X-Robots-Tag", "index, follow");
-    return response;
+    return persistClickIdsOnResponse(response, capturedClickIds);
   }
   // === END BLOG SEO PIPELINE ===
 
@@ -940,7 +969,10 @@ export async function middleware(request: NextRequest) {
         null;
 
       if (!subdomain) {
-        return NextResponse.next();
+        return persistClickIdsOnResponse(
+          NextResponse.next(),
+          capturedClickIds,
+        );
       }
 
       const website = await getWebsiteBySubdomain(subdomain, {
@@ -960,7 +992,10 @@ export async function middleware(request: NextRequest) {
         localeResolution.pathnameWithoutLang,
       );
       if (legacyRedirectResponse) {
-        return legacyRedirectResponse;
+        return persistClickIdsOnResponse(
+          legacyRedirectResponse,
+          capturedClickIds,
+        );
       }
 
       const missingBlogResponse = await tryMissingBlogNotFound(
@@ -969,7 +1004,10 @@ export async function middleware(request: NextRequest) {
         localeResolution,
       );
       if (missingBlogResponse) {
-        return missingBlogResponse;
+        return persistClickIdsOnResponse(
+          missingBlogResponse,
+          capturedClickIds,
+        );
       }
 
       if (potentialProductRoute) {
@@ -982,23 +1020,26 @@ export async function middleware(request: NextRequest) {
             : localeResolution.resolvedLanguage,
         );
         if (redirectResponse) {
-          return redirectResponse;
+          return persistClickIdsOnResponse(redirectResponse, capturedClickIds);
         }
       }
 
       // Rewrite to tenant route
-      return applyLocaleAwareTenantRewrite({
-        request,
-        sourceUrl: url,
-        pathnameWithoutLang: localeResolution.pathnameWithoutLang,
-        canonicalPathname: localeResolution.canonicalPathname,
-        originalPathname: localeResolution.originalPathname,
-        subdomain,
-        resolvedLocale: localeResolution.resolvedLocale,
-        defaultLocale: localeResolution.defaultLocale,
-        resolvedLanguage: localeResolution.resolvedLanguage,
-        hasLanguageSegment: localeResolution.hasLanguageSegment,
-      });
+      return persistClickIdsOnResponse(
+        applyLocaleAwareTenantRewrite({
+          request,
+          sourceUrl: url,
+          pathnameWithoutLang: localeResolution.pathnameWithoutLang,
+          canonicalPathname: localeResolution.canonicalPathname,
+          originalPathname: localeResolution.originalPathname,
+          subdomain,
+          resolvedLocale: localeResolution.resolvedLocale,
+          defaultLocale: localeResolution.defaultLocale,
+          resolvedLanguage: localeResolution.resolvedLanguage,
+          hasLanguageSegment: localeResolution.hasLanguageSegment,
+        }),
+        capturedClickIds,
+      );
     }
 
     // Production Bukeer domain handling
@@ -1019,7 +1060,7 @@ export async function middleware(request: NextRequest) {
 
     // Check if subdomain is reserved
     if (RESERVED_SUBDOMAINS.includes(subdomain.toLowerCase())) {
-      return NextResponse.next();
+      return persistClickIdsOnResponse(NextResponse.next(), capturedClickIds);
     }
 
     const website = await getWebsiteBySubdomain(subdomain);
@@ -1037,7 +1078,10 @@ export async function middleware(request: NextRequest) {
       localeResolution.pathnameWithoutLang,
     );
     if (legacyRedirectResponse) {
-      return legacyRedirectResponse;
+      return persistClickIdsOnResponse(
+        legacyRedirectResponse,
+        capturedClickIds,
+      );
     }
 
     const missingBlogResponse = await tryMissingBlogNotFound(
@@ -1046,7 +1090,7 @@ export async function middleware(request: NextRequest) {
       localeResolution,
     );
     if (missingBlogResponse) {
-      return missingBlogResponse;
+      return persistClickIdsOnResponse(missingBlogResponse, capturedClickIds);
     }
 
     if (potentialProductRoute) {
@@ -1059,23 +1103,26 @@ export async function middleware(request: NextRequest) {
           : localeResolution.resolvedLanguage,
       );
       if (redirectResponse) {
-        return redirectResponse;
+        return persistClickIdsOnResponse(redirectResponse, capturedClickIds);
       }
     }
 
     // Rewrite to tenant route
-    return applyLocaleAwareTenantRewrite({
-      request,
-      sourceUrl: url,
-      pathnameWithoutLang: localeResolution.pathnameWithoutLang,
-      canonicalPathname: localeResolution.canonicalPathname,
-      originalPathname: localeResolution.originalPathname,
-      subdomain,
-      resolvedLocale: localeResolution.resolvedLocale,
-      defaultLocale: localeResolution.defaultLocale,
-      resolvedLanguage: localeResolution.resolvedLanguage,
-      hasLanguageSegment: localeResolution.hasLanguageSegment,
-    });
+    return persistClickIdsOnResponse(
+      applyLocaleAwareTenantRewrite({
+        request,
+        sourceUrl: url,
+        pathnameWithoutLang: localeResolution.pathnameWithoutLang,
+        canonicalPathname: localeResolution.canonicalPathname,
+        originalPathname: localeResolution.originalPathname,
+        subdomain,
+        resolvedLocale: localeResolution.resolvedLocale,
+        defaultLocale: localeResolution.defaultLocale,
+        resolvedLanguage: localeResolution.resolvedLanguage,
+        hasLanguageSegment: localeResolution.hasLanguageSegment,
+      }),
+      capturedClickIds,
+    );
   } else {
     let website = await getWebsiteByCustomDomain(host);
 
@@ -1105,7 +1152,10 @@ export async function middleware(request: NextRequest) {
       localeResolution.pathnameWithoutLang,
     );
     if (legacyRedirectResponse) {
-      return legacyRedirectResponse;
+      return persistClickIdsOnResponse(
+        legacyRedirectResponse,
+        capturedClickIds,
+      );
     }
 
     const missingBlogResponse = await tryMissingBlogNotFound(
@@ -1114,7 +1164,7 @@ export async function middleware(request: NextRequest) {
       localeResolution,
     );
     if (missingBlogResponse) {
-      return missingBlogResponse;
+      return persistClickIdsOnResponse(missingBlogResponse, capturedClickIds);
     }
 
     if (potentialProductRoute) {
@@ -1127,26 +1177,29 @@ export async function middleware(request: NextRequest) {
           : localeResolution.resolvedLanguage,
       );
       if (redirectResponse) {
-        return redirectResponse;
+        return persistClickIdsOnResponse(redirectResponse, capturedClickIds);
       }
     }
 
     // Prefer the stable tenant pipeline for verified custom domains.
     // This avoids custom-domain-specific rendering divergence in Worker runtime.
     if (website?.subdomain) {
-      return applyLocaleAwareTenantRewrite({
-        request,
-        sourceUrl: url,
-        pathnameWithoutLang: localeResolution.pathnameWithoutLang,
-        canonicalPathname: localeResolution.canonicalPathname,
-        originalPathname: localeResolution.originalPathname,
-        subdomain: website.subdomain,
-        host,
-        resolvedLocale: localeResolution.resolvedLocale,
-        defaultLocale: localeResolution.defaultLocale,
-        resolvedLanguage: localeResolution.resolvedLanguage,
-        hasLanguageSegment: localeResolution.hasLanguageSegment,
-      });
+      return persistClickIdsOnResponse(
+        applyLocaleAwareTenantRewrite({
+          request,
+          sourceUrl: url,
+          pathnameWithoutLang: localeResolution.pathnameWithoutLang,
+          canonicalPathname: localeResolution.canonicalPathname,
+          originalPathname: localeResolution.originalPathname,
+          subdomain: website.subdomain,
+          host,
+          resolvedLocale: localeResolution.resolvedLocale,
+          defaultLocale: localeResolution.defaultLocale,
+          resolvedLanguage: localeResolution.resolvedLanguage,
+          hasLanguageSegment: localeResolution.hasLanguageSegment,
+        }),
+        capturedClickIds,
+      );
     }
 
     // Custom domain (e.g., miagencia.com)
@@ -1155,7 +1208,7 @@ export async function middleware(request: NextRequest) {
     newUrl.pathname = `/domain/${encodeURIComponent(host)}${pathname}`;
     const response = NextResponse.rewrite(newUrl);
     response.headers.set("x-custom-domain", host);
-    return response;
+    return persistClickIdsOnResponse(response, capturedClickIds);
   }
 }
 

--- a/supabase/migrations/20260503120100_event_destination_mapping.sql
+++ b/supabase/migrations/20260503120100_event_destination_mapping.sql
@@ -146,7 +146,7 @@ values
   ('waflow_submit', 'meta', 'Lead', null, true,
    'Today: routed via app/api/waflow/lead + lib/meta/conversions-api. F1 cutover migrates this to dispatcher.'),
   ('waflow_submit', 'google_ads', 'waflow_submit', null, true,
-   'NEW conversion action — created in Google Ads UI per AC2.2. Phase 2 (#332).'),
+   'NEW conversion action — created in Google Ads UI per AC2.2. F2 (#421). The numeric conversion_action_id MUST be stored in tenant_overrides (see column comment + lib/funnel/destinations/google-ads.ts). Until then the dispatcher returns status="skipped" reason="missing_conversion_action_id".'),
   ('waflow_submit', 'ga4', 'generate_lead', null, true, null),
   ('waflow_submit', 'tiktok', 'SubmitForm', null, false,
    'Disabled until TikTok pixel id is configured per tenant.'),
@@ -154,7 +154,7 @@ values
   -- quote_form_submit (Lead)
   ('quote_form_submit', 'meta', 'Lead', null, true, null),
   ('quote_form_submit', 'google_ads', 'quote_form_submit', null, true,
-   'NEW conversion action. Phase 2 (#332).'),
+   'NEW conversion action. F2 (#421). Per-tenant conversion_action_id stored in tenant_overrides.'),
   ('quote_form_submit', 'ga4', 'generate_lead', null, true, null),
   ('quote_form_submit', 'tiktok', 'SubmitForm', null, false, null),
 
@@ -169,21 +169,21 @@ values
   -- chatwoot_label_qualified (Qualify)
   ('chatwoot_label_qualified', 'meta_messaging', 'Lead', null, true, null),
   ('chatwoot_label_qualified', 'google_ads', 'qualified_lead', null, true,
-   'NEW conversion action. Replaces the broken lead_calificado_form action.'),
+   'NEW conversion action. Replaces the broken lead_calificado_form action. F2 (#421). Per-tenant conversion_action_id stored in tenant_overrides.'),
   ('chatwoot_label_qualified', 'ga4', 'qualify_lead', null, true, null),
 
   -- crm_lead_stage_qualified (Qualify) — Flutter-originated
   ('crm_lead_stage_qualified', 'meta', 'Lead', null, true,
    'Custom event: Meta Lead from website action_source even though origin is CRM (no messaging context).'),
   ('crm_lead_stage_qualified', 'google_ads', 'qualified_lead', null, true,
-   'Same Google Ads conversion action as chatwoot_label_qualified — Google dedupes by gclid+action+time.'),
+   'Same Google Ads conversion action as chatwoot_label_qualified — Google dedupes by gclid+action+time. F2 (#421). Per-tenant conversion_action_id stored in tenant_overrides.'),
   ('crm_lead_stage_qualified', 'ga4', 'qualify_lead', null, true, null),
 
   -- crm_quote_sent (Quote)
   ('crm_quote_sent', 'meta', 'InitiateCheckout', null, true,
    'Custom event mapped to InitiateCheckout to capture mid-funnel intent in Meta funnel reports.'),
   ('crm_quote_sent', 'google_ads', 'quote_sent', null, true,
-   'NEW conversion action. Phase 3 (#327).'),
+   'NEW conversion action. F2 (#421). Per-tenant conversion_action_id stored in tenant_overrides.'),
   ('crm_quote_sent', 'ga4', 'begin_checkout', null, true, null),
 
   -- crm_booking_confirmed (Booking) — sign-off 2026-05-03
@@ -214,4 +214,28 @@ comment on column public.event_destination_mapping.destination is
 comment on column public.event_destination_mapping.value_field is
   'Column from funnel_events to use as conversion value (currently only value_amount supported). NULL = event has no monetary value.';
 comment on column public.event_destination_mapping.tenant_overrides is
-  'Per-tenant config: { "<account_id>": { "destination_event_name": "...", "enabled": false } }. Phase 4 AC4.4.';
+  $cmt$Per-tenant config keyed by account_id (UUID). Schema:
+  {
+    "<account_id>": {
+      "conversion_action_id": "987654321",            -- google_ads only
+      "destination_event_name": "custom_lead_event",  -- override the default event name
+      "enabled": false                                -- hard-disable for this tenant
+    }
+  }
+  Phase 4 AC4.4. For destination='google_ads' the conversion_action_id is REQUIRED
+  per tenant — otherwise the dispatcher returns status='skipped'
+  reason='missing_conversion_action_id' and logs a warning.
+  See lib/funnel/destinations/google-ads.ts for resolution logic.$cmt$;
+
+-- Example tenant_overrides (idempotent, no-op if account_id doesn't exist):
+-- Uncomment and replace placeholders to wire ColombiaTours per-tenant ids.
+--
+-- update public.event_destination_mapping
+-- set tenant_overrides = jsonb_set(
+--   coalesce(tenant_overrides, '{}'::jsonb),
+--   ARRAY['<colombiatours_account_id_uuid>'],
+--   '{"conversion_action_id": "<numeric_id_from_google_ads_ui>"}'::jsonb,
+--   true
+-- )
+-- where destination = 'google_ads'
+--   and funnel_event_name in ('waflow_submit', 'qualified_lead', 'quote_sent', 'crm_booking_confirmed');

--- a/supabase/migrations/20260503140000_google_ads_offline_uploads.sql
+++ b/supabase/migrations/20260503140000_google_ads_offline_uploads.sql
@@ -1,0 +1,167 @@
+-- ============================================================================
+-- google_ads_offline_uploads — idempotent log of Google Ads conversion uploads
+-- F2 / EPIC #419 — SPEC §AC2.3
+-- ============================================================================
+-- Purpose:
+--   Stores server-side Google Ads Conversions Upload API attempts. The unique
+--   constraint on (funnel_event_id, conversion_action_id) prevents duplicate
+--   uploads across retries — Google Ads itself dedupes by gclid+action+time
+--   but logging dedupe avoids hammering the API on retries.
+--
+--   Mirrors the shape of public.meta_conversion_events (#324) so dashboards
+--   can union the two tables for cross-platform conversion-pipeline views.
+--
+-- Safety:
+--   - Additive, forward-only migration. No data backfill.
+--   - RLS service-role only for v1; tenant-scoped read added when monitoring
+--     dashboards land (Phase 4).
+--   - Provider responses are expected to be redacted by application code
+--     (lib/google-ads/offline-upload.ts → redactGoogleAdsProviderResponse).
+-- ============================================================================
+
+create table if not exists public.google_ads_offline_uploads (
+  id uuid primary key default gen_random_uuid(),
+  provider text not null default 'google_ads',
+  account_id uuid references public.accounts(id) on delete set null,
+  website_id uuid references public.websites(id) on delete set null,
+  -- funnel_event_id is the canonical event_id (sha256 hex) from
+  -- public.funnel_events. Foreign key intentionally OMITTED so the dispatcher
+  -- can write the log even if funnel_events insert is contended/concurrent
+  -- (we tolerate orphan rows over blocking the pipeline). The FK can be
+  -- added later as a follow-up once F1 has stabilized.
+  funnel_event_id text,
+  booking_id uuid,
+  conversion_action_id text not null,
+  gclid text,
+  gbraid text,
+  wbraid text,
+  conversion_value numeric,
+  currency_code text,
+  conversion_date_time timestamptz not null,
+  status text not null default 'pending',
+  retry_count integer not null default 0,
+  request_payload jsonb not null default '{}'::jsonb,
+  provider_response jsonb,
+  error text,
+  trace jsonb not null default '{}'::jsonb,
+  sent_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint google_ads_offline_uploads_provider_check
+    check (provider = 'google_ads'),
+  constraint google_ads_offline_uploads_status_check
+    check (status in ('pending', 'sent', 'failed', 'skipped')),
+  constraint google_ads_offline_uploads_retry_count_check
+    check (retry_count >= 0),
+  -- At least one click identifier when the row is real. Skipped rows
+  -- (no_click_id) are still logged for observability so the constraint is
+  -- relaxed when status='skipped'.
+  constraint google_ads_offline_uploads_click_id_present
+    check (
+      status = 'skipped'
+      or (gclid is not null or gbraid is not null or wbraid is not null)
+    ),
+  -- Idempotency: one row per (funnel event × conversion action). Allows
+  -- retries to reuse the row via UPDATE rather than insert duplicates.
+  constraint google_ads_offline_uploads_event_action_unique
+    unique (funnel_event_id, conversion_action_id)
+);
+
+create index if not exists google_ads_offline_uploads_account_created_idx
+  on public.google_ads_offline_uploads(account_id, created_at desc)
+  where account_id is not null;
+
+create index if not exists google_ads_offline_uploads_website_created_idx
+  on public.google_ads_offline_uploads(website_id, created_at desc)
+  where website_id is not null;
+
+create index if not exists google_ads_offline_uploads_status_idx
+  on public.google_ads_offline_uploads(status, created_at desc)
+  where status <> 'sent';
+
+create index if not exists google_ads_offline_uploads_gclid_idx
+  on public.google_ads_offline_uploads(gclid)
+  where gclid is not null;
+
+create index if not exists google_ads_offline_uploads_trace_gin_idx
+  on public.google_ads_offline_uploads using gin(trace);
+
+alter table public.google_ads_offline_uploads enable row level security;
+
+-- Service-role only for writes + reads (v1). Tenant-scoped read policy will
+-- be added when admin dashboards consume this surface (Phase 4 / SPEC AC4.x).
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'google_ads_offline_uploads'
+      and policyname = 'google_ads_offline_uploads_service_all'
+  ) then
+    create policy google_ads_offline_uploads_service_all
+      on public.google_ads_offline_uploads
+      for all
+      using (auth.role() = 'service_role')
+      with check (auth.role() = 'service_role');
+  end if;
+end$$;
+
+-- Tenant-scoped SELECT for authenticated users on rows belonging to their
+-- account. Mirrors the future read surface used by funnel monitoring
+-- dashboards. Safe to add now: no PII, no destructive operations exposed.
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'google_ads_offline_uploads'
+      and policyname = 'google_ads_offline_uploads_tenant_read'
+  ) then
+    create policy google_ads_offline_uploads_tenant_read
+      on public.google_ads_offline_uploads
+      for select
+      using (
+        account_id is not null
+        and exists (
+          select 1
+          from public.account_users au
+          where au.account_id = public.google_ads_offline_uploads.account_id
+            and au.user_id = auth.uid()
+        )
+      );
+  end if;
+exception
+  when undefined_table then
+    -- account_users table not present in this branch; skip the tenant
+    -- read policy — service_role still works.
+    null;
+end$$;
+
+create or replace function public.touch_google_ads_offline_uploads_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_google_ads_offline_uploads_updated_at
+  on public.google_ads_offline_uploads;
+create trigger trg_google_ads_offline_uploads_updated_at
+before update on public.google_ads_offline_uploads
+for each row execute function public.touch_google_ads_offline_uploads_updated_at();
+
+comment on table public.google_ads_offline_uploads is
+  'Server-side Google Ads Conversions Upload API attempts and idempotency ledger. F2 / EPIC #419.';
+comment on column public.google_ads_offline_uploads.funnel_event_id is
+  'sha256 hex event_id from public.funnel_events. FK intentionally omitted (see migration header).';
+comment on column public.google_ads_offline_uploads.conversion_action_id is
+  'Numeric/string id of the conversion_action created in the Google Ads UI (per SPEC AC2.2). The dispatcher reads this from event_destination_mapping.tenant_overrides keyed by account_id.';
+comment on column public.google_ads_offline_uploads.request_payload is
+  'Conversions Upload API request body after hashing user_identifiers. Service-role only.';
+comment on column public.google_ads_offline_uploads.provider_response is
+  'Redacted Google Ads API response body.';

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -109,3 +109,34 @@ NEXT_PUBLIC_MAIN_DOMAIN = "bukeer.com"
 [[env.dev.routes]]
 pattern = "dev.studio.bukeer.com/*"
 zone_name = "bukeer.com"
+
+# ── Production secrets (set via `wrangler secret put`) ─────────────────────
+#
+# DO NOT commit secret VALUES to this file. The list below documents the
+# secrets each environment requires so deployers know what to provision.
+#
+# Existing secrets:
+#   wrangler secret put NEXT_PUBLIC_SUPABASE_URL
+#   wrangler secret put NEXT_PUBLIC_SUPABASE_ANON_KEY
+#   wrangler secret put SUPABASE_SERVICE_ROLE_KEY
+#   wrangler secret put OPENROUTER_AUTH_TOKEN
+#   wrangler secret put REVALIDATE_SECRET
+#   wrangler secret put SITE_PREVIEW_TOKEN
+#   wrangler secret put META_PIXEL_ID
+#   wrangler secret put META_ACCESS_TOKEN
+#   wrangler secret put CHATWOOT_WEBHOOK_SECRET
+#   wrangler secret put CHATWOOT_API_ACCESS_TOKEN
+#   wrangler secret put CRM_CONVERSION_WEBHOOK_SECRET
+#
+# F2 / EPIC #419 — Google Ads offline conversion upload secrets:
+#   wrangler secret put GOOGLE_ADS_OFFLINE_UPLOAD_ENABLED   # 'true' to flip on
+#   wrangler secret put GOOGLE_ADS_DEVELOPER_TOKEN
+#   wrangler secret put GOOGLE_ADS_LOGIN_CUSTOMER_ID        # MCC parent (digits only)
+#   wrangler secret put GOOGLE_ADS_CUSTOMER_ID              # owns conversion actions
+#   wrangler secret put GOOGLE_ADS_AUTH_TYPE                # 'service_account' (default)
+#   wrangler secret put GOOGLE_ADS_CREDENTIALS_PATH         # service-account JSON path
+#   # GOOGLE_ADS_API_VERSION can be a [vars] entry (non-secret); defaults to v18.
+#
+# Per SPEC AC2.2 conversion actions must exist in the Google Ads UI before the
+# OFFLINE_UPLOAD_ENABLED flag is flipped to 'true', and per-tenant
+# conversion_action_ids must be populated in event_destination_mapping.tenant_overrides.


### PR DESCRIPTION
## Summary

F2 of EPIC #419 — adds Google Ads as a destination in the funnel events
dispatcher. Implements the offline conversion upload client, dispatcher
branch, gclid/gbraid/wbraid/fbclid capture in middleware, and the
idempotent log table. Real Google Ads API call is intentionally **stubbed**
behind a `TODO[F2-followup]` marker — the full structure (hashing,
idempotent log, retry) is implemented and tested with mocked fetch but
the OAuth/service-account exchange is not exercised in this session
because no developer token was available to validate against.

## AC checklist (mapped to SPEC §Phase 2)

- [x] **AC2.1** gclid/gbraid/wbraid (+ fbclid) capture — `captureClickIds` + `setClickIdsCookie` in `lib/analytics/gclid-capture.ts`, wired into `middleware.ts` for every public-site response (skips api/dashboard/editor/auth/static/site-preview routes)
- [ ] **AC2.2** conversion actions created in Google Ads UI — **manual step required by assignee**, see §Manual setup
- [x] **AC2.3** `google_ads_offline_uploads` log table + dispatcher branch — `supabase/migrations/20260503140000_google_ads_offline_uploads.sql` + `lib/funnel/destinations/google-ads.ts` + `lib/google-ads/offline-upload.ts`
- [ ] **AC2.4** legacy GA4-imported actions reclassified — **manual step in Google Ads UI**, see §Manual setup
- [ ] **AC2.5** Smart Bidding strategies pointed to new conversions — **manual step**
- [ ] **AC2.6** E2E test with real gclid — depends on F1 merge + Google Ads account setup; **post-merge validation**

## Files added / modified

**New:**
- `lib/google-ads/offline-upload.ts` — Conversions Upload API client (sha256 hashing, request builder, idempotent log writes, redaction). Real fetch is stubbed pending dev token.
- `lib/funnel/destinations/google-ads.ts` — `dispatchToGoogleAds(event, mapping)` consumed by F1.
- `lib/analytics/gclid-capture.ts` — extends existing browser helpers with edge `captureClickIds`/`setClickIdsCookie`/`getStoredClickIds`.
- `supabase/migrations/20260503140000_google_ads_offline_uploads.sql` — log table mirroring `meta_conversion_events` shape.
- `__tests__/lib/analytics/gclid-capture.test.ts` (10 tests)
- `__tests__/lib/google-ads/offline-upload.test.ts` (12 tests)
- `__tests__/lib/funnel/destinations/google-ads.test.ts` (6 tests)

**Modified:**
- `middleware.ts` — captures click ids early, stamps cookie on every public-site response.
- `supabase/migrations/20260503120100_event_destination_mapping.sql` — updated notes for waflow_submit / quote_form_submit / qualified_lead / quote_sent google_ads rows; documented `tenant_overrides` shape (no change to `crm_booking_confirmed` rows — F3's territory).
- `.dev.vars.example`, `.env.local.example`, `wrangler.toml` — `GOOGLE_ADS_*` env var documentation + `wrangler secret put` checklist.

## Manual setup required by assignee before merging to prod

1. **Create conversion actions in Google Ads UI** (per SPEC AC2.2):
   - `waflow_submit`, `quote_form_submit`, `qualified_lead`, `quote_sent`, `booking_confirmed` (with `value_settings = total_markup` `currency = COP` for `booking_confirmed`).
   - Mark all as `primary=true`, `include_in_conversions_metric=true`.
2. **Reclassify legacy actions** (per SPEC AC2.4):
   - `ColombiaTours - GA4 (web) envio_formulario`, `form_submit`, `lead_calificado_form` → `primary=false`, `include_in_conversions_metric=false`.
3. **Smart Bidding** (per SPEC AC2.5): point reactivated campaigns at the new `waflow_submit` + `booking_confirmed` actions.
4. **Populate `event_destination_mapping.tenant_overrides`** with the new conversion_action_ids (one row per ColombiaTours account_id × event). See the commented example block at the bottom of `20260503120100_event_destination_mapping.sql`.
5. **Wrangler secrets**: `wrangler secret put GOOGLE_ADS_*` for each env var listed in `.dev.vars.example`. See the `wrangler.toml` secret-list comment.
6. Flip `GOOGLE_ADS_OFFLINE_UPLOAD_ENABLED=true` only AFTER steps 1+4 are complete; otherwise the dispatcher logs `status='skipped' reason='missing_conversion_action_id'` (visible in `google_ads_offline_uploads` table).

## Tests

- `npx tsc --noEmit` — clean.
- `npx jest __tests__/lib/analytics/gclid-capture.test.ts __tests__/lib/google-ads/offline-upload.test.ts __tests__/lib/funnel/destinations/google-ads.test.ts` — **28 passed**:
  - URL parse (4 tests)
  - cookie roundtrip + max-age + override behaviour (5 tests)
  - hashing (email lowercased, phone E.164, address grouped) (3 tests)
  - request shape + customer-resource path (2 tests)
  - config + redaction (2 tests)
  - mock fetch — sent / failed / skipped / no-token-stub branches (4 tests)
  - dispatcher: missing click id, missing tenant override, mapping disabled, gclid happy path, value passthrough (5 tests)
  - exposed internals (3 tests)

The broader suite has 14 pre-existing failures (CSS imports in component tests) that are unrelated to this PR.

## Stubbed code (TODO markers)

- `lib/google-ads/offline-upload.ts` `sendOfflineUpload(...)` — `// TODO[F2-followup]: real Google Ads API integration pending dev token + auth validation.` Without an `accessToken` the client logs and returns a synthetic 202 stub response. With an accessToken (production wiring) it fully constructs and POSTs the real API request. The OAuth/JWT exchange to obtain that token is the only piece left for a follow-up PR.

## Open questions for human reviewer

1. **`funnel_event_id` foreign key** — I left it as a free-form `text` column with no FK to `funnel_events.event_id` so the dispatcher can write the log even if F1's insert is concurrently in flight. F1's PR may want to enforce the FK once the pipeline is stable; flag if you want it added now.
2. **`tenant_overrides` lookup vs. ENV fallback** — currently the dispatcher returns `skipped/missing_conversion_action_id` when a tenant has no override. Should I also support a global `GOOGLE_ADS_DEFAULT_CONVERSION_ACTION_ID_<EVENT>` env var as a single-tenant fallback (useful for staging), or keep it strict-per-tenant?
3. **AI crawler branch persisting cookies** — the AI-crawler branch in `middleware.ts` now also calls `persistClickIdsOnResponse`. Crawlers shouldn't carry `gclid` so this is a no-op in practice, but the call adds a (tiny) header. Acceptable, or skip for crawler UAs?

## Constraints honoured

- DID NOT apply migrations to live DB.
- DID NOT call the real Google Ads API (no dev token validation).
- DID NOT modify F1 files (`record_funnel_event` RPC, dispatch-funnel-event Edge Function, `lib/funnel/dispatch.ts`).
- DID NOT modify F3 files (`crm_booking_confirmed` trigger, `value=total_markup` logic, the `crm_booking_confirmed` row in the mapping seed).
- DID NOT touch `lib/meta/*`.
- DID NOT change ADR-029, SPEC, or DIFF docs.

Closes #421
Supersedes #332