### PR TITLE
feat(growth): add provider context packet contract and builder

### DIFF
--- a/__tests__/lib/growth/context-packets/builder.test.ts
+++ b/__tests__/lib/growth/context-packets/builder.test.ts
@@ -1,0 +1,345 @@
+import {
+  GrowthProviderContextPacketSchema,
+  type GrowthProviderContextPacket,
+} from "@bukeer/website-contract";
+import { buildGrowthProviderContextPacket } from "@/lib/growth/context-packets";
+
+const ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
+const WEBSITE_ID = "22222222-2222-4222-8222-222222222222";
+const OTHER_ACCOUNT_ID = "33333333-3333-4333-8333-333333333333";
+const OTHER_WEBSITE_ID = "44444444-4444-4444-8444-444444444444";
+const NOW = new Date("2026-05-14T12:00:00.000Z");
+const ENTITY = {
+  type: "page" as const,
+  id: "pkg-colombia-tours",
+  canonical_url: "https://example.test/tours/colombia",
+  locale: "es-CO",
+  market: "CO",
+  path: "/tours/colombia",
+  slug: null,
+  metadata: {},
+};
+
+type TableRows = Record<string, Array<Record<string, unknown>>>;
+
+class ReadOnlySupabaseMock {
+  readonly calls: Array<{ table: string; method: string; args: unknown[] }> = [];
+
+  constructor(private readonly rowsByTable: TableRows) {}
+
+  from(table: string) {
+    this.calls.push({ table, method: "from", args: [] });
+    return new QueryMock(table, this.rowsByTable[table] ?? [], this.calls);
+  }
+}
+
+class QueryMock {
+  private rows: Array<Record<string, unknown>>;
+
+  constructor(
+    private readonly table: string,
+    rows: Array<Record<string, unknown>>,
+    private readonly calls: Array<{ table: string; method: string; args: unknown[] }>,
+  ) {
+    this.rows = [...rows];
+  }
+
+  select(...args: unknown[]) {
+    this.calls.push({ table: this.table, method: "select", args });
+    return this;
+  }
+
+  eq(column: string, value: unknown) {
+    this.calls.push({ table: this.table, method: "eq", args: [column, value] });
+    this.rows = this.rows.filter((row) => row[column] === value);
+    return this;
+  }
+
+  in(column: string, values: unknown[]) {
+    this.calls.push({ table: this.table, method: "in", args: [column, values] });
+    this.rows = this.rows.filter((row) => values.includes(row[column]));
+    return this;
+  }
+
+  order(column: string, options?: { ascending?: boolean }) {
+    this.calls.push({ table: this.table, method: "order", args: [column, options] });
+    const direction = options?.ascending === false ? -1 : 1;
+    this.rows = [...this.rows].sort((left, right) => {
+      const leftValue = String(left[column] ?? "");
+      const rightValue = String(right[column] ?? "");
+      return leftValue.localeCompare(rightValue) * direction;
+    });
+    return this;
+  }
+
+  limit(count: number) {
+    this.calls.push({ table: this.table, method: "limit", args: [count] });
+    this.rows = this.rows.slice(0, count);
+    return this;
+  }
+
+  then<TResult1 = { data: Array<Record<string, unknown>>; error: null }, TResult2 = never>(
+    onfulfilled?: ((value: { data: Array<Record<string, unknown>>; error: null }) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): PromiseLike<TResult1 | TResult2> {
+    return Promise.resolve({ data: this.rows, error: null }).then(onfulfilled, onrejected);
+  }
+}
+
+function profileRun(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    account_id: ACCOUNT_ID,
+    website_id: WEBSITE_ID,
+    provider: "gsc",
+    profile_id: "gsc_growth_minimum_v1",
+    run_status: "completed",
+    freshness_status: "fresh",
+    quality_status: "pass",
+    evidence_fingerprint: "sha256:gsc-fresh",
+    source_refs: ["growth_gsc_cache:gsc-row-1"],
+    payload: { summary: { clicks: 42, impressions: 4200 } },
+    started_at: "2026-05-14T10:00:00.000Z",
+    completed_at: "2026-05-14T10:10:00.000Z",
+    expires_at: "2026-05-22T10:10:00.000Z",
+    entity_key: "page:pkg-colombia-tours",
+    action_key: "content_refresh:page:pkg-colombia-tours",
+    ...overrides,
+  };
+}
+
+function createRows(overrides: TableRows = {}): TableRows {
+  return {
+    growth_profile_runs: [
+      profileRun(),
+      profileRun({
+        id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        provider: "ga4",
+        profile_id: "ga4_growth_minimum_v1",
+        evidence_fingerprint: "sha256:ga4-fresh",
+        source_refs: ["growth_ga4_cache:ga4-row-1"],
+        payload: { summary: { sessions: 120, conversions: 8 } },
+        expires_at: "2026-05-22T10:10:00.000Z",
+      }),
+    ],
+    growth_gsc_cache: [
+      {
+        id: "gsc-row-1",
+        account_id: ACCOUNT_ID,
+        website_id: WEBSITE_ID,
+        page_path: "/tours/colombia",
+        query: "colombia tours",
+        clicks: 42,
+        impressions: 4200,
+      },
+    ],
+    growth_ga4_cache: [
+      {
+        id: "ga4-row-1",
+        account_id: ACCOUNT_ID,
+        website_id: WEBSITE_ID,
+        page_path: "/tours/colombia",
+        sessions: 120,
+        conversions: 8,
+      },
+    ],
+    growth_dataforseo_cache: [],
+    growth_inventory: [],
+    funnel_events: [],
+    growth_work_items: [],
+    growth_publication_jobs: [],
+    growth_work_item_outcomes: [],
+    ...overrides,
+  };
+}
+
+async function buildPacket(rows: TableRows, requiredProfileIds = ["gsc_growth_minimum_v1", "ga4_growth_minimum_v1"]) {
+  const supabase = new ReadOnlySupabaseMock(rows);
+  const packet = await buildGrowthProviderContextPacket({
+    supabase,
+    accountId: ACCOUNT_ID,
+    websiteId: WEBSITE_ID,
+    workerLane: "content",
+    workType: "content_refresh",
+    entity: ENTITY,
+    requiredProfileIds,
+    allowedActions: ["draft_content_brief"],
+    now: NOW,
+  });
+  return { packet, supabase };
+}
+
+describe("Growth provider context packet contract", () => {
+  it("accepts complete fresh packets and requires direct provider API blocking", () => {
+    const basePacket: GrowthProviderContextPacket = {
+      packet_version: "growth-provider-context-packet-v1",
+      status: "pass",
+      generated_at: NOW.toISOString(),
+      account_id: ACCOUNT_ID,
+      website_id: WEBSITE_ID,
+      locale: "es-CO",
+      market: "CO",
+      worker_lane: "content",
+      work_type: "content_refresh",
+      entity: ENTITY,
+      freshness_map: {
+        gsc_growth_minimum_v1: {
+          profile_id: "gsc_growth_minimum_v1",
+          provider: "gsc",
+          status: "fresh",
+          required: true,
+          fetched_at: "2026-05-14T10:10:00.000Z",
+          expires_at: "2026-05-22T10:10:00.000Z",
+          quality_status: "pass",
+          run_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          no_go_reasons: [],
+        },
+      },
+      source_profiles: [
+        {
+          profile_id: "gsc_growth_minimum_v1",
+          provider: "gsc",
+          run_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          window_start: "2026-05-14T10:00:00.000Z",
+          window_end: "2026-05-14T10:10:00.000Z",
+          cache_refs: ["growth_gsc_cache:gsc-row-1"],
+          fact_ids: [],
+          evidence_fingerprint: "sha256:gsc-fresh",
+          source_refs: ["growth_gsc_cache:gsc-row-1"],
+        },
+      ],
+      facts: {
+        search_demand: {
+          items: [{ query: "colombia tours", clicks: 42 }],
+          source_profile_ids: ["gsc_growth_minimum_v1"],
+          no_go_reasons: [],
+        },
+        technical_issues: { items: [], source_profile_ids: [], no_go_reasons: [] },
+        market_terms: { items: [], source_profile_ids: [], no_go_reasons: [] },
+        conversion_signals: { items: [], source_profile_ids: [], no_go_reasons: [] },
+        paid_signals: { items: [], source_profile_ids: [], no_go_reasons: [] },
+        ux_friction: { items: [], source_profile_ids: [], no_go_reasons: [] },
+      },
+      previous_actions: [],
+      dedupe_verdict: {
+        verdict: "proceed",
+        evidence_fingerprint: "sha256:gsc-fresh",
+        reason: "fresh_required_profiles",
+        previous_refs: [],
+        no_go_reasons: [],
+      },
+      allowed_actions: ["draft_content_brief"],
+      blocked_actions: [
+        {
+          action: "call_provider_api_directly",
+          reason: "Provider API access is restricted to provider profiles.",
+        },
+      ],
+    };
+
+    expect(GrowthProviderContextPacketSchema.parse(basePacket).blocked_actions).toEqual(
+      expect.arrayContaining([expect.objectContaining({ action: "call_provider_api_directly" })]),
+    );
+
+    expect(
+      GrowthProviderContextPacketSchema.safeParse({
+        ...basePacket,
+        blocked_actions: [],
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("buildGrowthProviderContextPacket", () => {
+  it("builds a fresh PASS packet with scoped GSC/GA4 facts and no provider writes", async () => {
+    const { packet, supabase } = await buildPacket(createRows());
+
+    expect(packet.status).toBe("pass");
+    expect(packet.dedupe_verdict.verdict).toBe("proceed");
+    expect(packet.blocked_actions).toEqual(
+      expect.arrayContaining([expect.objectContaining({ action: "call_provider_api_directly" })]),
+    );
+    expect(packet.facts.search_demand.items).toEqual(
+      expect.arrayContaining([expect.objectContaining({ query: "colombia tours", clicks: 42 })]),
+    );
+    expect(packet.facts.conversion_signals.items).toEqual(
+      expect.arrayContaining([expect.objectContaining({ sessions: 120, conversions: 8 })]),
+    );
+    expect(supabase.calls.some((call) => ["insert", "upsert", "update", "delete"].includes(call.method))).toBe(false);
+    expect(supabase.calls).toEqual(expect.arrayContaining([
+      expect.objectContaining({ table: "growth_profile_runs", method: "eq", args: ["account_id", ACCOUNT_ID] }),
+      expect.objectContaining({ table: "growth_profile_runs", method: "eq", args: ["website_id", WEBSITE_ID] }),
+    ]));
+  });
+
+  it("returns WATCH and request_refresh when a required profile is stale", async () => {
+    const { packet } = await buildPacket(
+      createRows({
+        growth_profile_runs: [
+          profileRun({
+            freshness_status: "stale",
+            expires_at: "2026-05-13T10:10:00.000Z",
+          }),
+        ],
+      }),
+      ["gsc_growth_minimum_v1"],
+    );
+
+    expect(packet.status).toBe("watch");
+    expect(packet.freshness_map.gsc_growth_minimum_v1.status).toBe("stale");
+    expect(packet.dedupe_verdict.verdict).toBe("request_refresh");
+    expect(packet.dedupe_verdict.no_go_reasons).toContain("profile_stale:gsc_growth_minimum_v1");
+  });
+
+  it("returns BLOCKED and explicit no-go reasons when required evidence is missing", async () => {
+    const { packet } = await buildPacket(createRows({ growth_profile_runs: [] }), ["gsc_growth_minimum_v1"]);
+
+    expect(packet.status).toBe("blocked");
+    expect(packet.freshness_map.gsc_growth_minimum_v1.status).toBe("missing");
+    expect(packet.dedupe_verdict.verdict).toBe("blocked");
+    expect(packet.dedupe_verdict.no_go_reasons).toContain("profile_missing:gsc_growth_minimum_v1");
+    expect(packet.facts.search_demand.no_go_reasons).toContain("profile_missing:gsc_growth_minimum_v1");
+  });
+
+  it("coalesces duplicate active work with the same evidence fingerprint", async () => {
+    const activeWorkId = "55555555-5555-4555-8555-555555555555";
+    const { packet } = await buildPacket(
+      createRows({
+        growth_work_items: [
+          {
+            id: activeWorkId,
+            account_id: ACCOUNT_ID,
+            website_id: WEBSITE_ID,
+            status: "running",
+            evidence: {
+              correlation: {
+                evidence_fingerprint: "sha256:gsc-fresh",
+              },
+            },
+          },
+        ],
+      }),
+      ["gsc_growth_minimum_v1"],
+    );
+
+    expect(packet.dedupe_verdict.verdict).toBe("coalesce");
+    expect(packet.dedupe_verdict.previous_refs).toContain(`growth_work_items:${activeWorkId}`);
+  });
+
+  it("ignores rows from other tenants and does not silently pass missing scoped evidence", async () => {
+    const { packet } = await buildPacket(
+      createRows({
+        growth_profile_runs: [
+          profileRun({
+            account_id: OTHER_ACCOUNT_ID,
+            website_id: OTHER_WEBSITE_ID,
+          }),
+        ],
+      }),
+      ["gsc_growth_minimum_v1"],
+    );
+
+    expect(packet.status).toBe("blocked");
+    expect(packet.freshness_map.gsc_growth_minimum_v1.status).toBe("missing");
+  });
+});

--- a/docs/plans/PLAN_GROWTH_OS_CONTEXT_PACKET_CONTRACT_ISSUE_537.md
+++ b/docs/plans/PLAN_GROWTH_OS_CONTEXT_PACKET_CONTRACT_ISSUE_537.md
@@ -1,0 +1,227 @@
+# Growth OS Context Packet Contract (#537) Implementation Plan
+
+> For Hermes: Use subagent-driven-development skill to implement this plan task-by-task after tech-validator PLAN review. Do not implement code from this spec task.
+
+Goal: Add a contract-first, read-only Growth OS context packet schema and builder so workers consume scoped, fresh, deduped Supabase facts instead of calling provider APIs directly.
+
+Architecture: Put the packet Zod contract in `@bukeer/website-contract` beside existing Growth OS schemas, then implement a read-only app-side builder under `lib/growth/context-packets/` using mockable Supabase interfaces. The builder reads existing operational SSOT rows only, evaluates freshness and anti-rework, returns WATCH/BLOCKED for missing/stale required evidence, and always blocks direct provider API calls.
+
+Tech Stack: Next.js 15 / React 19 repo, TypeScript strict, Zod v4, Jest + ts-jest, Supabase query builder interfaces.
+
+Related ADRs and source docs:
+- ADR-003: contract-first Zod validation in `@bukeer/website-contract`.
+- ADR-005: no secrets/PII in packet payloads; defense-in-depth around worker inputs.
+- ADR-008: package exports from `packages/website-contract/src/index.ts` are the monorepo contract surface.
+- ADR-009: tenant scoping by `website_id` and `account_id`.
+- ADR-016: provider cache freshness/TTL must be explicit.
+- ADR-018: anti-rework/dedupe must use stable fingerprints and idempotent/replay-safe semantics.
+- ADR-029: `funnel_events` is conversion/CRM tracking SSOT, not GA4/Ads platform truth.
+- Source spec: `docs/specs/SPEC_GROWTH_OS_PROVIDER_PROFILE_ARCHITECTURE_V2.md` lines 122-137 require context packet sections.
+- Registry audit: `docs/audits/AUDIT_GROWTH_OS_PROVIDER_PROFILE_REGISTRY_MAP_2026-05.md` recommends `feat(contract): add GrowthProviderContextPacket schema` and `feat(growth): build read-only context packet builder over Supabase facts`.
+- Beta plan: `docs/plans/PLAN_GROWTH_OS_PROVIDER_PROFILE_BETA_IMPLEMENTATION.md` Phase 2.
+
+Important constraints:
+- Work only in `/opt/data/home/worktrees/bukeer-studio-context-packet` on branch `growth-context-packet-contract`.
+- Do not touch `/opt/data/home/repos/bukeer-studio`.
+- Read-only builder only; do not call DataForSEO, GSC, GA4, Clarity, Ads, Meta, TikTok, LinkedIn, or any provider API.
+- Do not log or commit secrets. Do not add fixtures containing raw PII.
+- GitHub planning SSOT; Supabase operational SSOT.
+- Missing/stale required provider profiles must yield WATCH/BLOCKED status, not silent empty arrays.
+- Multi-tenant scope is required by `website_id` and `account_id` where relevant.
+
+Existing surfaces inspected:
+- `packages/website-contract/src/index.ts`: central export surface; Growth OS schemas already exported here.
+- `packages/website-contract/src/schemas/growth-provider-intelligence.ts`: already defines `GrowthProviderSchema`, `GrowthProviderFreshnessStatusSchema`, `GrowthProviderQualityStatusSchema`, `ProviderEvidenceReadSchema`, `GrowthEvidenceCorrelationResultSchema`, and `GrowthEvidenceDedupeVerdictSchema`. Reuse these types rather than redefining them.
+- `packages/website-contract/src/schemas/growth-agent-context-packs.ts`: prior context-pack contract pattern using `GrowthTenantScopeSchema`.
+- `lib/growth/agentic/context-builder.ts`: existing broad agentic context snapshot builder. Do not replace it in #537; add a narrower provider context packet builder beside it.
+- `lib/growth/providers/profile-registry.ts`: typed provider registry with profile TTLs and approval/cost metadata; useful for default required profile definitions.
+- `lib/growth/providers/evidence-correlation.ts`: existing stable fingerprint + dedupe evaluator; reuse in builder tests for duplicate evidence cases.
+- Supabase migrations already expose operational tables: `growth_profile_runs`, `growth_gsc_cache`, `growth_ga4_cache`, `growth_dataforseo_cache`, `growth_inventory`, `growth_work_items`, `growth_publication_jobs`, `growth_work_item_outcomes`, `funnel_events`.
+
+Required packet sections from SPEC v2 and planned fields:
+- `packet_version`: literal `growth-provider-context-packet-v1`.
+- `website_id / account_id`: inherited from `GrowthTenantScopeSchema`, both required.
+- `worker_lane / work_type`: `worker_lane` enum/string for lane; `work_type` string for task/action family.
+- `entity`: object with `type`, `id`, `canonical_url`, `locale`, `market` plus optional `path`/`slug`/`metadata`.
+- `freshness_map by profile_id`: record or array keyed by profile id, with status `fresh|stale|missing|blocked|approval_required|cost_gated|quota_exhausted`, fetched/expires timestamps, required flag, quality status, and no-go reasons.
+- `source_profiles`: profile id, provider, run id, window, cache refs, fact ids, evidence fingerprint, source refs.
+- `facts`: named buckets `search_demand`, `technical_issues`, `market_terms`, `conversion_signals`, `paid_signals`, `ux_friction`, each carrying summarized rows and source profile ids.
+- `previous_actions`: prior work items, publication jobs, pending outcomes and measurement windows.
+- `dedupe_verdict`: `proceed|skip|coalesce|reopen|request_refresh|blocked` with evidence fingerprint, reason, previous refs, no-go reasons.
+- `allowed_actions`: explicit worker actions allowed by packet.
+- `blocked_actions`: must include `call_provider_api_directly` whenever workers consume provider-derived context; also include paid mutation actions during beta.
+
+Schema outline:
+- Create `packages/website-contract/src/schemas/growth-provider-context-packet.ts`.
+- Reuse imports from `growth-attribution` and `growth-provider-intelligence`.
+- Add/Export:
+  - `GrowthProviderContextPacketVersionSchema = z.literal('growth-provider-context-packet-v1')`
+  - `GrowthProviderContextPacketStatusSchema = z.enum(['pass','watch','blocked'])`
+  - `GrowthProviderWorkerLaneSchema = z.enum(['content','transcreation','technical','cro','campaign_optimizer','all']).or(z.string().min(1).max(80))`
+  - `GrowthProviderContextEntitySchema`
+  - `GrowthProviderFreshnessEntrySchema`
+  - `GrowthProviderSourceProfileSchema`
+  - `GrowthProviderContextFactBucketSchema`
+  - `GrowthProviderContextFactsSchema`
+  - `GrowthProviderPreviousActionSchema`
+  - `GrowthProviderDedupeVerdictSchema = z.enum(['proceed','skip','coalesce','reopen','request_refresh','blocked'])`
+  - `GrowthProviderContextDedupeSchema`
+  - `GrowthProviderBlockedActionSchema`
+  - `GrowthProviderContextPacketSchema = GrowthTenantScopeSchema.extend({...}).superRefine(...)`
+  - `GrowthProviderContextPacketInputSchema` if useful for tests/builder input.
+  - Types for every schema with `z.infer`.
+- SuperRefine rules:
+  - `blocked_actions` must include `call_provider_api_directly`.
+  - If any required freshness entry is `missing|stale|blocked|approval_required|cost_gated|quota_exhausted`, top-level `status` cannot be `pass` and dedupe verdict should be `request_refresh` or `blocked`.
+  - Every fact source profile id must exist in `source_profiles` or be empty with an explicit freshness WATCH/BLOCKED reason.
+  - `generated_at` must be ISO datetime; source windows with both `window_start` and `window_end` must have end >= start.
+
+Exports:
+- Modify `packages/website-contract/src/index.ts` near the Growth OS provider-intelligence exports to export the new schemas and types.
+- Do not alter unrelated package exports.
+
+Builder strategy:
+- Create `lib/growth/context-packets/types.ts` with builder options and a minimal mockable Supabase interface if the existing `SupabaseLike` from `lib/growth/autonomy/runtime-common.ts` is too broad.
+- Create `lib/growth/context-packets/builder.ts` with `buildGrowthProviderContextPacket(options)`.
+- Recommended options:
+  - `supabase`
+  - `accountId`
+  - `websiteId`
+  - `workerLane`
+  - `workType`
+  - `entity: { type, id?, canonicalUrl?, locale?, market?, path?, slug? }`
+  - `requiredProfileIds?: string[]`
+  - `allowedActions?: string[]`
+  - `now?: Date`
+- Read-only Supabase reads only:
+  - `growth_profile_runs`: latest rows for profile freshness/source profiles; filter by account/website, profile ids, entity key where available; never insert/update.
+  - `growth_gsc_cache`, `growth_ga4_cache`, `growth_dataforseo_cache`: summarized/cache refs for source facts when available.
+  - `growth_inventory`: canonical URL/entity metadata and technical inventory facts.
+  - `funnel_events`: conversion/CRM truth per ADR-029, scoped by account/website/entity where possible.
+  - `growth_work_items`, `growth_publication_jobs`, `growth_work_item_outcomes`: previous actions and measurement windows.
+- Use `GROWTH_PROVIDER_PROFILE_REGISTRY` TTL metadata to classify freshness when profile row expires_at is absent. Prefer explicit `freshness_status`/`expires_at` from `growth_profile_runs` when present.
+- Use `computeGrowthEvidenceFingerprint` and/or `evaluateGrowthEvidenceCorrelation` from `lib/growth/providers/evidence-correlation.ts` for anti-rework instead of creating a new hash convention.
+- Always return a parsed `GrowthProviderContextPacketSchema` object; validation failure should be a developer error in tests.
+- Do not persist packets in #537 unless a later issue asks for `growth_context_snapshots` integration. This task is read-only builder + contract.
+- Add a tiny `index.ts` under `lib/growth/context-packets/` only if internal imports benefit from it.
+
+Fresh/stale/missing/duplicate behavior:
+- Fresh: required profiles have latest successful rows with `freshness_status='fresh'` or `expires_at > now`; packet status `pass`, dedupe verdict `proceed`, facts populated from fixture rows, direct provider calls blocked.
+- Stale: required profile has row but `expires_at <= now` or explicit `freshness_status='stale'`; packet status `watch`, dedupe verdict `request_refresh`, facts may include stale summaries with no-go reason `profile_stale:<profile_id>`.
+- Missing: required profile has no row; packet status `blocked`, dedupe verdict `request_refresh` or `blocked`, facts bucket empty only with explicit `profile_missing:<profile_id>` no-go reason.
+- Duplicate evidence: existing active/measuring/failed/won/lost work with same correlation/action/evidence fingerprint returns `coalesce`, `skip`, `reopen`, `blocked`, or `scale` mapping to context packet `dedupe_verdict` as appropriate. For #537 tests, cover at least active duplicate -> `coalesce` and measurement duplicate -> `skip`.
+
+Files to add/change:
+- Create: `packages/website-contract/src/schemas/growth-provider-context-packet.ts`
+- Modify: `packages/website-contract/src/index.ts`
+- Create: `lib/growth/context-packets/types.ts`
+- Create: `lib/growth/context-packets/builder.ts`
+- Optional Create: `lib/growth/context-packets/index.ts`
+- Create: `__tests__/growth/context-packets/builder.test.ts`
+- Optional Create: `packages/website-contract/src/__tests__/growth-provider-context-packet.test.ts` if package-local schema tests are preferred.
+- Modify: `docs/INDEX.md` only if implementation adds a new spec/doc link beyond this plan. At minimum link this plan in the Plans section/resolution map if the repo pattern requires plan indexing.
+
+Test strategy:
+- Use Jest. Avoid E2E/dev-server tests; no Playwright needed.
+- Add a lightweight in-memory Supabase mock with chainable `from().select().eq().in().order().limit()` methods, or reuse any existing mock if found during implementation.
+- Fixture data should be synthetic UUIDs, URLs, markets and aggregate counts only; no secrets, tokens, raw emails or phone numbers.
+- Unit tests:
+  1. Contract accepts a complete fresh packet and requires blocked direct provider API action.
+  2. Builder fresh case: GSC/GA4 profile rows fresh; packet status `pass`; includes search/conversion facts; blocked action includes `call_provider_api_directly`.
+  3. Builder stale case: required GSC row expired; packet status `watch`; freshness map marks stale; dedupe verdict `request_refresh`; no silent empty context.
+  4. Builder missing case: required profile absent; packet status `blocked`; no-go reason names missing profile; facts bucket empty only with reason.
+  5. Duplicate evidence case: existing active work item with same evidence fingerprint yields `coalesce` and previous action refs.
+  6. Tenant scoping case: rows for another `website_id`/`account_id` are ignored.
+
+Acceptance criteria:
+- Contract includes every required Context Packet section from SPEC v2 lines 122-137.
+- Schema and builder are exported/usable without consumers importing private files.
+- Builder performs no provider API calls and no Supabase writes.
+- Builder queries include `website_id` and `account_id` filters for all operational tables that have those columns.
+- Missing/stale required profiles produce WATCH/BLOCKED packet status and explicit no-go reasons.
+- Duplicate evidence is not treated as proceed.
+- `blocked_actions` always includes `call_provider_api_directly`.
+- Tests cover fresh, stale, missing, duplicate evidence and tenant isolation.
+- No secrets or raw PII are added to fixtures/logs/docs.
+
+Validation commands:
+- `cd /opt/data/home/worktrees/bukeer-studio-context-packet`
+- `npm run ai:check`
+- `npm run typecheck`
+- `npm test -- __tests__/growth/context-packets/builder.test.ts --runInBand`
+- If package-local tests are added: `npm test -- packages/website-contract/src/__tests__/growth-provider-context-packet.test.ts --runInBand`
+- `cd packages/website-contract && npm run typecheck && npm run build`
+- `npm run tech-validator:code:quick`
+- `git diff --check`
+- Secret/PII sanity check before commit: inspect changed fixtures/docs for tokens, API keys, emails, phone numbers.
+
+Suggested implementation sequence:
+
+### Task 1: Add context packet Zod schema
+Objective: Create the contract in website-contract with validation rules.
+Files:
+- Create `packages/website-contract/src/schemas/growth-provider-context-packet.ts`
+- Test optionally in `packages/website-contract/src/__tests__/growth-provider-context-packet.test.ts`
+Steps:
+1. Write schema tests for required sections and blocked provider action.
+2. Implement schema with reused provider-intelligence enums/types.
+3. Run the package-local schema test or targeted Jest test.
+4. Run `cd packages/website-contract && npm run typecheck`.
+
+### Task 2: Export the contract
+Objective: Make the schema/types available through `@bukeer/website-contract`.
+Files:
+- Modify `packages/website-contract/src/index.ts`
+Steps:
+1. Add exports near existing Growth OS provider-intelligence section.
+2. Run `cd packages/website-contract && npm run build`.
+3. Run `npm run typecheck` from repo root.
+
+### Task 3: Add read-only builder scaffolding
+Objective: Add typed builder entrypoint without provider/API/write behavior.
+Files:
+- Create `lib/growth/context-packets/types.ts`
+- Create `lib/growth/context-packets/builder.ts`
+- Optional create `lib/growth/context-packets/index.ts`
+Steps:
+1. Define builder options and helper types.
+2. Implement tenant-scoped select helpers; queries should read only.
+3. Implement freshness classification against `growth_profile_runs` and registry TTLs.
+4. Parse the output through `GrowthProviderContextPacketSchema`.
+
+### Task 4: Add fixture-driven builder tests
+Objective: Prove fresh/stale/missing/duplicate behavior.
+Files:
+- Create `__tests__/growth/context-packets/builder.test.ts`
+Steps:
+1. Build in-memory Supabase query mock.
+2. Add fresh fixture test.
+3. Add stale fixture test.
+4. Add missing fixture test.
+5. Add duplicate evidence fixture test.
+6. Add tenant isolation test.
+7. Run `npm test -- __tests__/growth/context-packets/builder.test.ts --runInBand`.
+
+### Task 5: Final validation and docs/index check
+Objective: Ensure repo-level checks and documentation traceability pass.
+Files:
+- Modify `docs/INDEX.md` if required by docs convention for this new plan.
+Steps:
+1. Run `npm run ai:check`.
+2. Run `npm run typecheck`.
+3. Run package build/typecheck.
+4. Run targeted tests.
+5. Run `npm run tech-validator:code:quick`.
+6. Run `git diff --check` and review changed fixtures for secrets/PII.
+
+Risks / WATCH items:
+- `GrowthProviderSchema` currently only includes `dataforseo|gsc|ga4|clarity`; paid providers from SPEC v2 are not represented there yet. For #537, either allow source profile `provider` to accept string extensions or plan a separate registry/schema expansion for paid read-only providers.
+- Existing `lib/growth/agentic/context-builder.ts` also builds broad context snapshots. The new builder must not collide semantically; name it `provider context packet` and keep it consumer-worker focused.
+- Supabase table column names may differ across migrations for some previous action/outcome rows. Keep the builder query layer narrow and mockable; fail with WATCH/BLOCKED rather than silently dropping required evidence.
+- Jest path aliases can be brittle for package imports. Prefer importing public `@bukeer/website-contract` exports after Task 2 and use existing Jest config patterns.
+- No live Supabase credentials should be required for unit tests.
+
+Definition of done for #537 implementation PR:
+- All acceptance criteria above pass.
+- The PR description links GitHub issue #537, source spec v2, audit #536, beta plan, and ADRs 003/005/008/009/016/018/029.
+- Tech-validator PLAN review is PASS before implementation and CODE review is PASS before merge.

--- a/lib/growth/context-packets/builder.ts
+++ b/lib/growth/context-packets/builder.ts
@@ -1,0 +1,438 @@
+import {
+  GrowthProviderContextPacketSchema,
+  type GrowthProviderContextFactBucket,
+  type GrowthProviderContextFacts,
+  type GrowthProviderContextPacket,
+  type GrowthProviderDedupeVerdict,
+  type GrowthProviderFreshnessEntry,
+  type GrowthProviderFreshnessStatus,
+  type GrowthProviderPreviousAction,
+  type GrowthProviderSourceProfile,
+} from "@bukeer/website-contract";
+
+import { asRecord, addHours } from "@/lib/growth/autonomy/runtime-common";
+import {
+  computeGrowthEvidenceFingerprint,
+  evaluateGrowthEvidenceCorrelation,
+  type ExistingGrowthEvidenceWork,
+} from "@/lib/growth/providers/evidence-correlation";
+import { GROWTH_PROVIDER_PROFILE_REGISTRY } from "@/lib/growth/providers/profile-registry";
+
+import type {
+  BuildGrowthProviderContextPacketOptions,
+  GrowthProviderContextPacketTableRow,
+} from "./types";
+
+const DIRECT_PROVIDER_API_BLOCK = {
+  action: "call_provider_api_directly",
+  reason: "Provider API access is restricted to provider profiles.",
+};
+
+const PAID_MUTATION_BLOCKS = [
+  {
+    action: "mutate_paid_media_campaign",
+    reason: "Paid media mutation is out of scope for the read-only beta.",
+  },
+  {
+    action: "upload_provider_conversion",
+    reason: "Conversion uploads require a separately approved contract.",
+  },
+];
+
+const FACT_BUCKETS = [
+  "search_demand",
+  "technical_issues",
+  "market_terms",
+  "conversion_signals",
+  "paid_signals",
+  "ux_friction",
+] as const;
+
+const PROFILE_TO_BUCKET: Record<string, keyof GrowthProviderContextFacts> = {
+  gsc_growth_minimum_v1: "search_demand",
+  gsc_indexability_v1: "technical_issues",
+  ga4_growth_minimum_v1: "conversion_signals",
+  ga4_admin_governance_v1: "conversion_signals",
+  dfs_onpage_full_comparable_v3: "technical_issues",
+  dfs_onpage_changed_urls_v1: "technical_issues",
+  dfs_serp_labs_primary_v1: "market_terms",
+  dfs_serp_labs_secondary_v1: "market_terms",
+  clarity_ux_friction_v1: "ux_friction",
+};
+
+function emptyFacts(): GrowthProviderContextFacts {
+  return {
+    search_demand: { items: [], source_profile_ids: [], no_go_reasons: [] },
+    technical_issues: { items: [], source_profile_ids: [], no_go_reasons: [] },
+    market_terms: { items: [], source_profile_ids: [], no_go_reasons: [] },
+    conversion_signals: { items: [], source_profile_ids: [], no_go_reasons: [] },
+    paid_signals: { items: [], source_profile_ids: [], no_go_reasons: [] },
+    ux_friction: { items: [], source_profile_ids: [], no_go_reasons: [] },
+  };
+}
+
+async function readRows(
+  supabase: BuildGrowthProviderContextPacketOptions["supabase"],
+  table: string,
+  accountId: string,
+  websiteId: string,
+): Promise<GrowthProviderContextPacketTableRow[]> {
+  const { data, error } = await supabase
+    .from(table)
+    .select("*")
+    .eq("account_id", accountId)
+    .eq("website_id", websiteId)
+    .order("created_at", { ascending: false })
+    .limit(200);
+
+  if (error) {
+    throw new Error(`Failed to read ${table}: ${error.message ?? String(error)}`);
+  }
+  return Array.isArray(data) ? data : [];
+}
+
+function profileDefinition(profileId: string) {
+  return GROWTH_PROVIDER_PROFILE_REGISTRY.find(
+    (definition) => definition.profileId === profileId,
+  );
+}
+
+function providerForProfile(profileId: string, row?: GrowthProviderContextPacketTableRow) {
+  const rowProvider = typeof row?.provider === "string" ? row.provider : null;
+  return rowProvider ?? profileDefinition(profileId)?.provider ?? "unknown";
+}
+
+function isoOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function classifyFreshness(
+  profileId: string,
+  row: GrowthProviderContextPacketTableRow | undefined,
+  now: Date,
+): { status: GrowthProviderFreshnessStatus; expiresAt: string | null; fetchedAt: string | null; reasons: string[] } {
+  if (!row) {
+    return {
+      status: "missing",
+      expiresAt: null,
+      fetchedAt: null,
+      reasons: [`profile_missing:${profileId}`],
+    };
+  }
+
+  const explicitStatus = typeof row.freshness_status === "string" ? row.freshness_status : null;
+  const fetchedAt = isoOrNull(row.completed_at) ?? isoOrNull(row.fetched_at) ?? isoOrNull(row.created_at);
+  const explicitExpiresAt = isoOrNull(row.expires_at);
+  const ttlHours = profileDefinition(profileId)?.cadence.freshnessTtlHours;
+  const computedExpiresAt = fetchedAt && ttlHours ? addHours(new Date(fetchedAt), ttlHours).toISOString() : null;
+  const expiresAt = explicitExpiresAt ?? computedExpiresAt;
+
+  if (
+    explicitStatus &&
+    ["blocked", "approval_required", "cost_gated", "quota_exhausted", "missing"].includes(explicitStatus)
+  ) {
+    return {
+      status: explicitStatus as GrowthProviderFreshnessStatus,
+      expiresAt,
+      fetchedAt,
+      reasons: [`profile_${explicitStatus}:${profileId}`],
+    };
+  }
+
+  const expired = expiresAt ? Date.parse(expiresAt) <= now.getTime() : false;
+  if (explicitStatus === "stale" || expired) {
+    return {
+      status: "stale",
+      expiresAt,
+      fetchedAt,
+      reasons: [`profile_stale:${profileId}`],
+    };
+  }
+
+  return { status: "fresh", expiresAt, fetchedAt, reasons: [] };
+}
+
+function sourceRefs(row: GrowthProviderContextPacketTableRow): string[] {
+  const refs = row.source_refs;
+  if (Array.isArray(refs)) return refs.map(String);
+  const id = typeof row.id === "string" ? row.id : null;
+  const profileId = typeof row.profile_id === "string" ? row.profile_id : "profile";
+  return id ? [`growth_profile_runs:${id}`] : [`growth_profile_runs:${profileId}`];
+}
+
+function latestRowsByProfile(rows: GrowthProviderContextPacketTableRow[]) {
+  const byProfile = new Map<string, GrowthProviderContextPacketTableRow>();
+  for (const row of rows) {
+    const profileId = typeof row.profile_id === "string" ? row.profile_id : null;
+    if (!profileId || byProfile.has(profileId)) continue;
+    byProfile.set(profileId, row);
+  }
+  return byProfile;
+}
+
+function buildFactItem(row: GrowthProviderContextPacketTableRow) {
+  const payload = asRecord(row.payload);
+  const summary = asRecord(payload.summary);
+  return {
+    profile_id: String(row.profile_id ?? "unknown"),
+    provider: String(row.provider ?? "unknown"),
+    run_id: typeof row.id === "string" ? row.id : null,
+    evidence_fingerprint: typeof row.evidence_fingerprint === "string" ? row.evidence_fingerprint : null,
+    ...summary,
+  };
+}
+
+function pushNoGoToEmptyBuckets(facts: GrowthProviderContextFacts, reasons: string[]) {
+  if (reasons.length === 0) return;
+  for (const bucket of FACT_BUCKETS) {
+    const factBucket = facts[bucket] as GrowthProviderContextFactBucket;
+    if (factBucket.items.length === 0 && factBucket.source_profile_ids.length === 0) {
+      factBucket.no_go_reasons.push(...reasons);
+    }
+  }
+}
+
+function buildPreviousActions(
+  workItems: GrowthProviderContextPacketTableRow[],
+  publicationJobs: GrowthProviderContextPacketTableRow[],
+  outcomes: GrowthProviderContextPacketTableRow[],
+): GrowthProviderPreviousAction[] {
+  const mapRow = (table: string, row: GrowthProviderContextPacketTableRow): GrowthProviderPreviousAction => {
+    const id = String(row.id ?? "unknown");
+    const evidence = asRecord(row.evidence);
+    const correlation = asRecord(evidence.correlation);
+    return {
+      ref: `${table}:${id}`,
+      table,
+      id,
+      status: typeof row.status === "string" ? row.status : null,
+      action_key: typeof row.action_key === "string" ? row.action_key : null,
+      evidence_fingerprint:
+        typeof correlation.evidence_fingerprint === "string"
+          ? correlation.evidence_fingerprint
+          : typeof row.evidence_fingerprint === "string"
+            ? row.evidence_fingerprint
+            : null,
+      measurement_window_end:
+        isoOrNull(row.measurement_window_end) ?? isoOrNull(row.measuring_until),
+      metadata: asRecord(row.metadata),
+    };
+  };
+
+  return [
+    ...workItems.map((row) => mapRow("growth_work_items", row)),
+    ...publicationJobs.map((row) => mapRow("growth_publication_jobs", row)),
+    ...outcomes.map((row) => mapRow("growth_work_item_outcomes", row)),
+  ];
+}
+
+function mapCorrelationVerdict(verdict: string): GrowthProviderDedupeVerdict {
+  if (verdict === "create") return "proceed";
+  if (verdict === "block") return "blocked";
+  if (verdict === "scale") return "skip";
+  if (["coalesce", "skip", "reopen"].includes(verdict)) {
+    return verdict as GrowthProviderDedupeVerdict;
+  }
+  return "proceed";
+}
+
+function sourceProfilesFromRows(rows: GrowthProviderContextPacketTableRow[]): GrowthProviderSourceProfile[] {
+  return rows.map((row) => ({
+    profile_id: String(row.profile_id),
+    provider: providerForProfile(String(row.profile_id), row),
+    run_id: typeof row.id === "string" ? row.id : null,
+    window_start: isoOrNull(row.started_at),
+    window_end: isoOrNull(row.completed_at) ?? isoOrNull(row.fetched_at),
+    cache_refs: sourceRefs(row).filter((ref) => ref.includes("cache")),
+    fact_ids: [],
+    evidence_fingerprint:
+      typeof row.evidence_fingerprint === "string" ? row.evidence_fingerprint : null,
+    source_refs: sourceRefs(row),
+  }));
+}
+
+export async function buildGrowthProviderContextPacket(
+  options: BuildGrowthProviderContextPacketOptions,
+): Promise<GrowthProviderContextPacket> {
+  const now = options.now ?? new Date();
+  const requiredProfileIds = options.requiredProfileIds?.length
+    ? options.requiredProfileIds
+    : ["gsc_growth_minimum_v1"];
+  const entityKey = `${options.entity.type}:${options.entity.id ?? options.entity.path ?? options.entity.canonical_url ?? "unknown"}`;
+  const actionKey = `${options.workType}:${entityKey}`;
+
+  const [
+    profileRows,
+    gscRows,
+    ga4Rows,
+    dataforseoRows,
+    inventoryRows,
+    funnelRows,
+    workItems,
+    publicationJobs,
+    outcomes,
+  ] = await Promise.all([
+    readRows(options.supabase, "growth_profile_runs", options.accountId, options.websiteId),
+    readRows(options.supabase, "growth_gsc_cache", options.accountId, options.websiteId),
+    readRows(options.supabase, "growth_ga4_cache", options.accountId, options.websiteId),
+    readRows(options.supabase, "growth_dataforseo_cache", options.accountId, options.websiteId),
+    readRows(options.supabase, "growth_inventory", options.accountId, options.websiteId),
+    readRows(options.supabase, "funnel_events", options.accountId, options.websiteId),
+    readRows(options.supabase, "growth_work_items", options.accountId, options.websiteId),
+    readRows(options.supabase, "growth_publication_jobs", options.accountId, options.websiteId),
+    readRows(options.supabase, "growth_work_item_outcomes", options.accountId, options.websiteId),
+  ]);
+
+  const rowsByProfile = latestRowsByProfile(profileRows);
+  const freshnessMap: Record<string, GrowthProviderFreshnessEntry> = {};
+  const packetNoGoReasons: string[] = [];
+  const freshRequiredRows: GrowthProviderContextPacketTableRow[] = [];
+
+  for (const profileId of requiredProfileIds) {
+    const row = rowsByProfile.get(profileId);
+    const freshness = classifyFreshness(profileId, row, now);
+    packetNoGoReasons.push(...freshness.reasons);
+    if (row && freshness.status === "fresh") freshRequiredRows.push(row);
+
+    freshnessMap[profileId] = {
+      profile_id: profileId,
+      provider: providerForProfile(profileId, row),
+      status: freshness.status,
+      required: true,
+      fetched_at: freshness.fetchedAt,
+      expires_at: freshness.expiresAt,
+      quality_status:
+        typeof row?.quality_status === "string" && ["pass", "watch", "blocked"].includes(row.quality_status)
+          ? (row.quality_status as "pass" | "watch" | "blocked")
+          : freshness.status === "fresh"
+            ? "pass"
+            : "watch",
+      run_id: typeof row?.id === "string" ? row.id : null,
+      no_go_reasons: freshness.reasons,
+    };
+  }
+
+  const facts = emptyFacts();
+  for (const row of freshRequiredRows) {
+    const profileId = String(row.profile_id);
+    const bucketName = PROFILE_TO_BUCKET[profileId] ?? "market_terms";
+    const bucket = facts[bucketName];
+    bucket.items.push(buildFactItem(row));
+    bucket.source_profile_ids.push(profileId);
+  }
+
+  if (gscRows.length > 0 && facts.search_demand.source_profile_ids.includes("gsc_growth_minimum_v1")) {
+    facts.search_demand.items.push(...gscRows.slice(0, 10).map(asRecord));
+  }
+  if (ga4Rows.length > 0 && facts.conversion_signals.source_profile_ids.includes("ga4_growth_minimum_v1")) {
+    facts.conversion_signals.items.push(...ga4Rows.slice(0, 10).map(asRecord));
+  }
+  if (dataforseoRows.length > 0) {
+    facts.technical_issues.items.push(...dataforseoRows.slice(0, 10).map(asRecord));
+  }
+  if (inventoryRows.length > 0) {
+    facts.technical_issues.items.push(...inventoryRows.slice(0, 10).map(asRecord));
+  }
+  if (funnelRows.length > 0) {
+    facts.conversion_signals.items.push(...funnelRows.slice(0, 10).map(asRecord));
+  }
+
+  pushNoGoToEmptyBuckets(facts, packetNoGoReasons);
+
+  const evidence = {
+    entity_key: entityKey,
+    action_key: actionKey,
+    profiles: freshRequiredRows.map((row) => ({
+      profile_id: row.profile_id,
+      evidence_fingerprint: row.evidence_fingerprint,
+    })),
+    facts,
+  };
+  const fallbackFingerprint = computeGrowthEvidenceFingerprint(evidence);
+  const primaryFingerprint =
+    freshRequiredRows.find((row) => typeof row.evidence_fingerprint === "string")?.evidence_fingerprint as string | undefined;
+
+  let status: "pass" | "watch" | "blocked" = "pass";
+  if (Object.values(freshnessMap).some((entry) => entry.status === "missing" || entry.status === "blocked")) {
+    status = "blocked";
+  } else if (Object.values(freshnessMap).some((entry) => entry.status !== "fresh")) {
+    status = "watch";
+  }
+
+  let dedupeVerdict: GrowthProviderDedupeVerdict = "proceed";
+  let dedupeReason = "fresh_required_profiles";
+  let previousRefs: string[] = [];
+  let dedupeNoGoReasons = [...packetNoGoReasons];
+
+  if (status === "blocked") {
+    dedupeVerdict = "blocked";
+    dedupeReason = "required_profile_missing_or_blocked";
+  } else if (status === "watch") {
+    dedupeVerdict = "request_refresh";
+    dedupeReason = "required_profile_stale_or_gated";
+  } else {
+    const existingWork: ExistingGrowthEvidenceWork[] = workItems
+      .filter((row) => {
+        const evidenceRecord = asRecord(row.evidence);
+        const correlation = asRecord(evidenceRecord.correlation);
+        const rowFingerprint = correlation.evidence_fingerprint;
+        return !rowFingerprint || rowFingerprint === primaryFingerprint;
+      })
+      .map((row) => ({
+        id: String(row.id),
+        status: String(row.status ?? "unknown"),
+        evidence: asRecord(row.evidence),
+        outcome_status: typeof row.outcome_status === "string" ? row.outcome_status : null,
+      }));
+
+    const correlation = evaluateGrowthEvidenceCorrelation({
+      websiteId: options.websiteId,
+      decisionFamily: "provider_context_packet",
+      entityKey,
+      actionKey,
+      evidence: primaryFingerprint ? { evidence_fingerprint: primaryFingerprint } : evidence,
+      existingWork,
+    });
+    dedupeVerdict = mapCorrelationVerdict(correlation.dedupe_verdict);
+    dedupeReason = correlation.reason ?? "anti_rework_gate";
+    previousRefs = correlation.previous_work_item_ids.map((id) => `growth_work_items:${id}`);
+    dedupeNoGoReasons = correlation.no_go_reasons;
+  }
+
+  const packet = {
+    packet_version: "growth-provider-context-packet-v1",
+    status,
+    generated_at: now.toISOString(),
+    account_id: options.accountId,
+    website_id: options.websiteId,
+    locale: options.entity.locale ?? "es-CO",
+    market: options.entity.market ?? "CO",
+    worker_lane: options.workerLane,
+    work_type: options.workType,
+    entity: {
+      id: null,
+      canonical_url: null,
+      locale: options.entity.locale ?? "es-CO",
+      market: options.entity.market ?? "CO",
+      path: null,
+      slug: null,
+      metadata: {},
+      ...options.entity,
+    },
+    freshness_map: freshnessMap,
+    source_profiles: sourceProfilesFromRows(freshRequiredRows),
+    facts,
+    previous_actions: buildPreviousActions(workItems, publicationJobs, outcomes),
+    dedupe_verdict: {
+      verdict: dedupeVerdict,
+      evidence_fingerprint: primaryFingerprint ?? fallbackFingerprint,
+      reason: dedupeReason,
+      previous_refs: previousRefs,
+      no_go_reasons: dedupeNoGoReasons,
+    },
+    allowed_actions: options.allowedActions ?? [],
+    blocked_actions: [DIRECT_PROVIDER_API_BLOCK, ...PAID_MUTATION_BLOCKS],
+  };
+
+  return GrowthProviderContextPacketSchema.parse(packet);
+}

--- a/lib/growth/context-packets/index.ts
+++ b/lib/growth/context-packets/index.ts
@@ -1,0 +1,6 @@
+export { buildGrowthProviderContextPacket } from "./builder";
+export type {
+  BuildGrowthProviderContextPacketOptions,
+  GrowthProviderContextPacketResult,
+  GrowthProviderContextPacketTableRow,
+} from "./types";

--- a/lib/growth/context-packets/types.ts
+++ b/lib/growth/context-packets/types.ts
@@ -1,0 +1,22 @@
+import type {
+  GrowthProviderContextEntity,
+  GrowthProviderContextPacket,
+  GrowthProviderWorkerLane,
+} from "@bukeer/website-contract";
+import type { SupabaseLike } from "@/lib/growth/autonomy/runtime-common";
+
+export interface BuildGrowthProviderContextPacketOptions {
+  supabase: SupabaseLike;
+  accountId: string;
+  websiteId: string;
+  workerLane: GrowthProviderWorkerLane;
+  workType: string;
+  entity: Partial<GrowthProviderContextEntity> & Pick<GrowthProviderContextEntity, "type">;
+  requiredProfileIds?: string[];
+  allowedActions?: string[];
+  now?: Date;
+}
+
+export type GrowthProviderContextPacketResult = GrowthProviderContextPacket;
+
+export type GrowthProviderContextPacketTableRow = Record<string, unknown>;

--- a/packages/website-contract/src/index.ts
+++ b/packages/website-contract/src/index.ts
@@ -785,6 +785,39 @@ export type {
 } from './schemas/growth-provider-intelligence';
 
 export {
+  GrowthProviderContextPacketVersionSchema,
+  GrowthProviderContextPacketStatusSchema,
+  GrowthProviderWorkerLaneSchema,
+  GrowthProviderContextEntitySchema,
+  GrowthProviderFreshnessEntrySchema,
+  GrowthProviderSourceProfileSchema,
+  GrowthProviderContextFactBucketSchema,
+  GrowthProviderContextFactsSchema,
+  GrowthProviderPreviousActionSchema,
+  GrowthProviderDedupeVerdictSchema,
+  GrowthProviderContextDedupeSchema,
+  GrowthProviderBlockedActionSchema,
+  GrowthProviderContextPacketSchema,
+  GrowthProviderContextPacketInputSchema,
+} from './schemas/growth-provider-context-packet';
+export type {
+  GrowthProviderContextPacketVersion,
+  GrowthProviderContextPacketStatus,
+  GrowthProviderWorkerLane,
+  GrowthProviderContextEntity,
+  GrowthProviderFreshnessEntry,
+  GrowthProviderSourceProfile,
+  GrowthProviderContextFactBucket,
+  GrowthProviderContextFacts,
+  GrowthProviderPreviousAction,
+  GrowthProviderDedupeVerdict,
+  GrowthProviderContextDedupe,
+  GrowthProviderBlockedAction,
+  GrowthProviderContextPacket,
+  GrowthProviderContextPacketInput,
+} from './schemas/growth-provider-context-packet';
+
+export {
   GrowthRuntimeCycleStatusSchema,
   GrowthRuntimeCycleTriggerSchema,
   GrowthRuntimeCycleStageSchema,

--- a/packages/website-contract/src/schemas/growth-provider-context-packet.ts
+++ b/packages/website-contract/src/schemas/growth-provider-context-packet.ts
@@ -1,0 +1,284 @@
+import { z } from 'zod';
+
+import { GrowthTenantScopeSchema } from './growth-attribution';
+import {
+  GrowthProviderFreshnessStatusSchema,
+  GrowthProviderQualityStatusSchema,
+  GrowthProviderSchema,
+} from './growth-provider-intelligence';
+
+const DateTimeSchema = z.string().datetime();
+const JsonRecordSchema = z.record(z.string(), z.unknown());
+const ProviderSchema = GrowthProviderSchema.or(z.string().min(1).max(80));
+const SourceRefsSchema = z.union([
+  z.array(z.string().min(1).max(240)),
+  JsonRecordSchema,
+]).default([]);
+
+export const GrowthProviderContextPacketVersionSchema = z.literal(
+  'growth-provider-context-packet-v1',
+);
+export type GrowthProviderContextPacketVersion = z.infer<
+  typeof GrowthProviderContextPacketVersionSchema
+>;
+
+export const GrowthProviderContextPacketStatusSchema = z.enum([
+  'pass',
+  'watch',
+  'blocked',
+]);
+export type GrowthProviderContextPacketStatus = z.infer<
+  typeof GrowthProviderContextPacketStatusSchema
+>;
+
+export const GrowthProviderWorkerLaneSchema = z
+  .enum([
+    'content',
+    'transcreation',
+    'technical',
+    'cro',
+    'campaign_optimizer',
+    'all',
+  ])
+  .or(z.string().min(1).max(80));
+export type GrowthProviderWorkerLane = z.infer<
+  typeof GrowthProviderWorkerLaneSchema
+>;
+
+export const GrowthProviderContextEntitySchema = z.object({
+  type: z.string().min(1).max(80),
+  id: z.string().min(1).max(240).nullable().default(null),
+  canonical_url: z.string().url().nullable().default(null),
+  locale: z.string().min(2).max(16).nullable().default(null),
+  market: z.string().min(2).max(16).nullable().default(null),
+  path: z.string().min(1).max(500).nullable().default(null),
+  slug: z.string().min(1).max(240).nullable().default(null),
+  metadata: JsonRecordSchema.default({}),
+});
+export type GrowthProviderContextEntity = z.infer<
+  typeof GrowthProviderContextEntitySchema
+>;
+
+export const GrowthProviderFreshnessEntrySchema = z.object({
+  profile_id: z.string().min(1).max(120),
+  provider: ProviderSchema,
+  status: GrowthProviderFreshnessStatusSchema,
+  required: z.boolean().default(true),
+  fetched_at: DateTimeSchema.nullable().default(null),
+  expires_at: DateTimeSchema.nullable().default(null),
+  quality_status: GrowthProviderQualityStatusSchema.default('watch'),
+  run_id: z.string().uuid().nullable().default(null),
+  no_go_reasons: z.array(z.string().min(1).max(500)).default([]),
+});
+export type GrowthProviderFreshnessEntry = z.infer<
+  typeof GrowthProviderFreshnessEntrySchema
+>;
+
+export const GrowthProviderSourceProfileSchema = z
+  .object({
+    profile_id: z.string().min(1).max(120),
+    provider: ProviderSchema,
+    run_id: z.string().uuid().nullable().default(null),
+    window_start: DateTimeSchema.nullable().default(null),
+    window_end: DateTimeSchema.nullable().default(null),
+    cache_refs: z.array(z.string().min(1).max(240)).default([]),
+    fact_ids: z.array(z.string().uuid()).default([]),
+    evidence_fingerprint: z.string().min(8).max(160).nullable().default(null),
+    source_refs: SourceRefsSchema,
+  })
+  .superRefine((profile, ctx) => {
+    if (
+      profile.window_start &&
+      profile.window_end &&
+      Date.parse(profile.window_end) < Date.parse(profile.window_start)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['window_end'],
+        message: 'window_end must be after window_start.',
+      });
+    }
+  });
+export type GrowthProviderSourceProfile = z.infer<
+  typeof GrowthProviderSourceProfileSchema
+>;
+
+export const GrowthProviderContextFactBucketSchema = z.object({
+  items: z.array(JsonRecordSchema).default([]),
+  source_profile_ids: z.array(z.string().min(1).max(120)).default([]),
+  no_go_reasons: z.array(z.string().min(1).max(500)).default([]),
+});
+export type GrowthProviderContextFactBucket = z.infer<
+  typeof GrowthProviderContextFactBucketSchema
+>;
+
+export const GrowthProviderContextFactsSchema = z.object({
+  search_demand: GrowthProviderContextFactBucketSchema.default({
+    items: [],
+    source_profile_ids: [],
+    no_go_reasons: [],
+  }),
+  technical_issues: GrowthProviderContextFactBucketSchema.default({
+    items: [],
+    source_profile_ids: [],
+    no_go_reasons: [],
+  }),
+  market_terms: GrowthProviderContextFactBucketSchema.default({
+    items: [],
+    source_profile_ids: [],
+    no_go_reasons: [],
+  }),
+  conversion_signals: GrowthProviderContextFactBucketSchema.default({
+    items: [],
+    source_profile_ids: [],
+    no_go_reasons: [],
+  }),
+  paid_signals: GrowthProviderContextFactBucketSchema.default({
+    items: [],
+    source_profile_ids: [],
+    no_go_reasons: [],
+  }),
+  ux_friction: GrowthProviderContextFactBucketSchema.default({
+    items: [],
+    source_profile_ids: [],
+    no_go_reasons: [],
+  }),
+});
+export type GrowthProviderContextFacts = z.infer<
+  typeof GrowthProviderContextFactsSchema
+>;
+
+export const GrowthProviderPreviousActionSchema = z.object({
+  ref: z.string().min(1).max(240),
+  table: z.string().min(1).max(120),
+  id: z.string().min(1).max(120),
+  status: z.string().min(1).max(120).nullable().default(null),
+  action_key: z.string().min(1).max(300).nullable().default(null),
+  evidence_fingerprint: z.string().min(8).max(160).nullable().default(null),
+  measurement_window_end: DateTimeSchema.nullable().default(null),
+  metadata: JsonRecordSchema.default({}),
+});
+export type GrowthProviderPreviousAction = z.infer<
+  typeof GrowthProviderPreviousActionSchema
+>;
+
+export const GrowthProviderDedupeVerdictSchema = z.enum([
+  'proceed',
+  'skip',
+  'coalesce',
+  'reopen',
+  'request_refresh',
+  'blocked',
+]);
+export type GrowthProviderDedupeVerdict = z.infer<
+  typeof GrowthProviderDedupeVerdictSchema
+>;
+
+export const GrowthProviderContextDedupeSchema = z.object({
+  verdict: GrowthProviderDedupeVerdictSchema,
+  evidence_fingerprint: z.string().min(8).max(160).nullable().default(null),
+  reason: z.string().min(1).max(1000).nullable().default(null),
+  previous_refs: z.array(z.string().min(1).max(240)).default([]),
+  no_go_reasons: z.array(z.string().min(1).max(500)).default([]),
+});
+export type GrowthProviderContextDedupe = z.infer<
+  typeof GrowthProviderContextDedupeSchema
+>;
+
+export const GrowthProviderBlockedActionSchema = z.object({
+  action: z.string().min(1).max(160),
+  reason: z.string().min(1).max(1000),
+});
+export type GrowthProviderBlockedAction = z.infer<
+  typeof GrowthProviderBlockedActionSchema
+>;
+
+export const GrowthProviderContextPacketSchema = GrowthTenantScopeSchema.extend({
+  packet_version: GrowthProviderContextPacketVersionSchema,
+  status: GrowthProviderContextPacketStatusSchema,
+  generated_at: DateTimeSchema,
+  worker_lane: GrowthProviderWorkerLaneSchema,
+  work_type: z.string().min(1).max(160),
+  entity: GrowthProviderContextEntitySchema,
+  freshness_map: z.record(z.string(), GrowthProviderFreshnessEntrySchema),
+  source_profiles: z.array(GrowthProviderSourceProfileSchema).default([]),
+  facts: GrowthProviderContextFactsSchema,
+  previous_actions: z.array(GrowthProviderPreviousActionSchema).default([]),
+  dedupe_verdict: GrowthProviderContextDedupeSchema,
+  allowed_actions: z.array(z.string().min(1).max(160)).default([]),
+  blocked_actions: z.array(GrowthProviderBlockedActionSchema).default([]),
+}).superRefine((packet, ctx) => {
+  const directProviderApiBlocked = packet.blocked_actions.some(
+    (entry) => entry.action === 'call_provider_api_directly',
+  );
+  if (!directProviderApiBlocked) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['blocked_actions'],
+      message: 'blocked_actions must include call_provider_api_directly.',
+    });
+  }
+
+  const nonPassRequiredStatuses = new Set([
+    'missing',
+    'stale',
+    'blocked',
+    'approval_required',
+    'cost_gated',
+    'quota_exhausted',
+  ]);
+  const requiredNonPass = Object.values(packet.freshness_map).filter(
+    (entry) => entry.required && nonPassRequiredStatuses.has(entry.status),
+  );
+  if (requiredNonPass.length > 0) {
+    if (packet.status === 'pass') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['status'],
+        message: 'packet status cannot be pass when required evidence is missing or stale.',
+      });
+    }
+    if (!['request_refresh', 'blocked'].includes(packet.dedupe_verdict.verdict)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['dedupe_verdict', 'verdict'],
+        message: 'dedupe verdict must request_refresh or blocked for missing/stale required evidence.',
+      });
+    }
+  }
+
+  const sourceProfileIds = new Set(
+    packet.source_profiles.map((profile) => profile.profile_id),
+  );
+  for (const [bucketName, bucket] of Object.entries(packet.facts)) {
+    for (const profileId of bucket.source_profile_ids) {
+      if (!sourceProfileIds.has(profileId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['facts', bucketName, 'source_profile_ids'],
+          message: `fact source profile ${profileId} is absent from source_profiles.`,
+        });
+      }
+    }
+    if (
+      bucket.items.length === 0 &&
+      bucket.source_profile_ids.length === 0 &&
+      packet.status !== 'pass' &&
+      bucket.no_go_reasons.length === 0
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['facts', bucketName, 'no_go_reasons'],
+        message: 'empty non-pass fact buckets must include an explicit no-go reason.',
+      });
+    }
+  }
+});
+export type GrowthProviderContextPacket = z.infer<
+  typeof GrowthProviderContextPacketSchema
+>;
+
+export const GrowthProviderContextPacketInputSchema = GrowthProviderContextPacketSchema;
+export type GrowthProviderContextPacketInput = z.infer<
+  typeof GrowthProviderContextPacketInputSchema
+>;


### PR DESCRIPTION
## Summary
- Adds Growth Provider Context Packet v1 Zod contract.
- Adds read-only context packet builder for worker inputs.
- Covers fresh/stale/missing/duplicate evidence, tenant isolation, and blocked direct provider API action.

## Validation
- `npm test -- tests/lib/growth/context-packets/builder.test.ts --runInBand` - PASS, 6 tests
- `npm run typecheck` - PASS
- `cd packages/website-contract && npm run typecheck` - PASS
- `cd packages/website-contract && npm run build` - PASS
- `npm run ai:check` - PASS
- `npm run tech-validator:code:quick` - PASS with unrelated warnings
- `git diff --check` - PASS
- Secret/PII diff scan - PASS

Closes #537
References #536 / #541.
