### PR TITLE
Add learning loop to Bukeer Studio development pipeline

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -11,6 +11,8 @@ Last updated: 2026-05-08 (SPEC_GROWTH_OS_AUTONOMOUS_PRODUCTION_OPERATING_SYSTEM 
 
 Latest update: 2026-05-01 (SPEC_GROWTH_OS_SYMPHONY_ORCHESTRATOR audit revision for #310: contract-first gate added with five Zod schemas, SSOT relationship vs growth_profile_runs / Unified Backlog formalised, lane-level autonomy semantics tightened, sprint scope clarified — Symphony OPERATIONAL ≠ #310 PASS, #256 interlock and ADR matrix added; child issues #402–#409 received labels and TVBs); 2026-05-01 (SPEC_GROWTH_OS_SYMPHONY_ORCHESTRATOR added for #310: multi-tenant Supabase/Bukeer control plane, VPS Docker runtime, agent definitions/tool permissions/context packs, Growth UI contract and opt-in E2E); 2026-05-01 (WAFlow reference-first E2E for #310/#322: missing-ref guardrail PASS, two references in one Chatwoot conversation create two CRM requests, legacy `waflow_leads.chatwoot_conversation_id` unique index moved to WATCH with Flutter/SSOT migration prepared); 2026-05-01 (SPEC_GROWTH_OS_AGENT_LANES added for #310: five core Growth OS agent lanes, blocked routing, transcreation/content separation and Council governance); 2026-05-01 (SPEC_GROWTH_OS_SSOT_MODEL added for #310: GitHub is implementation SSOT, Supabase/Bukeer Studio is operational Growth SSOT).
 
+Latest spec addition: 2026-05-14 - [[github-542-learning-loop-20260514-SPEC]] defines GitHub #542: add T6 learning-curator to the development Kanban pipeline, learning-run docs/templates/schema, memory boundaries, task metadata contracts, and Villa de Leyva backfill handling.
+
 Latest spec addition: 2026-05-14 - [[SPEC_GROWTH_OS_PROVIDER_PROFILE_ARCHITECTURE_V2]] redirects Epic #521 into the Neo/Hermes Provider Profile Beta: GitHub remains planning SSOT, Supabase remains operational SSOT, Neo/Hermes acts as architect-orchestrator, provider profiles own API access, workers consume context packets/facts, and paid media profiles enter the same read-only/freshness-governed architecture.
 
 Latest audit addition: 2026-05-14 - [[AUDIT_GROWTH_OS_PROVIDER_PROFILE_REGISTRY_MAP_2026-05]] maps the current provider-profile registry for #536: 45 profiles across DataForSEO/GSC/GA4/tracking/joint plus Clarity and paid-media WATCH/BLOCKED gaps, with no provider API calls and credential redaction.
@@ -96,6 +98,7 @@ All ADRs accepted unless noted. Cross-cut by Principles P1–P10 (see [[ARCHITEC
 | [[ADR-025]] | [ADR-025](./architecture/ADR-025-studio-flutter-field-ownership.md)                    | Studio / Flutter Field Ownership Boundary (**Accepted 2026-04-19** — pkg+act Studio-editable, hotels Flutter-owner; Option A RPC expansion + activities parity) | [[studio-editor-v2]] [[package-kits]] [[pilot-readiness]] [[studio-editor-parity-audit]] |
 | [[ADR-028]] | [ADR-028](./architecture/ADR-028-media-assets-canonical-registry.md)                   | Media Assets Canonical Registry                                                                                                                                 | [[media-assets]] [[storage]] [[cross-repo-flutter]]                                      |
 | [[ADR-029]] | [ADR-029](./architecture/ADR-029-funnel-events-source-of-truth.md)                     | Funnel Events as Source of Truth (**Proposed 2026-05-03** — `funnel_events` table = SOT, single dispatcher fans out to Meta/Ads/GA4/TikTok)                     | [[funnel-events]] [[SOT]] [[tracking]] [[Meta CAPI]] [[Google Ads]] [[GA4]]              |
+| [[ADR-030]] | [ADR-030](./architecture/ADR-030-dev-pipeline-self-learning.md)                       | Development pipeline self-learning and memory boundaries                                                                                                         | [[dev-pipeline-learning-loop]] [[learning-loop]] [[Kanban]] [[Hermes]] [[quality-gate]] |
 
 > **Note:** `ADR-022` and `ADR-032` referenced in specs are anchored in `weppa-cloud/bukeer-flutter`. Studio respects them but does not own them. See [[cross-repo-flutter]].
 
@@ -142,6 +145,7 @@ Feature requests formalized. Status tracked inline. GitHub Issues = source of tr
 | [[SPEC_GROWTH_OS_HERMES_AGENT_CONTEXT_ISOLATION_9]]       | [file](./specs/SPEC_GROWTH_OS_HERMES_AGENT_CONTEXT_ISOLATION_9.md)       | [[growth-os]] [[agents]] [[Hermes]] [[skills]] [[memory]] [[context-isolation]] [[learning-loop]] [[multi-tenant]] [[ColombiaTours]]                              |
 | [[SPEC_GROWTH_OS_HERMES_PRIMARY_RUNTIME_MVE_V0]]           | [file](./specs/SPEC_GROWTH_OS_HERMES_PRIMARY_RUNTIME_MVE_V0.md)           | [[growth-os]] [[agents]] [[Hermes]] [[hermes-primary-runtime]] [[Kanban]] [[mcp-tool-safety]] [[provider-context-profiles]] [[tenant-context]] [[autonomy]] [[ColombiaTours]] |
 | [[SPEC_GROWTH_OS_PROVIDER_PROFILE_ARCHITECTURE_V2]]        | [file](./specs/SPEC_GROWTH_OS_PROVIDER_PROFILE_ARCHITECTURE_V2.md)        | [[growth-os]] [[provider-profiles]] [[Hermes]] [[Neo]] [[Supabase]] [[SSOT]] [[paid-media]] [[context-packets]] [[anti-rework]] [[ColombiaTours]]                  |
+| [[github-542-learning-loop-20260514-SPEC]]                 | [file](./specs/generated/github-542-learning-loop-20260514-SPEC.md)        | [[dev-pipeline-learning-loop]] [[Kanban]] [[Hermes]] [[learning-loop]] [[quality-gate]] [[GitHub]]                                                              |
 | [[SPEC_GROWTH_OS_DATAFORSEO_EVIDENCE_GOVERNED_BRAIN]]     | [file](./specs/SPEC_GROWTH_OS_DATAFORSEO_EVIDENCE_GOVERNED_BRAIN.md)     | [[growth-os]] [[agents]] [[DataForSEO]] [[orchestration]] [[evidence]] [[learning-loop]] [[ColombiaTours]]                                                       |
 | [[SPEC_GROWTH_OS_PROVIDER_EXTRACTION_PROFILES]]            | [file](./specs/SPEC_GROWTH_OS_PROVIDER_EXTRACTION_PROFILES.md)            | [[growth-os]] [[DataForSEO]] [[GA4]] [[GSC]] [[clarity]] [[provider-profiles]] [[evidence]] [[ColombiaTours]]                                                     |
 | [[SPEC_FUNNEL_EVENTS_SOT]]                                | [file](./specs/SPEC_FUNNEL_EVENTS_SOT.md)                                | [[funnel-events]] [[SOT]] [[tracking]] [[Meta CAPI]] [[Google Ads]] [[GA4]] [[cross-repo-flutter]] — operational counterpart to [[ADR-029]]                     |
@@ -159,6 +163,23 @@ Feature requests formalized. Status tracked inline. GitHub Issues = source of tr
 | [[ROADMAP_SEO_CONTENT_INTELLIGENCE]]                      | [file](./specs/ROADMAP_SEO_CONTENT_INTELLIGENCE.md)                      | [[SEO]] [[roadmap]]                                                                                                                                             |
 
 ---
+
+## AI development learning
+
+| Wikilink | File | Purpose |
+| --- | --- | --- |
+| [[ai-learning-runs]] | [file](./ai/learning-runs/README.md) | T6 learning-run policy, three memory layers, redaction rules, and schema entry point. |
+| [[learning-run-template]] | [file](./ai/templates/learning-run-template.md) | Standard template for T6 learning summaries. |
+| [[learning-run-index-schema]] | [file](./ai/learning-runs/index.schema.json) | JSON Schema for learning-run index/frontmatter contracts. |
+| [[ai-development-patterns]] | [file](./ai/patterns/README.md) | Reviewed institutional pattern docs and candidate routing boundaries. |
+| [[villa-leyva-learning-run-2026-05-14]] | [file](./ai/learning-runs/2026-05-14-villa-leyva-dev-20260514b.md) | First manual learning-run backfill example for the Villa de Leyva destination bug. |
+
+### [[dev-pipeline-learning-loop]] + [[learning-loop]]
+
+- [[ADR-030]] defines the decision to add T6 learning-curator and memory boundaries.
+- [[development-kanban-pipeline]] documents the operational T0→T6 DAG and retry invariant.
+- [[github-542-learning-loop-20260514-SPEC]] is the executable implementation spec for GitHub #542.
+- [[ai-learning-runs]], [[learning-run-template]], [[learning-run-index-schema]], and [[ai-development-patterns]] define curated learning artifacts and routing rules.
 
 ## Product
 
@@ -212,6 +233,7 @@ Feature requests formalized. Status tracked inline. GitHub Issues = source of tr
 | [[clarity-mcp]]                          | [file](./ops/clarity-mcp.md)                          | Official Microsoft Clarity MCP setup: `.mcp.json`, `.env.mcp`, API token, quota limits, Data Export fallback and ColombiaTours project config.           |
 | [[clarity-operations]]                   | [file](../ops/clarity/README.md)                      | Clarity operational standard matching Meta/Google: tenant iterations, local setup, read-only UX analysis and privacy guardrails.                         |
 | [[product-landing-rollout-runbook]]      | [file](./runbooks/product-landing-rollout-runbook.md) | Rollout for public site rendering / ISR changes.                                                                                                        |
+| [[development-kanban-pipeline]]          | [file](./ops/development-kanban-pipeline.md)          | T0→T6 Hermes/Kanban development DAG, Codex runner contract, gates, retry invariant, and learning-curator handoff.                                      |
 
 ---
 

--- a/docs/ai/learning-runs/2026-05-14-villa-leyva-dev-20260514b.md
+++ b/docs/ai/learning-runs/2026-05-14-villa-leyva-dev-20260514b.md
@@ -1,0 +1,65 @@
+# Learning run — Villa de Leyva destination bug
+
+- GitHub issue: n/a (Kanban pipeline bugfix run)
+- Pipeline ID: villa-leyva-dev-20260514b
+- Date: 2026-05-14
+- Branch: feat/fix-villa-de-leyva-destination-bug
+- PR: n/a at time of learning backfill
+- Commits: 9da792d7
+- Task IDs: t_9a3252f6
+- ADR refs: ADR-003, ADR-005, ADR-010, ADR-013, ADR-014, ADR-023
+- Spec refs: docs/specs/generated/villa-leyva-dev-20260514b-SPEC.md
+
+## Outcome
+
+PASS: implementation committed canonical destination alias handling for Villa de Leyva, including the common `Villa de Leiva` typo, without persisting raw Supabase credentials or raw logs.
+
+## Evidence links
+
+- Kanban task: t_9a3252f6
+- Commit: 9da792d7
+- Branch: feat/fix-villa-de-leyva-destination-bug
+- Spec: docs/specs/generated/villa-leyva-dev-20260514b-SPEC.md
+
+## Commands and gates
+
+Summaries only. The run reported code fallback implementation and validation evidence through Kanban handoff; this backfill does not duplicate raw logs.
+
+| Gate/command | Result | Evidence |
+| --- | --- | --- |
+| T2 implementation | PASS | t_9a3252f6 summary and commit 9da792d7 |
+| Redaction check | PASS | No credentials, tokens, raw env values, cookies, raw PII, or full logs copied here |
+
+## Failures and retries
+
+The destination bug was rooted in name/slug mismatch and the need for canonical alias handling. No secret-bearing diagnostic output is persisted in this learning document.
+
+## Reusable patterns
+
+- Destination source of truth is dynamic RPC/content from `websites.featured_products`, not a standalone destinations table assumption.
+- Canonical typo alias `Villa de Leiva` must map to `Villa de Leyva`.
+- Prefer data-first remediation before code where possible; use code fallback when durable alias handling is required.
+- Preserve no-secrets discipline when summarizing Supabase-backed investigations.
+
+## Learning candidates
+
+| Type | Audience | Recommendation | Evidence | Decision |
+| --- | --- | --- | --- | --- |
+| pattern_doc | developer, qa-engineer | propose | t_9a3252f6 and commit 9da792d7 | Keep as this learning-run backfill; create a standalone pattern only if the issue recurs |
+| profile_fact | developer | reject | One destination-specific bug | Too specific for private memory; repo learning-run is sufficient |
+
+## Applied learning
+
+- Added this redacted learning-run example as the first manual T6 backfill candidate for future learning-curator runs.
+
+## Rejected learning
+
+- Raw Supabase query output/logs: rejected because learning value is captured by summarized source-of-truth and alias lessons.
+
+## Redaction checklist
+
+- [x] No secrets, credentials, tokens, cookie values, or raw env values.
+- [x] No raw PII.
+- [x] No full raw logs.
+- [x] Evidence is summarized and linked by task ID, commit, and doc path.
+- [x] Candidates whose value depends on secret values are rejected.

--- a/docs/ai/learning-runs/README.md
+++ b/docs/ai/learning-runs/README.md
@@ -1,0 +1,25 @@
+# Learning runs
+
+Learning runs are reviewed summaries of what a completed Bukeer Studio development DAG learned. They close the T0→T6 loop without turning raw Kanban trace or profile-private memories into global knowledge.
+
+## Memory layers
+
+1. Profile-private Holographic memory/facts — compact durable facts useful to one profile, such as a developer preflight pitfall. Keep private by default. Do not store task progress, raw logs, credentials, raw env values, tokens, cookies, or one-off TODOs.
+2. Kanban operational trace — immutable task bodies, comments, parent/child edges, retries, PASS/FAIL/WARN handoffs, and structured metadata for the current DAG. Treat it as audit evidence, not as a curated knowledge base. T6 summarizes and links evidence instead of copying full logs.
+3. GitHub/repo institutional knowledge — GitHub issues/PRs, commits, ADRs, specs, docs/ai/patterns, and learning-run docs. Use this layer for reviewed cross-profile knowledge. GitHub remains the implementation source of truth.
+
+## T6 learning-curator contract
+
+T6 runs after T5 and reads final branch/commit/PR/deploy outcome, all gate evidence, QA evidence, blocked/retry history, and follow-up state. It must return PASS/FAIL/WARN with evidence and metadata containing learning_run_path, patterns_created, skill_patches_proposed, facts_proposed, follow_up_issues, rejected_candidates, and redaction_checked.
+
+## Redaction rules
+
+Before writing a learning run, replace secrets with `[REDACTED]`, summarize logs, avoid raw PII, link task IDs/commits/PRs instead of copying sensitive payloads, and reject candidates whose value depends on secret values.
+
+## Required index/frontmatter fields
+
+Use docs/ai/learning-runs/index.schema.json for machine validation of learning-run index entries or frontmatter objects. Core fields include id, title, date, pipeline_id, github_issue, task_ids, branch, commits, pr_url, adr_refs, spec_refs, outcome, learning_candidates, applied_learning, follow_up_issues, and redaction_checked.
+
+## Backfill policy
+
+If a run predates T6 but produced reusable lessons, create a redacted manual learning-run document or a GitHub/Kanban follow-up containing enough context to backfill later.

--- a/docs/ai/learning-runs/index.schema.json
+++ b/docs/ai/learning-runs/index.schema.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/weppa-cloud/bukeer-studio/docs/ai/learning-runs/index.schema.json",
+  "title": "Bukeer Studio learning run index entry",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "id",
+    "title",
+    "date",
+    "pipeline_id",
+    "github_issue",
+    "task_ids",
+    "branch",
+    "commits",
+    "pr_url",
+    "adr_refs",
+    "spec_refs",
+    "outcome",
+    "learning_candidates",
+    "applied_learning",
+    "follow_up_issues",
+    "redaction_checked"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "pipeline_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "github_issue": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 1
+    },
+    "github_url": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "uri"
+    },
+    "task_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "branch": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "commits": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "pr_url": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "adr_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "spec_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "outcome": {
+      "type": "string",
+      "enum": [
+        "PASS",
+        "FAIL",
+        "WARN",
+        "BLOCKED",
+        "NOT_APPLICABLE"
+      ]
+    },
+    "learning_candidates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/learningCandidate"
+      }
+    },
+    "applied_learning": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "follow_up_issues": {
+      "type": "array",
+      "items": {
+        "type": [
+          "string",
+          "object"
+        ]
+      }
+    },
+    "redaction_checked": {
+      "type": "boolean"
+    }
+  },
+  "$defs": {
+    "learningCandidate": {
+      "type": "object",
+      "required": [
+        "kind",
+        "audience",
+        "summary",
+        "evidence",
+        "recommended_action",
+        "risk",
+        "redaction_checked"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "skill_patch",
+            "profile_fact",
+            "pattern_doc",
+            "adr_update",
+            "github_issue",
+            "prompt_update",
+            "rejected_noise"
+          ]
+        },
+        "audience": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "evidence": {
+          "type": "string"
+        },
+        "recommended_action": {
+          "type": "string",
+          "enum": [
+            "apply",
+            "propose",
+            "follow_up",
+            "reject"
+          ]
+        },
+        "risk": {
+          "type": "string",
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "redaction_checked": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/docs/ai/patterns/README.md
+++ b/docs/ai/patterns/README.md
@@ -1,0 +1,26 @@
+# AI development patterns
+
+Pattern docs are reviewed institutional knowledge for Bukeer Studio agents and humans. They are not raw task logs and they do not replace GitHub issues, PRs, specs, or ADRs as source of truth.
+
+## When to create a pattern
+
+Create or update a pattern when a completed run reveals reusable, cross-profile knowledge: a validated preflight sequence, session-pool pitfall, retry DAG invariant, feature-branch setup pattern, QA failure mode, or implementation pattern with evidence.
+
+## Required content
+
+Each pattern should include:
+
+- source evidence: GitHub issue/PR, commit, Kanban task IDs, docs, or test reports;
+- ADR refs and relevant specs;
+- the reusable rule or workflow;
+- examples that summarize evidence without raw logs;
+- redaction status.
+
+## Routing boundaries
+
+- Use skill patches for narrow validated tool/profile operational fixes.
+- Use profile-private facts only for stable facts useful to a specific profile.
+- Use ADRs for decision-level boundaries.
+- Use GitHub issues for owned follow-up work.
+- Use prompt update proposals for profile behavior changes; do not silently apply them.
+- Reject one-off noise and transient failures.

--- a/docs/ai/templates/learning-run-template.md
+++ b/docs/ai/templates/learning-run-template.md
@@ -1,0 +1,60 @@
+# Learning run — <title>
+
+- GitHub issue:
+- Pipeline ID:
+- Date:
+- Branch:
+- PR:
+- Commits:
+- Task IDs:
+- ADR refs:
+- Spec refs:
+
+## Outcome
+
+PASS/FAIL/WARN summary.
+
+## Evidence links
+
+Kanban tasks, PR, commits, docs, test reports.
+
+## Commands and gates
+
+Summaries only; no raw secrets or full logs.
+
+| Gate/command | Result | Evidence |
+| --- | --- | --- |
+| T1 PLAN | PASS/FAIL/WARN | |
+| T3 CODE | PASS/FAIL/WARN | |
+| T4 QA | PASS/FAIL/WARN | |
+| T5 OPS | PASS/FAIL/WARN | |
+
+## Failures and retries
+
+What failed, why, and how it was resolved. Do not copy full logs; summarize with links/task IDs.
+
+## Reusable patterns
+
+What should future runs reuse?
+
+## Learning candidates
+
+| Type | Audience | Recommendation | Evidence | Decision |
+| --- | --- | --- | --- | --- |
+| skill_patch / profile_fact / pattern_doc / adr_update / github_issue / prompt_update / rejected_noise | | apply / propose / follow_up / reject | | |
+
+## Applied learning
+
+Skill patches, facts, ADRs, pattern docs, follow-up issues.
+
+## Rejected learning
+
+Noise/transient findings intentionally not persisted.
+
+## Redaction checklist
+
+- [ ] No secrets, credentials, tokens, cookie values, or raw env values.
+- [ ] No raw PII.
+- [ ] No full raw logs.
+- [ ] Evidence is summarized and linked by task ID, PR, commit, doc path, or test report.
+- [ ] Candidates whose value depends on secret values are rejected.

--- a/docs/architecture/ADR-030-dev-pipeline-self-learning.md
+++ b/docs/architecture/ADR-030-dev-pipeline-self-learning.md
@@ -1,0 +1,46 @@
+# ADR-030: Development pipeline self-learning and memory boundaries
+
+Status: Accepted
+Date: 2026-05-14
+
+## Context
+
+Bukeer Studio development work is orchestrated through a Hermes/Kanban DAG that previously ended at T5 ops/deploy handoff. The pipeline produced useful operational trace in Kanban and GitHub, but durable lessons were not consistently captured, filtered, routed, reviewed, or reused. Runs can reveal preflight pitfalls, implementation patterns, ADR gaps, QA failure modes, profile-specific facts, and follow-up issues.
+
+The learning loop must respect existing architecture decisions: ADR-003 contract-first validation, ADR-005 defense-in-depth security, ADR-010 observability, ADR-013 automated tech-validator gates, ADR-014 delta TypeScript quality gates, and ADR-023 QA tooling.
+
+## Decision
+
+Add T6 learning-curator after T5 for development DAGs. T6 reads final branch/commit/PR/deploy state, gate evidence, QA evidence, retry/block history, and learning_candidates emitted by earlier tasks. It curates redacted reusable knowledge into the correct storage layer and returns PASS/FAIL/WARN with machine-readable evidence.
+
+Bukeer Studio recognizes three memory layers:
+
+1. Profile-private Holographic memory/facts for compact durable facts useful to a specific profile.
+2. Kanban operational trace for immutable per-DAG audit evidence.
+3. GitHub/repo institutional knowledge for reviewed cross-profile source of truth: issues, PRs, commits, ADRs, specs, docs/ai/patterns, and docs/ai/learning-runs.
+
+T6 must classify candidates before writing durable knowledge: skill_patch, profile_fact, pattern_doc, adr_update, github_issue, prompt_update, or rejected_noise. Shared institutional knowledge belongs in GitHub/repo docs or issues. Profile-private memory must not be silently treated as globally shared.
+
+## Security and redaction
+
+Learning artifacts must not persist credentials, raw tokens, cookies, raw env values, raw PII, or full raw logs. Evidence should be summarized and linked by task ID, commit, PR, doc path, or test report. Candidates whose value depends on secret values are rejected.
+
+## Consequences
+
+- Development DAGs become T0→T6 instead of T0→T5.
+- T1/T3/T4/T5 gates must emit structured `learning_candidates` metadata in addition to PASS/FAIL/WARN evidence.
+- Learning-run docs and schema provide ADR-003-compatible contracts without adding a new runtime dependency.
+- The retry invariant remains unchanged: retries resolving blocked gates MUST NOT use `parents=[blocked_gate]`.
+- GitHub remains the implementation source of truth; T6 curates learning but does not replace issues, PRs, or CODE/QA/OPS gates.
+
+## Related documents
+
+- ADR-003: Contract-First Validation with Zod
+- ADR-005: Defense-in-Depth Security
+- ADR-010: Observability Strategy
+- ADR-013: Automated Tech Validator Quality Gate
+- ADR-014: Delta TypeScript Quality Gate
+- ADR-023: QA Tooling: Playwright Component Testing + Visual Regression
+- docs/ops/development-kanban-pipeline.md
+- docs/ai/learning-runs/README.md
+- docs/ai/patterns/README.md

--- a/docs/ops/development-kanban-pipeline.md
+++ b/docs/ops/development-kanban-pipeline.md
@@ -1,0 +1,170 @@
+# Bukeer Studio Development Kanban Pipeline
+
+Workflow operacional para features/fixes de código en `bukeer-studio`.
+
+## DAG
+
+```txt
+T0 specifier (Codex) → SPEC
+  ↓
+T1 tech-validator (DeepSeek) → PLAN GATE
+  ↓
+T2 developer-runner (terminal) → Codex CLI implementa
+  ↓
+T3 tech-validator (DeepSeek) → CODE GATE
+  ↓
+T4 qa-engineer (DeepSeek) → QA/E2E/WCAG GATE
+  ↓
+T5 ops (DeepSeek) → PR/merge/deploy handoff
+  ↓
+T6 learning-curator → learning-run / patterns / follow-ups
+```
+
+T6 runs after T5 because it needs the final branch, commit, PR, deploy/no-deploy outcome, gate evidence, QA evidence, blocked/retry history, and follow-up state. If deploy is not applicable, T5 still emits PASS/WARN evidence explaining why; T6 still runs.
+
+## Principio clave
+
+T2 **no depende** de que el worker kanban sea el modelo que codea. El worker debe tener terminal/git y ejecutar:
+
+```bash
+PATH=/opt/data/.npm-global/bin:$PATH codex exec --full-auto --ephemeral "<implementation prompt>"
+```
+
+Codex CLI es el motor de implementación. Hermes/Kanban es el runtime de orquestación, logs, gates, retries y learning loop.
+
+## Scripts
+
+### Preflight
+
+```bash
+npm run dev-pipeline:preflight
+npm run dev-pipeline:preflight -- --allow-main
+node scripts/ai/dev-pipeline-preflight.mjs --json --allow-main
+```
+
+Valida:
+- gateway/dispatcher corriendo
+- perfiles `specifier`, `tech-validator`, `developer`, `qa-engineer`, `ops`
+- `kanban.db` alcanzable
+- Node >= 22
+- branch `dev` para runs reales
+- Codex CLI en PATH o `/opt/data/.npm-global/bin/codex`
+- `codex login status`
+- watchdog disponible en `/opt/data/scripts/kanban-watchdog.py`
+
+### Crear pipeline
+
+Dry-run por defecto:
+
+```bash
+npm run dev-pipeline:create --   --title "Fix Villa de Leyva destination bug"   --scope "Diagnose and fix destination rendering/search/SEO issue for Villa de Leyva"
+```
+
+Crear tareas reales:
+
+```bash
+npm run dev-pipeline:create --   --apply   --title "Fix Villa de Leyva destination bug"   --scope "Diagnose and fix destination rendering/search/SEO issue for Villa de Leyva"   --priority high
+
+hermes kanban dispatch --max 3
+```
+
+## Contratos de gates
+
+- Todo gate devuelve `PASS`, `WARN` o `FAIL` con evidencia.
+- T1/T3/T4/T5 deben emitir `learning_candidates` estructurados en metadata.
+- Si un gate falla y crea retry, el retry **NO** debe tener `parents=[blocked_gate]`.
+- El retry debe recibir contexto completo en body/comments.
+- El watchdog/orquestador desbloquea el gate cuando el retry termina.
+- GitHub issue/PR siguen siendo source of truth para alcance y cierre.
+
+### Common metadata contract
+
+Cada tarea T0–T6 debe devolver metadata JSON-compatible con campos comunes cuando apliquen:
+
+```json
+{
+  "pipeline_id": "dev-...",
+  "github_issue": null,
+  "github_url": null,
+  "task_id": "t_xxxxxxxx",
+  "role": "T0_SPECIFIER | T1_PLAN_GATE | T2_DEVELOPER_RUNNER | T3_CODE_GATE | T4_QA_GATE | T5_OPS_HANDOFF | T6_LEARNING_CURATOR",
+  "status": "PASS | FAIL | WARN | BLOCKED | NOT_APPLICABLE",
+  "branch": "feat/...",
+  "commit_sha": null,
+  "pr_url": null,
+  "adr_refs": [],
+  "changed_files": [],
+  "commands": [{"cmd": "npm run typecheck", "result": "PASS", "evidence": "summary only"}],
+  "gate_evidence": [{"gate": "PLAN | CODE | QA | OPS | LEARNING", "result": "PASS", "evidence": "summary/link"}],
+  "failures": [],
+  "learning_candidates": [],
+  "follow_up_issues": []
+}
+```
+
+Role-specific additions:
+- T0: `spec_path`, `adr_refs`, `acceptance_criteria_count`, `non_goals`, `validation_plan`.
+- T1: `plan_gate_result`, `blocking_findings`, `watch_items`, `adr_alignment`, `learning_candidates`.
+- T2: `branch`, `commit_sha`, `changed_files`, `commands`, `test_results`, `implementation_risks`, `learning_candidates` when implementation discovers durable lessons.
+- T3: `code_gate_result`, `security_result`, `typecheck_result`, `regression_result`, `secret_scan_result`, `learning_candidates`.
+- T4: `qa_gate_result`, `routes_or_surfaces_checked`, `browser_matrix`, `accessibility_result`, `console_result`, `learning_candidates`.
+- T5: `ops_result`, `pr_url`, `merge_target`, `deploy_target`, `rollback_plan`, `monitoring_notes`, `learning_candidates`.
+- T6: `learning_run_path`, `patterns_created`, `skill_patches_proposed`, `facts_proposed`, `follow_up_issues`, `rejected_candidates`, `redaction_checked`.
+
+## Validaciones obligatorias para T2
+
+T2 debe devolver:
+- branch
+- commit SHA
+- PR URL si aplica
+- archivos modificados
+- comandos ejecutados
+- resultado de `npm run typecheck`
+- resultado de `npm run lint`
+- tests relevantes
+- riesgos/TODOs
+- learning_candidates si descubre lecciones reutilizables
+
+Para E2E/dev server usar session pool:
+
+```bash
+npm run session:list
+npm run session:run -- --grep "<area>"
+```
+
+Nunca usar puerto 3000 desde agentes.
+
+## T6 learning-curator
+
+T6 clasifica candidatos y decide dónde persisten:
+
+| Candidate type | Save as | Apply rules |
+| --- | --- | --- |
+| `skill_patch` | Hermes skill patch | Apply only if narrow, validated, non-secret, and profile/tool-specific; otherwise propose. |
+| `profile_fact` | Profile-private Holographic fact/fact_store | Save only for the profile that needs it. Keep compact. No task progress or raw logs. |
+| `pattern_doc` | `docs/ai/patterns/*.md` | Reviewed institutional knowledge with source evidence and ADR refs. |
+| `adr_update` | ADR add/update | Use only for decision-level guidance or memory boundary changes. |
+| `github_issue` | GitHub follow-up | Use when work remains open, owned, or needs prioritization. |
+| `prompt_update` | Prompt update proposal | Do not auto-apply. Document proposed diff/reviewer. |
+| `rejected_noise` | T6 rejected candidates | Record reason; do not persist elsewhere. |
+
+T6 can create a GitHub follow-up or repo pattern, but it must not silently share profile-private memory across profiles.
+
+## Memory boundaries
+
+- Profile-private memory/facts: profile-scoped durable facts only.
+- Kanban trace: immutable operational audit trail, summarized/linked by T6.
+- GitHub/repo knowledge: reviewed shared source of truth for ADRs, specs, patterns, and learning runs.
+
+No learning artifact may persist secrets, credentials, tokens, cookie values, raw env values, raw PII, or full raw logs. Use `[REDACTED]` and summarize evidence.
+
+## Self-healing
+
+El pipeline asume que `kanban-watchdog` está activo como cron. El preflight solo verifica que el script exista; el orquestador debe revisar cron si hay síntomas de crash-loop.
+
+Known failure modes:
+- perfil faltante → crash-loop infinito si watchdog no corre
+- Codex no está en PATH → T2 bloquea temprano
+- Node v20 → Next.js build/dev falla; usar Node >= 22
+- repo en `main` → preflight falla para runs reales; setup-only puede usar `--allow-main`
+- learning-curator profile faltante → T6 no dispatcha; crear perfil o documentar follow-up antes de aplicar pipelines reales

--- a/docs/specs/generated/github-542-learning-loop-20260514-SPEC.md
+++ b/docs/specs/generated/github-542-learning-loop-20260514-SPEC.md
@@ -1,0 +1,657 @@
+# Add learning loop to Bukeer Studio development pipeline — Executable SPEC
+
+Pipeline: `github-542-learning-loop-20260514`
+GitHub issue: [#542](https://github.com/weppa-cloud/bukeer-studio/issues/542)
+Source of truth: GitHub issue #542
+Base branch: `dev`
+Feature branch: `feat/542-dev-pipeline-learning-loop`
+Role: T0 SPECIFIER
+Status: Ready for `tech-validator` MODE:PLAN
+
+## 1. Problem statement
+
+Bukeer Studio has a Hermes/Kanban development pipeline:
+
+```txt
+T0 specifier
+T1 tech-validator [PLAN GATE]
+T2 developer-runner/Codex
+T3 tech-validator [CODE GATE]
+T4 QA gate
+T5 ops/deploy handoff
+```
+
+The pipeline creates useful operational trace in Kanban and GitHub, but it does not yet close the learning loop. Runs can discover durable lessons — preflight pitfalls, reusable implementation patterns, ADR gaps, QA failure modes, profile-specific facts, follow-up issues — yet those lessons are not consistently captured, filtered, routed, reviewed, or reused in future runs.
+
+This work adds `T6 learning-curator` after T5 and defines the docs, templates, metadata contracts, memory boundaries, and generator updates required for every development DAG to learn safely without replacing GitHub as source of truth or polluting profile-private memory.
+
+## 2. Relevant architecture decisions and repo conventions
+
+- [[ADR-003]] Contract-First Validation with Zod: task metadata and learning-run indexes must have schemas/contracts, not ad hoc blobs.
+- [[ADR-005]] Defense-in-Depth Security: learning artifacts must not persist secrets, credentials, raw tokens, or unredacted logs.
+- [[ADR-010]] Observability Strategy: learning records should summarize evidence and link to trace artifacts rather than duplicate full logs.
+- [[ADR-013]] Automated Tech Validator Quality Gate: T1/T3 remain mandatory gates and must emit machine-readable PASS/FAIL/WARN evidence.
+- [[ADR-014]] Delta TypeScript Quality Gate: gate evidence must distinguish scoped regressions from legacy debt when relevant.
+- [[ADR-023]] QA Tooling: QA/E2E results must become structured evidence for learning, especially flaky or repeated failure modes.
+- [[SPEC_GROWTH_OS_HERMES_AGENT_CONTEXT_ISOLATION_9]] and [[SPEC_GROWTH_OS_HERMES_PRIMARY_RUNTIME_MVE_V0]]: Hermes-inspired agents need scoped skills, memory boundaries, traceability, and learning-impact certification.
+- `AGENTS.md` / `CLAUDE.md`: docs additions must update `docs/INDEX.md`; E2E/dev server work must use the session pool, never raw port 3000.
+
+## 3. Scope
+
+Implement and document the learning loop architecture for development DAGs:
+
+1. Update `docs/ops/development-kanban-pipeline.md` from T0→T5 to T0→T6.
+2. Add an ADR for pipeline self-learning and memory boundaries.
+3. Add docs structure and templates:
+   - `docs/ai/learning-runs/`
+   - `docs/ai/patterns/`
+   - `docs/ai/templates/learning-run-template.md`
+   - `docs/ai/learning-runs/index.schema.json`
+   - `docs/ai/learning-runs/README.md` and `docs/ai/patterns/README.md` if useful.
+4. Update `scripts/ai/create-dev-pipeline.mjs` so generated DAGs include T6 `learning-curator` after T5.
+5. Define structured task metadata contracts each T0–T6 task should emit.
+6. Define safe routing from learning candidates to:
+   - skill patch,
+   - profile prompt update proposal,
+   - ADR or pattern doc,
+   - profile-private Holographic fact/fact_store entry,
+   - GitHub follow-up issue.
+7. Ensure tech-validator, QA, and ops contracts require `learning_candidates` output.
+8. Include Villa de Leyva run `villa-leyva-dev-20260514b` as the first manual learning-run example or create an explicit follow-up issue/task for backfill.
+
+## 4. Non-goals
+
+- Do not replace GitHub as implementation source of truth.
+- Do not make profile-private memory globally shared by default.
+- Do not dump raw logs into docs.
+- Do not persist secrets, credentials, tokens, cookie values, raw env values, or raw PII.
+- Do not auto-apply profile prompt changes without review.
+- Do not auto-apply skill changes except narrow validated operational pitfall patches that already meet Hermes skill maintenance rules.
+- Do not build a UI for learning approval in this issue.
+- Do not rewrite the Hermes Kanban runtime.
+
+## 5. Target DAG
+
+```txt
+T0 specifier
+  ↓
+T1 tech-validator PLAN gate
+  ↓
+T2 developer-runner/Codex implementation
+  ↓
+T3 tech-validator CODE gate
+  ↓
+T4 QA gate
+  ↓
+T5 ops/deploy handoff
+  ↓
+T6 learning-curator
+```
+
+T6 runs after T5 because it needs the final branch/commit/PR/deploy outcome, gate evidence, QA evidence, blocked/retry history, and follow-up state. If T5 is skipped for a docs-only or no-deploy task, T5 must still emit a PASS/WARN handoff explaining why deploy/PR was not applicable; T6 still runs.
+
+## 6. Memory model and boundaries
+
+The docs must explain three memory layers and their boundaries.
+
+### Layer 1 — Profile-private Holographic memory/facts
+
+Purpose: durable facts that help a specific profile behave better in future runs.
+
+Examples:
+- `specifier` learns a stable repo convention.
+- `developer` learns that Codex auth is profile-HOME scoped and preflight must set `HERMES_HOME=/opt/data`.
+- `qa-engineer` learns a recurring session-pool pitfall.
+
+Rules:
+- Private by default to the profile where the fact is useful.
+- Use only compact, durable facts.
+- Never store task progress, raw logs, credentials, or one-off TODOs.
+- If the fact is cross-profile institutional knowledge, prefer pattern doc, ADR, or GitHub issue over private memory.
+
+### Layer 2 — Kanban operational trace
+
+Purpose: immutable operational history for the current DAG and its tasks.
+
+Examples:
+- task bodies,
+- parent/child edges,
+- comments,
+- PASS/FAIL/WARN gate handoffs,
+- retry/block events,
+- structured metadata.
+
+Rules:
+- Treat Kanban as the audit trail, not a curated knowledge base.
+- T6 should link/summarize Kanban evidence but not duplicate full logs into docs.
+- Retries that resolve blocked gates MUST NOT use `parents=[blocked_gate]`; this remains a pipeline invariant.
+
+### Layer 3 — GitHub/repo institutional knowledge
+
+Purpose: shared source of truth and reusable knowledge for all agents and humans.
+
+Examples:
+- GitHub issue/PR/commit links,
+- ADRs,
+- specs,
+- docs/ops runbooks,
+- `docs/ai/patterns/*`,
+- `docs/ai/learning-runs/*`,
+- follow-up issues.
+
+Rules:
+- GitHub remains source of truth for feature scope and closure.
+- Repo docs are for reviewed, reusable knowledge.
+- Learning docs should cite issue, pipeline, task IDs, branch, commit, PR, ADRs, tests, and outcomes.
+
+## 7. Task metadata contract
+
+Every task T0–T6 must emit a structured handoff in Kanban metadata. The exact schema is lightweight JSON-compatible metadata, not a new runtime dependency.
+
+Common fields:
+
+```json
+{
+  "pipeline_id": "github-542-learning-loop-20260514",
+  "github_issue": 542,
+  "github_url": "https://github.com/weppa-cloud/bukeer-studio/issues/542",
+  "task_id": "t_xxxxxxxx",
+  "role": "T0_SPECIFIER | T1_PLAN_GATE | T2_DEVELOPER_RUNNER | T3_CODE_GATE | T4_QA_GATE | T5_OPS_HANDOFF | T6_LEARNING_CURATOR",
+  "status": "PASS | FAIL | WARN | BLOCKED | NOT_APPLICABLE",
+  "branch": "feat/542-dev-pipeline-learning-loop",
+  "commit_sha": null,
+  "pr_url": null,
+  "adr_refs": ["ADR-003", "ADR-005", "ADR-013", "ADR-014"],
+  "changed_files": [],
+  "commands": [
+    {"cmd": "npm run typecheck", "result": "PASS | FAIL | WARN | SKIPPED", "evidence": "summary only"}
+  ],
+  "gate_evidence": [
+    {"gate": "PLAN | CODE | QA | OPS | LEARNING", "result": "PASS | FAIL | WARN", "evidence": "summary/link"}
+  ],
+  "failures": [
+    {"kind": "test | build | auth | infra | spec | qa | deploy", "summary": "redacted summary", "resolution": "fixed | follow-up | unresolved"}
+  ],
+  "learning_candidates": [
+    {
+      "kind": "skill_patch | profile_fact | pattern_doc | adr_update | github_issue | prompt_update",
+      "audience": "specifier | developer | tech-validator | qa-engineer | ops | all",
+      "summary": "compact reusable lesson",
+      "evidence": "task id, commit, doc path, or gate summary",
+      "recommended_action": "apply | propose | follow_up | reject",
+      "risk": "low | medium | high",
+      "redaction_checked": true
+    }
+  ],
+  "follow_up_issues": []
+}
+```
+
+Role-specific requirements:
+
+- T0: `spec_path`, `adr_refs`, `acceptance_criteria_count`, `non_goals`, `validation_plan`.
+- T1: `plan_gate_result`, `blocking_findings`, `watch_items`, `adr_alignment`.
+- T2: `branch`, `commit_sha`, `changed_files`, `commands`, `test_results`, `implementation_risks`.
+- T3: `code_gate_result`, `security_result`, `typecheck_result`, `regression_result`, `secret_scan_result`.
+- T4: `qa_gate_result`, `routes_or_surfaces_checked`, `browser_matrix`, `accessibility_result`, `console_result`.
+- T5: `ops_result`, `pr_url`, `merge_target`, `deploy_target`, `rollback_plan`, `monitoring_notes`.
+- T6: `learning_run_path`, `patterns_created`, `skill_patches_proposed`, `facts_proposed`, `follow_up_issues`, `rejected_candidates`.
+
+## 8. Learning candidate routing rules
+
+T6 must classify each candidate before writing anything durable.
+
+| Candidate type | Save as | Apply rules |
+|---|---|---|
+| Repeated operational pitfall with exact fix | Skill patch | Apply only if narrow, validated, non-secret, and profile/tool-specific. Otherwise propose. |
+| Stable profile-local preference or environment fact | Holographic fact/fact_store | Save only for the profile that needs it. Keep compact. No task progress. |
+| Cross-profile implementation or QA pattern | `docs/ai/patterns/*.md` | Requires repo-doc PR/commit review. Include ADR refs and example evidence. |
+| Architecture decision or boundary | ADR | Add new ADR or update existing ADR only when it changes decision-level guidance. |
+| Product/engineering follow-up | GitHub issue | Use GitHub when work remains open, owned, or needs prioritization. |
+| Prompt/profile behavior change | Prompt update proposal | Do not auto-apply by default. Document proposed diff and reviewer. |
+| One-off failure/noise | Reject | Record in T6 rejected candidates with reason; do not persist elsewhere. |
+
+All candidates must pass redaction review:
+
+- replace tokens/secrets with `[REDACTED]`,
+- summarize logs instead of copying logs,
+- avoid raw PII,
+- include evidence links/IDs instead of sensitive payloads,
+- reject candidates whose value depends on secret values.
+
+## 9. Required docs/artifacts
+
+### 9.1 ADR
+
+Create the next available Studio ADR, expected path:
+
+- `docs/architecture/ADR-030-dev-pipeline-self-learning.md`
+
+Required ADR contents:
+
+- status/date/principles,
+- context: T0→T5 lacks durable learning closure,
+- decision: add T6 learning-curator and memory boundaries,
+- consequences,
+- memory layer rules,
+- security/redaction rules,
+- relation to ADR-003, ADR-005, ADR-010, ADR-013, ADR-014, ADR-023.
+
+If `ADR-030` is already used at implementation time, choose the next available number and update all references.
+
+### 9.2 Pipeline docs
+
+Modify:
+
+- `docs/ops/development-kanban-pipeline.md`
+
+Required updates:
+
+- DAG diagram includes T6.
+- T6 role contract explains learning curation after T5.
+- Gate contracts require PASS/FAIL/WARN evidence.
+- T2/T3/T4/T5 contracts require `learning_candidates` metadata.
+- Retry invariant remains explicit: retries resolving blocked gates MUST NOT use `parents=[blocked_gate]`.
+- Document that `T6` can create a GitHub follow-up or repo pattern but does not silently share profile-private memory.
+
+### 9.3 Learning docs structure
+
+Create:
+
+- `docs/ai/learning-runs/README.md`
+- `docs/ai/learning-runs/index.schema.json`
+- `docs/ai/templates/learning-run-template.md`
+- `docs/ai/patterns/README.md`
+
+Recommended optional first example:
+
+- `docs/ai/learning-runs/2026-05-14-villa-leyva-dev-20260514b.md`
+
+If the Villa de Leyva backfill is not included in this implementation, create or document a follow-up with enough context to backfill it later.
+
+### 9.4 Learning-run template minimum sections
+
+`docs/ai/templates/learning-run-template.md` must include:
+
+```md
+# Learning run — <title>
+
+- GitHub issue:
+- Pipeline ID:
+- Date:
+- Branch:
+- PR:
+- Commits:
+- Task IDs:
+- ADR refs:
+- Spec refs:
+
+## Outcome
+PASS/FAIL/WARN summary.
+
+## Evidence links
+Kanban tasks, PR, commits, docs, test reports.
+
+## Commands and gates
+Summaries only; no raw secrets or full logs.
+
+## Failures and retries
+What failed, why, and how it was resolved.
+
+## Reusable patterns
+What should future runs reuse?
+
+## Learning candidates
+Table with type, audience, recommendation, evidence, decision.
+
+## Applied learning
+Skill patches, facts, ADRs, pattern docs, follow-up issues.
+
+## Rejected learning
+Noise/transient findings intentionally not persisted.
+
+## Redaction checklist
+No secrets, no raw logs, no raw PII, evidence summarized.
+```
+
+### 9.5 `index.schema.json`
+
+The schema must validate a learning-run index entry or learning-run frontmatter/object with at least:
+
+- `id`,
+- `title`,
+- `date`,
+- `pipeline_id`,
+- `github_issue`,
+- `task_ids`,
+- `branch`,
+- `commits`,
+- `pr_url`,
+- `adr_refs`,
+- `spec_refs`,
+- `outcome`,
+- `learning_candidates`,
+- `applied_learning`,
+- `follow_up_issues`,
+- `redaction_checked`.
+
+Use JSON Schema draft 2020-12 or document equivalent if the repo prefers schema docs over machine validation. Prefer machine-readable JSON Schema to satisfy ADR-003.
+
+### 9.6 Pattern docs
+
+`docs/ai/patterns/README.md` must explain:
+
+- pattern docs are reviewed institutional knowledge,
+- patterns are not raw task logs,
+- each pattern needs source evidence and ADR refs,
+- examples: auth/preflight pitfalls, session-pool usage, retry DAG invariant, feature-branch setup.
+
+## 10. `create-dev-pipeline.mjs` implementation requirements
+
+Modify `scripts/ai/create-dev-pipeline.mjs`:
+
+1. Header comment and output graph describe T0→T6.
+2. `common.acceptanceContract` includes:
+   - GitHub issue/source-of-truth when provided,
+   - every gate returns PASS/FAIL/WARN with evidence,
+   - retries resolving blocked gates MUST NOT use `parents=[blocked_gate]`,
+   - structured `learning_candidates` emitted by T1–T5,
+   - no secrets/raw logs in learning artifacts.
+3. Add optional CLI args if not already available:
+   - `--github-issue <number>`
+   - `--github-url <url>`
+   - `--source-of-truth github`
+   These can be lightweight fields in task bodies; no GitHub API dependency required.
+4. Add T6 task creation after T5:
+
+```js
+const t6Body = JSON.stringify({
+  ...common,
+  role: "T6_LEARNING_CURATOR",
+  input: "Curate learning after T5 ops handoff. Read all parent task handoffs and Kanban trace.",
+  instructions: [
+    "Create or update docs/ai/learning-runs/<date>-<pipelineId>.md using docs/ai/templates/learning-run-template.md.",
+    "Classify learning_candidates into skill_patch, profile_fact, pattern_doc, adr_update, github_issue, prompt_update, or rejected_noise.",
+    "Do not persist secrets, raw logs, credentials, tokens, cookie values, or raw PII.",
+    "Prefer GitHub/repo docs for shared institutional knowledge; keep profile-private facts scoped.",
+    "If Villa de Leyva backfill applies and no example exists, create it or open/document a follow-up.",
+    "Return PASS/FAIL/WARN with learning_run_path, applied/proposed learning, rejected candidates, and follow_up_issues."
+  ]
+}, null, 2);
+
+const t6 = createTask({
+  key: "T6-learning-curator",
+  taskTitle: `[${pipelineId}] T6 LEARNING CURATOR — ${title}`,
+  assignee: "learning-curator",
+  body: t6Body,
+  parents: [t5.id],
+  skills: [],
+  maxRuntime: "90m",
+});
+```
+
+5. Include `t6` in `tasks` graph output.
+6. Keep dry-run mode working.
+7. Keep idempotency keys stable: `${pipelineId}:T6-learning-curator`.
+8. Do not require `gh` CLI for generation; this environment may not have `gh` installed.
+
+## 11. Suggested implementation plan
+
+### Task A — Docs skeleton and template
+
+Files:
+- Create `docs/ai/learning-runs/README.md`
+- Create `docs/ai/templates/learning-run-template.md`
+- Create `docs/ai/learning-runs/index.schema.json`
+- Create `docs/ai/patterns/README.md`
+
+Steps:
+1. Create directories and docs.
+2. Include redaction and memory-layer rules.
+3. Include the learning-run template sections from this SPEC.
+4. Run a JSON parser/schema sanity check on `index.schema.json`.
+
+Verification:
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('docs/ai/learning-runs/index.schema.json','utf8')); console.log('schema json ok')"
+```
+
+Expected: `schema json ok`.
+
+### Task B — ADR
+
+Files:
+- Create `docs/architecture/ADR-030-dev-pipeline-self-learning.md` or next available ADR.
+
+Steps:
+1. Check next available ADR number.
+2. Write ADR with decision and boundaries.
+3. Reference ADR-003/005/010/013/014/023.
+
+Verification:
+
+```bash
+test -f docs/architecture/ADR-030-dev-pipeline-self-learning.md
+```
+
+Expected: exit 0, or equivalent next-number file exists.
+
+### Task C — Pipeline docs
+
+Files:
+- Modify `docs/ops/development-kanban-pipeline.md`
+
+Steps:
+1. Update DAG to T0→T6.
+2. Add T6 role contract.
+3. Add metadata contract and learning candidate routing section.
+4. Preserve session-pool and retry invariant guidance.
+
+Verification:
+
+```bash
+grep -n "T6 learning-curator" docs/ops/development-kanban-pipeline.md
+grep -n "learning_candidates" docs/ops/development-kanban-pipeline.md
+```
+
+Expected: both commands find entries.
+
+### Task D — Pipeline generator
+
+Files:
+- Modify `scripts/ai/create-dev-pipeline.mjs`
+
+Steps:
+1. Add optional GitHub/source args.
+2. Add learning candidate contract to common/task bodies.
+3. Add T6 body and task after T5.
+4. Include T6 in graph.
+5. Keep dry-run and apply modes intact.
+
+Verification:
+
+```bash
+node scripts/ai/create-dev-pipeline.mjs \
+  --title "Test learning loop" \
+  --scope "Dry-run check" \
+  --pipeline-id test-learning-loop \
+  --github-issue 542 \
+  --github-url https://github.com/weppa-cloud/bukeer-studio/issues/542 \
+  | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const j=JSON.parse(d); if(!j.graph.some(t=>/T6 LEARNING CURATOR/.test(t.title))) process.exit(1); console.log('T6 dry-run ok')})"
+```
+
+Expected: `T6 dry-run ok`.
+
+### Task E — Villa de Leyva backfill decision
+
+Files:
+- Prefer create `docs/ai/learning-runs/2026-05-14-villa-leyva-dev-20260514b.md`
+- Or create a GitHub follow-up / Kanban follow-up if implementation wants a separate run.
+
+Minimum content if backfilled now:
+- GitHub/source context if known.
+- Pipeline ID `villa-leyva-dev-20260514b`.
+- Spec path `docs/specs/generated/villa-leyva-dev-20260514b-SPEC.md`.
+- Branch `feat/fix-villa-de-leyva-destination-bug`.
+- Known outcome/evidence from Kanban handoffs.
+- Lessons:
+  - destination source of truth was dynamic RPC from `websites.featured_products`, not a standalone destinations table,
+  - canonical typo alias `Villa de Leiva` must map to `Villa de Leyva`,
+  - data-first remediation before code path where possible,
+  - no raw Supabase credentials/logs persisted.
+
+Verification:
+
+```bash
+test -f docs/ai/learning-runs/2026-05-14-villa-leyva-dev-20260514b.md || grep -n "Villa de Leyva" docs/ai/learning-runs/README.md
+```
+
+Expected: example exists or explicit follow-up is documented.
+
+### Task F — Index update
+
+Files:
+- Modify `docs/INDEX.md`
+
+Steps:
+1. Add ADR row.
+2. Add ops row for development pipeline if missing.
+3. Add AI learning docs rows or a short `AI development learning` section.
+4. Add concept graph entry for `[[dev-pipeline-learning-loop]]` / `[[learning-loop]]` if needed.
+
+Verification:
+
+```bash
+grep -n "dev-pipeline-learning" docs/INDEX.md
+grep -n "development-kanban-pipeline" docs/INDEX.md
+```
+
+Expected: both references found.
+
+## 12. Acceptance criteria
+
+AC1 — T6 exists in generated DAG
+- PASS if `scripts/ai/create-dev-pipeline.mjs` dry-run graph includes a T6 task titled `T6 LEARNING CURATOR`.
+- PASS if T6 depends on T5 and not earlier gates.
+- FAIL if the generated graph stops at T5.
+
+AC2 — Learning docs explain three memory layers
+- PASS if docs explain profile-private memory/facts, Kanban operational trace, and GitHub/repo institutional knowledge.
+- FAIL if docs imply all profile memories are globally shared by default.
+
+AC3 — Template and schema exist
+- PASS if `docs/ai/templates/learning-run-template.md` exists and includes issue, pipeline ID, tasks, branch, commit, PR, ADRs, tests, outcome, failures, reusable patterns, skill patch candidates, follow-ups, and redaction checklist.
+- PASS if `docs/ai/learning-runs/index.schema.json` is valid JSON and captures core fields.
+
+AC4 — Routing rules are documented
+- PASS if docs define when to save to skill vs fact_store/Holographic fact vs ADR vs pattern doc vs GitHub issue vs prompt update proposal.
+- PASS if rejected/noisy candidates have an explicit path.
+
+AC5 — T1/T3/T4/T5 require learning candidates
+- PASS if pipeline docs and generated task bodies require structured `learning_candidates` output for tech-validator, QA, and ops contracts.
+- WARN acceptable if T0/T2 candidate emission is optional, but T1/T3/T4/T5 must be required.
+
+AC6 — Villa de Leyva first example or follow-up
+- PASS if `docs/ai/learning-runs/2026-05-14-villa-leyva-dev-20260514b.md` exists and is redacted.
+- WARN acceptable if a clear follow-up issue/task is created or documented with the required backfill context.
+- FAIL if Villa de Leyva is omitted entirely.
+
+AC7 — Security/redaction
+- PASS if docs and generator instructions forbid secrets, credentials, raw logs, raw env values, tokens, cookies, and raw PII in learning artifacts.
+- PASS if templates include a redaction checklist.
+
+AC8 — ADR and index
+- PASS if a self-learning ADR exists and `docs/INDEX.md` links the ADR, pipeline docs, and learning docs.
+
+AC9 — Existing pipeline invariants preserved
+- PASS if retry invariant remains: retries resolving blocked gates MUST NOT use `parents=[blocked_gate]`.
+- PASS if session-pool rule remains for E2E/dev server work.
+- PASS if GitHub remains source of truth.
+
+## 13. Validation plan
+
+Run these after implementation:
+
+```bash
+# JSON schema sanity
+node -e "JSON.parse(require('fs').readFileSync('docs/ai/learning-runs/index.schema.json','utf8')); console.log('schema json ok')"
+
+# Generator dry-run includes T6
+node scripts/ai/create-dev-pipeline.mjs \
+  --title "Test learning loop" \
+  --scope "Dry-run check" \
+  --pipeline-id test-learning-loop \
+  --github-issue 542 \
+  --github-url https://github.com/weppa-cloud/bukeer-studio/issues/542 \
+  | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const j=JSON.parse(d); const t6=j.graph.find(t=>/T6 LEARNING CURATOR/.test(t.title)); if(!t6 || !t6.parents?.length) process.exit(1); console.log('T6 dry-run ok')})"
+
+# Required docs references
+grep -n "T6 learning-curator" docs/ops/development-kanban-pipeline.md
+grep -n "learning_candidates" docs/ops/development-kanban-pipeline.md
+grep -n "dev-pipeline-learning" docs/INDEX.md
+
+# Existing local quality gates where applicable
+npm run typecheck
+npm run lint
+```
+
+Notes:
+- If full `npm run typecheck` or `npm run lint` fails due unrelated legacy/dirty repo state, T3 must classify evidence per ADR-014 and report new vs legacy blockers.
+- Do not run raw `npm run dev`, raw `npm run test:e2e`, or raw Playwright on port 3000.
+
+## 14. Rollout plan
+
+1. Implement docs/schema/ADR first.
+2. Update generator in dry-run mode only.
+3. Run generator dry-run validation for issue #542.
+4. Run JSON/doc grep validations.
+5. Run typecheck/lint if implementation touches JS beyond docs.
+6. Pass T3 CODE gate.
+7. Pass T4 QA/docs verification gate.
+8. Use T5 for PR/merge handoff.
+9. T6 creates the first learning run and curates candidates.
+
+## 15. Rollback plan
+
+For docs-only pieces:
+- Revert added docs/ADR/template/schema files and `docs/INDEX.md` links.
+
+For generator change:
+- Revert `scripts/ai/create-dev-pipeline.mjs` to T0→T5 graph.
+- Existing already-created T6 tasks can be archived manually if needed; do not mutate historical Kanban trace.
+
+For learning-run docs:
+- Remove or amend only via a follow-up commit; do not rewrite already-published GitHub/PR history without review.
+
+## 16. Touched files / artifacts
+
+Expected files:
+
+- `docs/specs/generated/github-542-learning-loop-20260514-SPEC.md` (this SPEC)
+- `docs/architecture/ADR-030-dev-pipeline-self-learning.md` or next available ADR
+- `docs/ops/development-kanban-pipeline.md`
+- `docs/ai/learning-runs/README.md`
+- `docs/ai/learning-runs/index.schema.json`
+- `docs/ai/templates/learning-run-template.md`
+- `docs/ai/patterns/README.md`
+- Optional: `docs/ai/learning-runs/2026-05-14-villa-leyva-dev-20260514b.md`
+- `scripts/ai/create-dev-pipeline.mjs`
+- `docs/INDEX.md`
+
+No database migrations are expected.
+No runtime Next.js UI changes are expected.
+No secrets should be added to any artifact.
+
+## 17. Implementation handoff checklist
+
+- [ ] Start from `dev` and create/use `feat/542-dev-pipeline-learning-loop` when repo state allows; do not overwrite unrelated dirty files.
+- [ ] Preserve current dirty work from other active pipelines.
+- [ ] Create docs/schema/template/ADR before generator change.
+- [ ] Update generator dry-run graph to include T6.
+- [ ] Require `learning_candidates` in T1/T3/T4/T5 task bodies.
+- [ ] Include or explicitly follow up Villa de Leyva backfill.
+- [ ] Update `docs/INDEX.md`.
+- [ ] Run validation plan and record PASS/FAIL/WARN evidence.
+- [ ] Pass tech-validator MODE:PLAN before implementation.
+- [ ] Pass tech-validator MODE:CODE before merge.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,9 @@
     "deploy:worker": "npm run check:node && opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",
     "tech-validator:code:strict": "node scripts/ai/validate-tech-validator.mjs --strict-global",
-    "tech-validator:code:strict:full": "node scripts/ai/validate-tech-validator.mjs --strict-global-full"
+    "tech-validator:code:strict:full": "node scripts/ai/validate-tech-validator.mjs --strict-global-full",
+    "dev-pipeline:preflight": "node scripts/ai/dev-pipeline-preflight.mjs",
+    "dev-pipeline:create": "node scripts/ai/create-dev-pipeline.mjs"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.58",

--- a/scripts/ai/create-dev-pipeline.mjs
+++ b/scripts/ai/create-dev-pipeline.mjs
@@ -1,0 +1,316 @@
+#!/usr/bin/env node
+/**
+ * Bukeer Studio Kanban Development Pipeline Creator
+ *
+ * Creates the validated T0→T6 DAG:
+ * T0 specifier → T1 tech-validator PLAN gate → T2 developer-runner (Codex CLI)
+ * → T3 tech-validator CODE gate → T4 qa-engineer gate → T5 ops handoff → T6 learning-curator.
+ *
+ * Default is --dry-run. Use --apply to create tasks.
+ *
+ * Usage:
+ *   node scripts/ai/create-dev-pipeline.mjs --title "Fix Villa de Leyva destination" --scope "..."
+ *   node scripts/ai/create-dev-pipeline.mjs --apply --title "..." --scope "..." --priority high
+ */
+
+import { execFileSync } from "node:child_process";
+import crypto from "node:crypto";
+import process from "node:process";
+
+const REPO = "/opt/data/home/repos/bukeer-studio";
+const DEFAULT_BRANCH = "dev";
+const WORKSPACE = `dir:${REPO}`;
+const args = process.argv.slice(2);
+
+function arg(name, fallback = "") {
+  const idx = args.indexOf(`--${name}`);
+  if (idx >= 0) return args[idx + 1] || fallback;
+  const pref = args.find((a) => a.startsWith(`--${name}=`));
+  return pref ? pref.slice(name.length + 3) : fallback;
+}
+function has(name) { return args.includes(`--${name}`); }
+
+const apply = has("apply");
+const title = arg("title");
+const scope = arg("scope");
+const priorityRaw = arg("priority", "0");
+const priorityMap = { low: "-10", normal: "0", medium: "0", high: "10", urgent: "20", p0: "30" };
+const priority = priorityMap[String(priorityRaw).toLowerCase()] || String(priorityRaw);
+const tenant = arg("tenant", "bukeer-studio-dev");
+const baseBranch = arg("base-branch", DEFAULT_BRANCH);
+const slug = arg("slug", title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 48));
+const pipelineId = arg("pipeline-id", `dev-${new Date().toISOString().slice(0,10)}-${crypto.randomBytes(3).toString("hex")}`);
+const githubIssueRaw = arg("github-issue", "");
+const githubIssue = githubIssueRaw ? Number(githubIssueRaw) : null;
+const githubUrl = arg("github-url", githubIssue ? `https://github.com/weppa-cloud/bukeer-studio/issues/${githubIssue}` : "");
+const sourceOfTruth = arg("source-of-truth", githubIssue || githubUrl ? "github" : "kanban");
+
+if (!title || !scope) {
+  console.error("Missing required --title and --scope");
+  process.exit(2);
+}
+
+function sh(cmd, cmdArgs, opts = {}) {
+  return execFileSync(cmd, cmdArgs, {
+    cwd: opts.cwd || REPO,
+    env: { ...process.env, PATH: `/opt/data/home/.nvm/versions/node/v22.22.2/bin:/opt/data/.npm-global/bin:${process.env.PATH || ""}` },
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: opts.timeout || 60_000,
+  }).trim();
+}
+
+function createTask({ key, taskTitle, assignee, body, parents = [], skills = [], maxRetries = 2, maxRuntime = "2h" }) {
+  const cmd = [
+    "kanban", "create", taskTitle,
+    "--assignee", assignee,
+    "--workspace", WORKSPACE,
+    "--tenant", tenant,
+    "--priority", priority,
+    "--idempotency-key", `${pipelineId}:${key}`,
+    "--max-retries", String(maxRetries),
+    "--max-runtime", maxRuntime,
+    "--body", body,
+    "--json",
+  ];
+  for (const p of parents) cmd.splice(cmd.length - 1, 0, "--parent", p);
+  for (const s of skills) cmd.splice(cmd.length - 1, 0, "--skill", s);
+
+  if (!apply) {
+    return { id: `DRY_${key}`, taskTitle, assignee, parents, skills };
+  }
+  const out = sh("hermes", cmd, { cwd: "/opt/data", timeout: 90_000 });
+  const parsed = JSON.parse(out);
+  return { id: parsed.task_id || parsed.id, taskTitle, assignee, parents, skills };
+}
+
+const common = {
+  pipelineId,
+  sourceOfTruth,
+  githubIssue,
+  githubUrl,
+  repo: REPO,
+  baseBranch,
+  featureBranch: `feat/${slug}`,
+  requestedTitle: title,
+  requestedScope: scope,
+  acceptanceContract: [
+    "No secrets in logs/output; redact credentials as [REDACTED].",
+    "Work from dev branch unless explicitly overridden.",
+    githubIssue ? `GitHub Issue #${githubIssue} is source of truth.` : "GitHub issue is source of truth when provided; otherwise Kanban body is run scope.",
+    "Every gate must return PASS/FAIL/WARN with evidence.",
+    "Retries created to resolve a blocked gate MUST NOT use parents=[blocked_gate].",
+    "Structured learning_candidates must be emitted by T1/T3/T4/T5 and by T2 when implementation discovers durable lessons.",
+    "No secrets, credentials, tokens, cookie values, raw env values, raw PII, or raw logs in learning artifacts.",
+    "Use session pool for E2E/dev server; never raw port 3000 from agents.",
+  ],
+};
+
+const learningCandidateContract = {
+  requiredFor: ["T1_PLAN_GATE", "T3_CODE_GATE", "T4_QA_GATE", "T5_OPS_HANDOFF"],
+  optionalFor: ["T0_SPECIFIER", "T2_DEVELOPER_RUNNER"],
+  fields: ["kind", "audience", "summary", "evidence", "recommended_action", "risk", "redaction_checked"],
+  allowedKinds: ["skill_patch", "profile_fact", "pattern_doc", "adr_update", "github_issue", "prompt_update", "rejected_noise"],
+  allowedActions: ["apply", "propose", "follow_up", "reject"],
+  redactionRule: "Do not include secrets, raw logs, credentials, tokens, cookie values, raw env values, or raw PII.",
+};
+
+const commonMetadataContract = {
+  fields: ["pipeline_id", "github_issue", "github_url", "task_id", "role", "status", "branch", "commit_sha", "pr_url", "adr_refs", "changed_files", "commands", "gate_evidence", "failures", "learning_candidates", "follow_up_issues"],
+  statusValues: ["PASS", "FAIL", "WARN", "BLOCKED", "NOT_APPLICABLE"],
+  evidenceRule: "Every gate returns PASS/FAIL/WARN with summarized evidence.",
+};
+
+const t0Body = JSON.stringify({
+  ...common,
+  role: "T0_SPECIFIER",
+  metadataContract: commonMetadataContract,
+  learningCandidateContract,
+  instructions: [
+    "Read docs/INDEX.md, relevant ADRs/SPECs, AGENTS.md, and code areas implied by scope.",
+    "Produce an executable SPEC at docs/specs/generated/<pipelineId>-SPEC.md or in task output if file write is not appropriate.",
+    "Include problem statement, non-goals, touched files, DB impact, acceptance criteria, validation plan, rollout/rollback.",
+    "Do not implement code.",
+  ],
+}, null, 2);
+
+const t0 = createTask({
+  key: "T0-spec",
+  taskTitle: `[${pipelineId}] T0 SPEC — ${title}`,
+  assignee: "specifier",
+  body: t0Body,
+  skills: [],
+  maxRuntime: "90m",
+});
+
+const t1Body = JSON.stringify({
+  ...common,
+  role: "T1_TECH_VALIDATOR_PLAN_GATE",
+  metadataContract: commonMetadataContract,
+  learningCandidateContract,
+  input: "Read parent T0 output/SPEC.",
+  gate: {
+    pass: "SPEC is executable, scoped, aligned with ADRs, testable, and safe for Bukeer Studio.",
+    fail: "Block with exact issues; if fixable, create a T0R spec retry WITHOUT parent link to this blocked gate.",
+  },
+  checks: ["architecture", "ADR alignment", "scope creep", "data/security", "test plan", "rollback", "learning_candidates"],
+}, null, 2);
+
+const t1 = createTask({
+  key: "T1-plan-gate",
+  taskTitle: `[${pipelineId}] T1 PLAN GATE — ${title}`,
+  assignee: "tech-validator",
+  body: t1Body,
+  parents: [t0.id],
+  skills: [],
+  maxRuntime: "60m",
+});
+
+const t2Body = JSON.stringify({
+  ...common,
+  role: "T2_DEVELOPER_RUNNER_CODEX_CLI",
+  metadataContract: commonMetadataContract,
+  learningCandidateContract,
+  criticalPattern: "This worker is a terminal/git runner. It invokes Codex CLI for implementation; it does not rely on Hermes openai-codex provider tools.",
+  preflight: [
+    "Run node scripts/ai/dev-pipeline-preflight.mjs --allow-main before implementation.",
+    "Ensure codex is callable via PATH or /opt/data/.npm-global/bin/codex.",
+    "If repo is on main, checkout/create branch from dev before edits unless this is dry-run.",
+  ],
+  codexCommandTemplate: "PATH=/opt/data/.npm-global/bin:$PATH codex exec --full-auto --ephemeral '<implementation prompt>'",
+  implementationPromptMustInclude: [
+    "SPEC from T0 and gate comments from T1",
+    "Create/switch branch feat/<slug> from dev",
+    "Implement minimal focused changes",
+    "Run npm run typecheck, npm run lint, and targeted tests; for E2E use npm run session:run -- --grep <area>",
+    "Commit changes with conventional commit message",
+    "Return branch, commit SHA, changed files, commands/results, risks",
+  ],
+  failBehavior: "If Codex or validation fails, block with logs or create T2R retry WITHOUT parent link to blocked gate.",
+}, null, 2);
+
+const t2 = createTask({
+  key: "T2-dev-codex-runner",
+  taskTitle: `[${pipelineId}] T2 DEV RUNNER/CODEX — ${title}`,
+  assignee: "developer",
+  body: t2Body,
+  parents: [t1.id],
+  skills: ["codex"],
+  maxRetries: 1,
+  maxRuntime: "4h",
+});
+
+const t3Body = JSON.stringify({
+  ...common,
+  role: "T3_TECH_VALIDATOR_CODE_GATE",
+  metadataContract: commonMetadataContract,
+  learningCandidateContract,
+  input: "Review branch/commit/diff from T2.",
+  gate: {
+    pass: "Diff is correct, minimal, typed, safe, and validation evidence is credible.",
+    warn: "Non-blocking debt documented; can proceed to QA.",
+    fail: "Block with concrete findings and create T2R retry WITHOUT parent link to this blocked gate.",
+  },
+  checks: ["security", "types", "architecture", "test coverage", "performance", "regressions", "secret leaks", "learning_candidates"],
+}, null, 2);
+
+const t3 = createTask({
+  key: "T3-code-gate",
+  taskTitle: `[${pipelineId}] T3 CODE GATE — ${title}`,
+  assignee: "tech-validator",
+  body: t3Body,
+  parents: [t2.id],
+  skills: [],
+  maxRuntime: "90m",
+});
+
+const t4Body = JSON.stringify({
+  ...common,
+  role: "T4_QA_GATE",
+  metadataContract: commonMetadataContract,
+  learningCandidateContract,
+  input: "Validate implementation from T2 after T3 pass/warn.",
+  requiredPattern: "Use session pool only: npm run session:list / npm run session:run; never raw port 3000.",
+  gate: {
+    pass: "Acceptance criteria verified with E2E/visual/accessibility evidence.",
+    flaky: "One auto-retry allowed for infra/timeouts; classify as QA_FLAKY with evidence.",
+    fail: "Block with reproducible steps and create T2R retry WITHOUT parent link to this blocked gate.",
+  },
+  checks: ["acceptance criteria", "responsive UI", "WCAG AA basics", "SEO/public rendering if applicable", "no console/runtime errors", "learning_candidates"],
+}, null, 2);
+
+const t4 = createTask({
+  key: "T4-qa-gate",
+  taskTitle: `[${pipelineId}] T4 QA GATE — ${title}`,
+  assignee: "qa-engineer",
+  body: t4Body,
+  parents: [t3.id],
+  skills: [],
+  maxRuntime: "2h",
+});
+
+const t5Body = JSON.stringify({
+  ...common,
+  role: "T5_OPS_HANDOFF",
+  metadataContract: commonMetadataContract,
+  learningCandidateContract,
+  input: "Prepare merge/deploy handoff after T4 pass.",
+  instructions: [
+    "Do not deploy blindly. Confirm branch, CI status, rollback plan, and target branch.",
+    "If PR missing, create PR or output exact command for PR creation.",
+    "For production: main push triggers GH Actions deploy; include monitoring/rollback notes.",
+    "Emit learning_candidates for T6 with redaction_checked=true.",
+  ],
+}, null, 2);
+
+const t5 = createTask({
+  key: "T5-ops-handoff",
+  taskTitle: `[${pipelineId}] T5 OPS HANDOFF — ${title}`,
+  assignee: "ops",
+  body: t5Body,
+  parents: [t4.id],
+  skills: [],
+  maxRuntime: "60m",
+});
+
+const t6Body = JSON.stringify({
+  ...common,
+  role: "T6_LEARNING_CURATOR",
+  metadataContract: commonMetadataContract,
+  learningCandidateContract,
+  input: "Curate learning after T5 ops handoff. Read all parent task handoffs and Kanban trace.",
+  instructions: [
+    "Create or update docs/ai/learning-runs/<date>-<pipelineId>.md using docs/ai/templates/learning-run-template.md.",
+    "Classify learning_candidates into skill_patch, profile_fact, pattern_doc, adr_update, github_issue, prompt_update, or rejected_noise.",
+    "Do not persist secrets, raw logs, credentials, tokens, cookie values, raw env values, or raw PII.",
+    "Prefer GitHub/repo docs for shared institutional knowledge; keep profile-private facts scoped.",
+    "If Villa de Leyva backfill applies and no example exists, create it or open/document a follow-up.",
+    "Return PASS/FAIL/WARN with learning_run_path, applied/proposed learning, rejected candidates, and follow_up_issues.",
+  ],
+}, null, 2);
+
+const t6 = createTask({
+  key: "T6-learning-curator",
+  taskTitle: `[${pipelineId}] T6 LEARNING CURATOR — ${title}`,
+  assignee: "learning-curator",
+  body: t6Body,
+  parents: [t5.id],
+  skills: [],
+  maxRuntime: "90m",
+});
+
+const tasks = [t0, t1, t2, t3, t4, t5, t6];
+
+console.log(JSON.stringify({
+  mode: apply ? "APPLY" : "DRY_RUN",
+  pipelineId,
+  tenant,
+  title,
+  sourceOfTruth,
+  githubIssue,
+  githubUrl,
+  graph: tasks.map((t) => ({ id: t.id, title: t.taskTitle, assignee: t.assignee, parents: t.parents, skills: t.skills })),
+  next: apply
+    ? "Run: hermes kanban dispatch --max 3"
+    : "Dry-run only. Re-run with --apply to create tasks.",
+}, null, 2));

--- a/scripts/ai/dev-pipeline-preflight.mjs
+++ b/scripts/ai/dev-pipeline-preflight.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * Bukeer Studio Development Pipeline Preflight
+ *
+ * Fails fast before creating a Kanban development workflow.
+ * Checks the exact things that have historically caused silent hangs:
+ * - Hermes gateway/dispatcher running
+ * - required T0→T6 profiles exist
+ * - Kanban DB reachable
+ * - repo branch / Node version
+ * - Codex CLI installed and authenticated
+ * - existing watchdog script available
+ *
+ * Usage:
+ *   node scripts/ai/dev-pipeline-preflight.mjs
+ *   node scripts/ai/dev-pipeline-preflight.mjs --json
+ *   node scripts/ai/dev-pipeline-preflight.mjs --allow-main
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import process from "node:process";
+
+const REQUIRED_PROFILES = ["specifier", "tech-validator", "developer", "qa-engineer", "ops", "learning-curator"];
+const DEFAULT_REPO = "/opt/data/home/repos/bukeer-studio";
+const REPO = process.env.DEV_PIPELINE_REPO || process.cwd() || DEFAULT_REPO;
+const WATCHDOG = "/opt/data/scripts/kanban-watchdog.py";
+const CODEX_CANDIDATES = [
+  process.env.CODEX_BIN,
+  "codex",
+  "/opt/data/.npm-global/bin/codex",
+  "/usr/local/bin/codex",
+].filter(Boolean);
+
+const args = new Set(process.argv.slice(2));
+const json = args.has("--json");
+const allowMain = args.has("--allow-main");
+
+function buildEnv() {
+  const nvmNodeBin = "/opt/data/home/.nvm/versions/node/v22.22.2/bin";
+  const pathEntries = [
+    nvmNodeBin,
+    "/opt/hermes/.venv/bin",
+    "/opt/data/.local/bin",
+    "/opt/data/.npm-global/bin",
+    process.env.PATH || "",
+  ];
+
+  return {
+    ...process.env,
+    HERMES_HOME: process.env.HERMES_HOME || "/opt/data",
+    NVM_DIR: process.env.NVM_DIR || "/opt/data/home/.nvm",
+    PATH: pathEntries.join(":"),
+  };
+}
+
+function run(cmd, cmdArgs = [], opts = {}) {
+  try {
+    return {
+      ok: true,
+      stdout: execFileSync(cmd, cmdArgs, {
+        cwd: opts.cwd || REPO,
+        env: buildEnv(),
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: opts.timeout || 30_000,
+      }).trim(),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      stdout: error.stdout?.toString()?.trim() || "",
+      stderr: error.stderr?.toString()?.trim() || error.message,
+      status: error.status,
+    };
+  }
+}
+
+function check(name, fn) {
+  try {
+    const result = fn();
+    return { name, ...result };
+  } catch (error) {
+    return { name, ok: false, detail: error.message };
+  }
+}
+
+function findCodex() {
+  for (const candidate of CODEX_CANDIDATES) {
+    const res = spawnSync(candidate, ["--version"], {
+      cwd: REPO,
+      env: buildEnv(),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (res.status === 0) {
+      return { bin: candidate, version: (res.stdout || res.stderr).trim() };
+    }
+  }
+  return null;
+}
+
+const checks = [];
+
+checks.push(check("repo_exists", () => ({
+  ok: existsSync(REPO),
+  detail: REPO,
+})));
+
+checks.push(check("git_branch", () => {
+  const res = run("git", ["branch", "--show-current"]);
+  const branch = res.stdout || "unknown";
+  const ok = allowMain ? branch !== "main" : branch === "dev";
+  return {
+    ok,
+    detail: ok ? branch : `current=${branch}; expected=dev (or pass --allow-main for setup-only runs)`,
+  };
+}));
+
+checks.push(check("working_tree", () => {
+  const res = run("git", ["status", "--short"]);
+  const lines = res.stdout.split("\n").filter(Boolean);
+  const unrelated = lines.filter((line) => !line.includes("scripts/ai/dev-pipeline") && !line.includes("scripts/growth/"));
+  return {
+    ok: true,
+    detail: lines.length ? `${lines.length} changed/untracked files (${unrelated.length} unrelated)` : "clean",
+  };
+}));
+
+checks.push(check("node_version", () => {
+  const res = run("node", ["--version"]);
+  const major = Number((res.stdout.match(/^v(\d+)/) || [])[1] || 0);
+  return {
+    ok: major >= 22,
+    detail: `${res.stdout}; expected >=22`,
+  };
+}));
+
+checks.push(check("hermes_gateway", () => {
+  const res = run("hermes", ["gateway", "status"], { cwd: "/opt/data" });
+  return {
+    ok: res.ok && /running/i.test(res.stdout),
+    detail: res.ok ? res.stdout.split("\n")[0] : res.stderr,
+  };
+}));
+
+checks.push(check("kanban_db", () => {
+  const res = run("hermes", ["kanban", "stats"], { cwd: "/opt/data" });
+  return {
+    ok: res.ok,
+    detail: res.ok ? "kanban stats reachable" : res.stderr,
+  };
+}));
+
+checks.push(check("profiles", () => {
+  const res = run("hermes", ["profile", "list"], { cwd: "/opt/data" });
+  const missing = REQUIRED_PROFILES.filter((p) => !res.stdout.includes(p));
+  return {
+    ok: res.ok && missing.length === 0,
+    detail: missing.length ? `missing: ${missing.join(", ")}` : `present: ${REQUIRED_PROFILES.join(", ")}`,
+  };
+}));
+
+checks.push(check("codex_cli", () => {
+  const found = findCodex();
+  return {
+    ok: Boolean(found),
+    detail: found ? `${found.bin} → ${found.version}` : "codex not found in PATH nor /opt/data/.npm-global/bin",
+  };
+}));
+
+checks.push(check("codex_auth", () => {
+  const found = findCodex();
+  if (!found) return { ok: false, detail: "skip: codex missing" };
+  const res = run(found.bin, ["login", "status"], { cwd: REPO, timeout: 20_000 });
+  return {
+    ok: res.ok,
+    detail: res.ok ? (res.stdout || "Logged in") : res.stderr,
+  };
+}));
+
+checks.push(check("watchdog", () => ({
+  ok: existsSync(WATCHDOG),
+  detail: WATCHDOG,
+})));
+
+const ok = checks.every((c) => c.ok);
+
+if (json) {
+  console.log(JSON.stringify({ ok, checks }, null, 2));
+} else {
+  console.log(`Bukeer Studio dev-pipeline preflight: ${ok ? "PASS" : "FAIL"}`);
+  for (const c of checks) {
+    console.log(`${c.ok ? "✅" : "❌"} ${c.name}: ${c.detail}`);
+  }
+  if (!ok) {
+    console.log("\nFix failing checks before creating/running a real development pipeline.");
+  }
+}
+
+process.exit(ok ? 0 : 1);


### PR DESCRIPTION
## Summary

Add T6 learning-curator stage to the Bukeer Studio development Kanban pipeline, closing the learning loop so each run captures, filters, routes, and reuses durable lessons without replacing GitHub as source of truth.

Closes #542
References #535

## Changes

### Pipeline and infrastructure
- **docs/ops/development-kanban-pipeline.md** — Updated DAG from T0-T5 to T0-T6 with full T6 role contract, memory boundaries, metadata contract for all T0-T6 tasks, learning candidate routing table, and redaction rules
- **scripts/ai/dev-pipeline-preflight.mjs** — Added learning-curator to required profiles check
- **scripts/ai/create-dev-pipeline.mjs** — Generator outputs T6 learning-curator stage after T5 in pipeline DAG
- **package.json** — Added dev-pipeline:create and dev-pipeline:preflight scripts

### Documentation and ADRs
- **docs/architecture/ADR-030-dev-pipeline-self-learning.md** — ADR documenting the decision to add T6 learning-curator, three memory layers, security/redaction rules, and relationship to ADR-003, ADR-005, ADR-010, ADR-013, ADR-014, ADR-023
- **docs/ai/learning-runs/README.md** — Guide for the learning runs directory
- **docs/ai/learning-runs/index.schema.json** — JSON Schema (draft 2020-12) for learning run indexes
- **docs/ai/templates/learning-run-template.md** — Template for learning runs with outcome, evidence, failures, patterns, candidates sections
- **docs/ai/patterns/README.md** — Guide for the patterns directory
- **docs/ai/learning-runs/2026-05-14-villa-leyva-dev-20260514b.md** — First manual learning run (Villa de Leyva backfill)
- **docs/INDEX.md** — Updated with 8 new wikilinks for learning-run docs

### Spec
- **docs/specs/generated/github-542-learning-loop-20260514-SPEC.md** — Full executable specification

## Gate results

| Gate | Result | Evidence |
|------|--------|----------|
| T1 PLAN gate | PASS | All ADRs referenced, non-goals documented, complete DAG defined |
| T3 CODE gate | PASS | 12 files, 9 security checks pass, no secrets in artifacts |
| T4 QA gate | PASS | 48/48 checks pass, dry-run confirms T6 in DAG, all docs complete |
| T5 OPS handoff | PASS | Branch pushed, PR created |

## Learning candidates from this run

1. **Profile fix (ops)**: Learning-curator profile SOUL.md and config.yaml had copy-paste from tech-validator - SOUL.md now correctly identifies as Learning Curator, config.yaml points to learning-curator/memory_store.db
2. **Worktree pattern**: When reviewing a feature branch that exists in git worktree, use .worktrees/feat-*/ directly instead of git checkout to avoid conflicts

## Follow-up

- Deploy profile learning-curator before enabling real T6 runs (profile created at /opt/data/profiles/learning-curator/)
- T6 task t_3b6161b8 already created and ready for dispatch once this PR is merged
