### PR TITLE
fix: stabilize ColombiaTours public site incident paths

### DIFF
--- a/app/api/webhooks/chatwoot/route.ts
+++ b/app/api/webhooks/chatwoot/route.ts
@@ -498,16 +498,27 @@ async function insertWebhookEvent(
   eventId: string,
   signature: string,
 ): Promise<"inserted" | "duplicate"> {
-  const { error } = await supabase.from("webhook_events").insert({
-    provider: PROVIDER,
-    event_id: eventId,
-    event_type: payload.event,
-    signature,
-    payload,
-  });
+  const { data, error } = await supabase
+    .from("webhook_events")
+    .upsert(
+      {
+        provider: PROVIDER,
+        event_id: eventId,
+        event_type: payload.event,
+        signature,
+        payload,
+      },
+      {
+        onConflict: "provider,event_id",
+        ignoreDuplicates: true,
+      },
+    )
+    .select("id")
+    .limit(1);
 
-  if (!error) return "inserted";
-  if (error.code === "23505") return "duplicate";
+  if (!error) {
+    return Array.isArray(data) && data.length === 0 ? "duplicate" : "inserted";
+  }
   throw new Error(error.message);
 }
 
@@ -1179,9 +1190,12 @@ async function emitLifecycleFunnelEvents(
           fbp: cleanString(attribution.fbp),
           fbc: cleanString(attribution.fbc),
           ctwa_clid: cleanString(attribution.ctwa_clid),
-          gclid: readAttributionClickId(funnelAttribution, "gclid") ?? undefined,
-          gbraid: readAttributionClickId(funnelAttribution, "gbraid") ?? undefined,
-          wbraid: readAttributionClickId(funnelAttribution, "wbraid") ?? undefined,
+          gclid:
+            readAttributionClickId(funnelAttribution, "gclid") ?? undefined,
+          gbraid:
+            readAttributionClickId(funnelAttribution, "gbraid") ?? undefined,
+          wbraid:
+            readAttributionClickId(funnelAttribution, "wbraid") ?? undefined,
           utm_source: funnelAttribution?.utm.utm_source ?? undefined,
           utm_medium: funnelAttribution?.utm.utm_medium ?? undefined,
           utm_campaign: funnelAttribution?.utm.utm_campaign ?? undefined,

--- a/app/site/[subdomain]/[...slug]/page.tsx
+++ b/app/site/[subdomain]/[...slug]/page.tsx
@@ -1,5 +1,4 @@
 import { Metadata } from "next";
-import { headers } from "next/headers";
 import { notFound, redirect } from "next/navigation";
 import { getWebsiteBySubdomain } from "@/lib/supabase/get-website";
 import type { WebsiteData } from "@/lib/supabase/get-website";
@@ -53,7 +52,7 @@ import {
 } from "@/lib/products/activity-circuit";
 import { sanitizeProductCopy } from "@/lib/products/normalize-product";
 import { toSimilarProductSummaries } from "@/lib/products/similar-product-summary";
-import { getBasePath } from "@/lib/utils/base-path";
+import { getBasePath, inferIsCustomDomainWebsite } from "@/lib/utils/base-path";
 import dynamic from "next/dynamic";
 import { applyContentTranslations } from "@/lib/sections/apply-content-translations";
 import { resolveTemplateSet } from "@/lib/sections/template-set";
@@ -774,8 +773,7 @@ export default async function DynamicPage({ params }: DynamicPageProps) {
   );
   const resolvedLocale = localeContext.resolvedLocale;
   const defaultLocale = localeContext.defaultLocale ?? "es-CO";
-  const headerList = await headers();
-  const isCustomDomain = Boolean(headerList.get("x-custom-domain"));
+  const isCustomDomain = inferIsCustomDomainWebsite(website);
 
   const translatedSections = applyContentTranslations(
     website.sections || [],

--- a/app/site/[subdomain]/actividades/[slug]/page.tsx
+++ b/app/site/[subdomain]/actividades/[slug]/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { headers } from "next/headers";
 import { notFound, permanentRedirect, redirect } from "next/navigation";
 
 import { ProductLandingPage } from "@/components/pages/product-landing-page";
@@ -34,7 +33,7 @@ import {
   translateCategoryPathname,
 } from "@/lib/seo/locale-routing";
 import { resolveOgImage } from "@/lib/seo/og-helpers";
-import { getBasePath } from "@/lib/utils/base-path";
+import { getBasePath, inferIsCustomDomainWebsite } from "@/lib/utils/base-path";
 
 interface ActivityPageProps {
   params: Promise<{ subdomain: string; slug: string }>;
@@ -264,8 +263,7 @@ export default async function ActivitySlugPage({ params }: ActivityPageProps) {
     }
   }
 
-  const headerList = await headers();
-  const isCustomDomain = Boolean(headerList.get("x-custom-domain"));
+  const isCustomDomain = inferIsCustomDomainWebsite(website);
   const websiteForRender = {
     ...website,
     resolvedLocale,

--- a/app/site/[subdomain]/actividades/page.tsx
+++ b/app/site/[subdomain]/actividades/page.tsx
@@ -7,7 +7,6 @@
  */
 
 import type { Metadata } from "next";
-import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 
 import { ActivitiesListingPage } from "@/components/pages/activities-listing-page";
@@ -24,6 +23,7 @@ import {
   normalizeLocale,
 } from "@/lib/seo/locale-routing";
 import { resolveOgImage } from "@/lib/seo/og-helpers";
+import { inferIsCustomDomainWebsite } from "@/lib/utils/base-path";
 
 interface ActividadesPageProps {
   params: Promise<{ subdomain: string }>;
@@ -142,8 +142,13 @@ export async function generateMetadata({
   const canonical = `${baseUrl}${localeContext.localizedPathname}`;
   const ogImage = resolveOgImage(website);
   const isEnglish = localeContext.resolvedLanguage === "en";
-  const title = isEnglish ? "Activities in Colombia" : "Actividades en Colombia";
-  const description = buildActivitiesDescription(siteName, localeContext.resolvedLocale);
+  const title = isEnglish
+    ? "Activities in Colombia"
+    : "Actividades en Colombia";
+  const description = buildActivitiesDescription(
+    siteName,
+    localeContext.resolvedLocale,
+  );
 
   return {
     title,
@@ -186,8 +191,7 @@ export default async function ActividadesPage({
     notFound();
   }
 
-  const headerList = await headers();
-  const isCustomDomain = Boolean(headerList.get("x-custom-domain"));
+  const isCustomDomain = inferIsCustomDomainWebsite(website);
   const localeContext = await resolvePublicMetadataLocale(website, PAGE_PATH);
   const { items: activities } = await getCategoryProducts(
     subdomain,

--- a/app/site/[subdomain]/blog/[slug]/page.tsx
+++ b/app/site/[subdomain]/blog/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import "./blog-typography.css";
 import { Metadata } from "next";
-import { headers } from "next/headers";
 import { notFound, redirect } from "next/navigation";
 import {
   getWebsiteBySubdomain,
@@ -25,6 +24,7 @@ import {
 import { isEnBlogQualityBlocked } from "@/lib/seo/en-quality-gate";
 import { normalizePublicMetadataTitle } from "@/lib/seo/metadata-title";
 import { getPublicUiMessages } from "@/lib/site/public-ui-messages";
+import { inferIsCustomDomainWebsite } from "@/lib/utils/base-path";
 
 interface BlogPostPageProps {
   params: Promise<{ subdomain: string; slug: string }>;
@@ -90,7 +90,10 @@ export async function generateMetadata({
     website.content?.account?.name || website.content?.siteName || subdomain;
   const title = post.seo_title
     ? post.seo_title
-    : normalizePublicMetadataTitle(post.title || localizedMessages.blogPost.notFoundTitle, siteName);
+    : normalizePublicMetadataTitle(
+        post.title || localizedMessages.blogPost.notFoundTitle,
+        siteName,
+      );
   const description = (
     post.seo_description ||
     post.excerpt ||
@@ -198,7 +201,9 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     : `https://${subdomain}.bukeer.com`;
 
   // Fetch travel planner when post has a created_by reference
-  const planner = post.created_by ? await getPlannerByUserId(post.created_by) : null;
+  const planner = post.created_by
+    ? await getPlannerByUserId(post.created_by)
+    : null;
 
   // Generate JSON-LD schemas (Article, Breadcrumb, Organization)
   const schemas = generateBlogPostSchemas(
@@ -209,8 +214,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     planner,
   );
 
-  const headerList = await headers();
-  const isCustomDomain = Boolean(headerList.get("x-custom-domain"));
+  const isCustomDomain = inferIsCustomDomainWebsite(website);
 
   return (
     <>

--- a/app/site/[subdomain]/blog/page.tsx
+++ b/app/site/[subdomain]/blog/page.tsx
@@ -1,43 +1,57 @@
-import { Metadata } from 'next';
-import { headers } from 'next/headers';
-import Link from 'next/link';
-import Image from 'next/image';
-import { getWebsiteBySubdomain, getBlogPosts, getBlogCategories } from '@/lib/supabase/get-website';
-import { notFound } from 'next/navigation';
-import { JsonLd, generateBlogListingSchemas } from '@/lib/schema';
-import { resolveOgImage } from '@/lib/seo/og-helpers';
+import { Metadata } from "next";
+import Link from "next/link";
+import Image from "next/image";
+import {
+  getWebsiteBySubdomain,
+  getBlogPosts,
+  getBlogCategories,
+} from "@/lib/supabase/get-website";
+import { notFound } from "next/navigation";
+import { JsonLd, generateBlogListingSchemas } from "@/lib/schema";
+import { resolveOgImage } from "@/lib/seo/og-helpers";
 import {
   buildLocaleAwareAlternateLanguages,
   resolvePublicMetadataLocale,
-} from '@/lib/seo/public-metadata';
-import { localeToOgLocale } from '@/lib/seo/locale-routing';
-import { formatPublicDate, getPublicUiMessages } from '@/lib/site/public-ui-messages';
-import { TemplateSlot } from '@/components/site/themes/editorial-v1/template-slot';
-import { getBasePath } from '@/lib/utils/base-path';
+} from "@/lib/seo/public-metadata";
+import { localeToOgLocale } from "@/lib/seo/locale-routing";
+import {
+  formatPublicDate,
+  getPublicUiMessages,
+} from "@/lib/site/public-ui-messages";
+import { TemplateSlot } from "@/components/site/themes/editorial-v1/template-slot";
+import { getBasePath, inferIsCustomDomainWebsite } from "@/lib/utils/base-path";
 
 interface BlogPageProps {
   params: Promise<{ subdomain: string }>;
   searchParams: Promise<{ category?: string; page?: string; q?: string }>;
 }
 
-export async function generateMetadata({ params }: BlogPageProps): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: BlogPageProps): Promise<Metadata> {
   const { subdomain } = await params;
   const website = await getWebsiteBySubdomain(subdomain);
 
   if (!website) {
-    return { title: 'Blog' };
+    return { title: "Blog" };
   }
 
-  const siteName = website.content?.account?.name || website.content?.siteName || subdomain;
+  const siteName =
+    website.content?.account?.name || website.content?.siteName || subdomain;
   const baseUrl = website.custom_domain
     ? `https://${website.custom_domain}`
     : `https://${subdomain}.bukeer.com`;
-  const localeContext = await resolvePublicMetadataLocale(website, '/blog');
+  const localeContext = await resolvePublicMetadataLocale(website, "/blog");
   const messages = getPublicUiMessages(localeContext.resolvedLocale);
   const localizedBlogPath = localeContext.localizedPathname;
   const canonical = `${baseUrl}${localizedBlogPath}`;
-  const languages = buildLocaleAwareAlternateLanguages(baseUrl, '/blog', localeContext);
-  const description = `${messages.blogListing.heroDescription} ${siteName}`.trim();
+  const languages = buildLocaleAwareAlternateLanguages(
+    baseUrl,
+    "/blog",
+    localeContext,
+  );
+  const description =
+    `${messages.blogListing.heroDescription} ${siteName}`.trim();
   const ogImage = resolveOgImage(website);
 
   return {
@@ -53,11 +67,11 @@ export async function generateMetadata({ params }: BlogPageProps): Promise<Metad
       url: canonical,
       siteName,
       locale: localeToOgLocale(localeContext.resolvedLocale),
-      type: 'website',
+      type: "website",
       ...(ogImage && { images: [{ url: ogImage }] }),
     },
     twitter: {
-      card: 'summary_large_image',
+      card: "summary_large_image",
       title: `${messages.blogListing.title} — ${siteName}`,
       description,
       ...(ogImage && { images: [ogImage] }),
@@ -65,27 +79,38 @@ export async function generateMetadata({ params }: BlogPageProps): Promise<Metad
   };
 }
 
-export default async function BlogPage({ params, searchParams }: BlogPageProps) {
+export default async function BlogPage({
+  params,
+  searchParams,
+}: BlogPageProps) {
   const { subdomain } = await params;
   const { category, page, q } = await searchParams;
 
   const website = await getWebsiteBySubdomain(subdomain);
 
-  if (!website || website.status !== 'published') {
+  if (!website || website.status !== "published") {
     notFound();
   }
 
-  const pageNum = parseInt(page || '1', 10);
+  const pageNum = parseInt(page || "1", 10);
   const limit = 9;
   const offset = (pageNum - 1) * limit;
 
   // Resolve locale before fetching so RPC filters by locale.
   // Non-default locale → only posts that have a translation row for that locale.
-  const localeContextEarly = await resolvePublicMetadataLocale(website, '/blog');
+  const localeContextEarly = await resolvePublicMetadataLocale(
+    website,
+    "/blog",
+  );
   const resolvedLocaleForFetch = localeContextEarly.resolvedLocale;
 
   const [postsData, categories] = await Promise.all([
-    getBlogPosts(website.id, { limit, offset, categorySlug: category, locale: resolvedLocaleForFetch }),
+    getBlogPosts(website.id, {
+      limit,
+      offset,
+      categorySlug: category,
+      locale: resolvedLocaleForFetch,
+    }),
     getBlogCategories(website.id),
   ]);
 
@@ -95,7 +120,7 @@ export default async function BlogPage({ params, searchParams }: BlogPageProps) 
   // Editorial-v1 filter: optional client-side (q) — server still paginates.
   const filteredPosts = q
     ? posts.filter((p) => {
-        const hay = `${p.title} ${p.excerpt ?? ''}`.toLowerCase();
+        const hay = `${p.title} ${p.excerpt ?? ""}`.toLowerCase();
         return hay.includes(q.toLowerCase());
       })
     : posts;
@@ -108,9 +133,13 @@ export default async function BlogPage({ params, searchParams }: BlogPageProps) 
   const messages = getPublicUiMessages(localeContext.resolvedLocale);
 
   // Generate JSON-LD schemas (CollectionPage, Breadcrumb, Organization)
-  const schemas = generateBlogListingSchemas(filteredPosts, website, baseUrl, localeContext.resolvedLocale);
-  const headerList = await headers();
-  const isCustomDomain = Boolean(headerList.get('x-custom-domain'));
+  const schemas = generateBlogListingSchemas(
+    filteredPosts,
+    website,
+    baseUrl,
+    localeContext.resolvedLocale,
+  );
+  const isCustomDomain = inferIsCustomDomainWebsite(website);
   const basePath = getBasePath(subdomain, isCustomDomain);
   const websiteForRender = {
     ...website,
@@ -139,168 +168,175 @@ export default async function BlogPage({ params, searchParams }: BlogPageProps) 
           query: q ?? null,
         }}
       >
-      <div className="section-padding">
-      <div className="container">
-        {/* Header */}
-        <div className="text-center mb-12">
-          <h1 className="text-4xl font-bold mb-4">{messages.blogListing.title}</h1>
-          <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
-            {messages.blogListing.heroDescription}
-          </p>
-        </div>
+        <div className="section-padding">
+          <div className="container">
+            {/* Header */}
+            <div className="text-center mb-12">
+              <h1 className="text-4xl font-bold mb-4">
+                {messages.blogListing.title}
+              </h1>
+              <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
+                {messages.blogListing.heroDescription}
+              </p>
+            </div>
 
-        {/* Categories */}
-        {categories.length > 0 && (
-          <div className="flex flex-wrap justify-center gap-2 mb-12">
-            <Link
-              href={`${basePath}/blog`}
-              className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
-                !category
-                  ? 'bg-primary text-primary-foreground'
-                  : 'bg-muted hover:bg-muted/80'
-              }`}
-            >
-              {messages.blogListing.allCategories}
-            </Link>
-            {categories.map((cat) => (
-              <Link
-                key={cat.id}
-                href={`${basePath}/blog?category=${cat.slug}`}
-                className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
-                  category === cat.slug
-                    ? 'bg-primary text-primary-foreground'
-                    : 'bg-muted hover:bg-muted/80'
-                }`}
-              >
-                {cat.name}
-              </Link>
-            ))}
-          </div>
-        )}
-
-        {/* Posts Grid */}
-        {filteredPosts.length === 0 ? (
-          <div className="text-center py-16">
-            <p className="text-muted-foreground text-lg">
-              {messages.blogListing.noPosts}
-            </p>
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {filteredPosts.map((post) => (
-              <article
-                key={post.id}
-                className="group rounded-lg overflow-hidden bg-card border shadow-sm hover:shadow-lg transition-shadow"
-              >
-                {/* Featured Image */}
-                <Link href={`${basePath}/blog/${post.slug}`}>
-                  <div className="relative aspect-[16/9] overflow-hidden">
-                    {post.featured_image ? (
-                      <Image
-                        src={post.featured_image}
-                        alt={post.title}
-                        fill
-                        loading="lazy"
-                        sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                        className="object-cover group-hover:scale-105 transition-transform duration-300"
-                      />
-                    ) : (
-                      <div className="w-full h-full bg-muted flex items-center justify-center">
-                        <svg
-                          className="w-12 h-12 text-muted-foreground"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={1.5}
-                            d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-                          />
-                        </svg>
-                      </div>
-                    )}
-                  </div>
+            {/* Categories */}
+            {categories.length > 0 && (
+              <div className="flex flex-wrap justify-center gap-2 mb-12">
+                <Link
+                  href={`${basePath}/blog`}
+                  className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
+                    !category
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-muted hover:bg-muted/80"
+                  }`}
+                >
+                  {messages.blogListing.allCategories}
                 </Link>
-
-                {/* Content */}
-                <div className="p-6">
-                  {/* Category */}
-                  {post.category && (
-                    <Link
-                      href={`${basePath}/blog?category=${post.category.slug}`}
-                      className="text-xs font-medium text-primary uppercase tracking-wider"
-                    >
-                      {post.category.name}
-                    </Link>
-                  )}
-
-                  {/* Title */}
-                  <h2 className="mt-2 text-xl font-semibold line-clamp-2">
-                    <Link
-                      href={`${basePath}/blog/${post.slug}`}
-                      className="hover:text-primary transition-colors"
-                    >
-                      {post.title}
-                    </Link>
-                  </h2>
-
-                  {/* Excerpt */}
-                  {post.excerpt && (
-                    <p className="mt-3 text-muted-foreground line-clamp-3">
-                      {post.excerpt}
-                    </p>
-                  )}
-
-                  {/* Date */}
-                  {post.published_at && (
-                    <time
-                      dateTime={post.published_at}
-                      className="mt-4 block text-sm text-muted-foreground"
-                    >
-                      {formatPublicDate(post.published_at, localeContext.resolvedLocale, {
-                        day: 'numeric',
-                        month: 'long',
-                        year: 'numeric',
-                      })}
-                    </time>
-                  )}
-                </div>
-              </article>
-            ))}
-          </div>
-        )}
-
-        {/* Pagination */}
-        {totalPages > 1 && (
-          <div className="flex justify-center gap-2 mt-12">
-            {pageNum > 1 && (
-              <Link
-                href={`${basePath}/blog?page=${pageNum - 1}${category ? `&category=${category}` : ''}`}
-                className="px-4 py-2 rounded-lg bg-muted hover:bg-muted/80 transition-colors"
-              >
-                {messages.blogListing.previous}
-              </Link>
+                {categories.map((cat) => (
+                  <Link
+                    key={cat.id}
+                    href={`${basePath}/blog?category=${cat.slug}`}
+                    className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
+                      category === cat.slug
+                        ? "bg-primary text-primary-foreground"
+                        : "bg-muted hover:bg-muted/80"
+                    }`}
+                  >
+                    {cat.name}
+                  </Link>
+                ))}
+              </div>
             )}
 
-            <span className="px-4 py-2">
-              {messages.blogListing.pageLabel} {pageNum} {messages.blogListing.ofLabel} {totalPages}
-            </span>
+            {/* Posts Grid */}
+            {filteredPosts.length === 0 ? (
+              <div className="text-center py-16">
+                <p className="text-muted-foreground text-lg">
+                  {messages.blogListing.noPosts}
+                </p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                {filteredPosts.map((post) => (
+                  <article
+                    key={post.id}
+                    className="group rounded-lg overflow-hidden bg-card border shadow-sm hover:shadow-lg transition-shadow"
+                  >
+                    {/* Featured Image */}
+                    <Link href={`${basePath}/blog/${post.slug}`}>
+                      <div className="relative aspect-[16/9] overflow-hidden">
+                        {post.featured_image ? (
+                          <Image
+                            src={post.featured_image}
+                            alt={post.title}
+                            fill
+                            loading="lazy"
+                            sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                            className="object-cover group-hover:scale-105 transition-transform duration-300"
+                          />
+                        ) : (
+                          <div className="w-full h-full bg-muted flex items-center justify-center">
+                            <svg
+                              className="w-12 h-12 text-muted-foreground"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={1.5}
+                                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                              />
+                            </svg>
+                          </div>
+                        )}
+                      </div>
+                    </Link>
 
-            {pageNum < totalPages && (
-              <Link
-                href={`${basePath}/blog?page=${pageNum + 1}${category ? `&category=${category}` : ''}`}
-                className="px-4 py-2 rounded-lg bg-muted hover:bg-muted/80 transition-colors"
-              >
-                {messages.blogListing.next}
-              </Link>
+                    {/* Content */}
+                    <div className="p-6">
+                      {/* Category */}
+                      {post.category && (
+                        <Link
+                          href={`${basePath}/blog?category=${post.category.slug}`}
+                          className="text-xs font-medium text-primary uppercase tracking-wider"
+                        >
+                          {post.category.name}
+                        </Link>
+                      )}
+
+                      {/* Title */}
+                      <h2 className="mt-2 text-xl font-semibold line-clamp-2">
+                        <Link
+                          href={`${basePath}/blog/${post.slug}`}
+                          className="hover:text-primary transition-colors"
+                        >
+                          {post.title}
+                        </Link>
+                      </h2>
+
+                      {/* Excerpt */}
+                      {post.excerpt && (
+                        <p className="mt-3 text-muted-foreground line-clamp-3">
+                          {post.excerpt}
+                        </p>
+                      )}
+
+                      {/* Date */}
+                      {post.published_at && (
+                        <time
+                          dateTime={post.published_at}
+                          className="mt-4 block text-sm text-muted-foreground"
+                        >
+                          {formatPublicDate(
+                            post.published_at,
+                            localeContext.resolvedLocale,
+                            {
+                              day: "numeric",
+                              month: "long",
+                              year: "numeric",
+                            },
+                          )}
+                        </time>
+                      )}
+                    </div>
+                  </article>
+                ))}
+              </div>
+            )}
+
+            {/* Pagination */}
+            {totalPages > 1 && (
+              <div className="flex justify-center gap-2 mt-12">
+                {pageNum > 1 && (
+                  <Link
+                    href={`${basePath}/blog?page=${pageNum - 1}${category ? `&category=${category}` : ""}`}
+                    className="px-4 py-2 rounded-lg bg-muted hover:bg-muted/80 transition-colors"
+                  >
+                    {messages.blogListing.previous}
+                  </Link>
+                )}
+
+                <span className="px-4 py-2">
+                  {messages.blogListing.pageLabel} {pageNum}{" "}
+                  {messages.blogListing.ofLabel} {totalPages}
+                </span>
+
+                {pageNum < totalPages && (
+                  <Link
+                    href={`${basePath}/blog?page=${pageNum + 1}${category ? `&category=${category}` : ""}`}
+                    className="px-4 py-2 rounded-lg bg-muted hover:bg-muted/80 transition-colors"
+                  >
+                    {messages.blogListing.next}
+                  </Link>
+                )}
+              </div>
             )}
           </div>
-        )}
-      </div>
-    </div>
-    </TemplateSlot>
+        </div>
+      </TemplateSlot>
     </>
   );
 }

--- a/app/site/[subdomain]/experiencias/page.tsx
+++ b/app/site/[subdomain]/experiencias/page.tsx
@@ -13,22 +13,22 @@
  * still return a usable page.
  */
 
-import type { Metadata } from 'next';
-import { headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 
-import { getWebsiteBySubdomain } from '@/lib/supabase/get-website';
-import { getCategoryProducts } from '@/lib/supabase/get-pages';
-import { toActivityItems } from '@/lib/products/to-items';
+import { getWebsiteBySubdomain } from "@/lib/supabase/get-website";
+import { getCategoryProducts } from "@/lib/supabase/get-pages";
+import { toActivityItems } from "@/lib/products/to-items";
 import {
   buildLocaleAwareAlternateLanguages,
   resolvePublicMetadataLocale,
-} from '@/lib/seo/public-metadata';
-import { localeToOgLocale } from '@/lib/seo/locale-routing';
-import { resolveOgImage } from '@/lib/seo/og-helpers';
-import { TemplateSlot } from '@/components/site/themes/editorial-v1/template-slot';
-import type { ExperienceItem } from '@/components/site/themes/editorial-v1/pages/experiences-grid.client';
-import { ExperiencesFallbackClient } from './experiences-fallback.client';
+} from "@/lib/seo/public-metadata";
+import { localeToOgLocale } from "@/lib/seo/locale-routing";
+import { resolveOgImage } from "@/lib/seo/og-helpers";
+import { TemplateSlot } from "@/components/site/themes/editorial-v1/template-slot";
+import type { ExperienceItem } from "@/components/site/themes/editorial-v1/pages/experiences-grid.client";
+import { ExperiencesFallbackClient } from "./experiences-fallback.client";
+import { inferIsCustomDomainWebsite } from "@/lib/utils/base-path";
 
 interface ExperiencesPageProps {
   params: Promise<{ subdomain: string }>;
@@ -43,9 +43,9 @@ interface ExperiencesPageProps {
   }>;
 }
 
-const PAGE_TITLE = 'Experiencias';
+const PAGE_TITLE = "Experiencias";
 const PAGE_DESCRIPTION =
-  'Actividades para sumar a tu viaje. Oficios, caminatas, cocina, mar, selva.';
+  "Actividades para sumar a tu viaje. Oficios, caminatas, cocina, mar, selva.";
 
 export async function generateMetadata({
   params,
@@ -55,15 +55,19 @@ export async function generateMetadata({
   if (!website) {
     return { title: PAGE_TITLE };
   }
-  const siteName = website.content?.account?.name || website.content?.siteName || subdomain;
+  const siteName =
+    website.content?.account?.name || website.content?.siteName || subdomain;
   const baseUrl = website.custom_domain
     ? `https://${website.custom_domain}`
     : `https://${subdomain}.bukeer.com`;
-  const localeContext = await resolvePublicMetadataLocale(website, '/experiencias');
+  const localeContext = await resolvePublicMetadataLocale(
+    website,
+    "/experiencias",
+  );
   const canonical = `${baseUrl}${localeContext.localizedPathname}`;
   const languages = buildLocaleAwareAlternateLanguages(
     baseUrl,
-    '/experiencias',
+    "/experiencias",
     localeContext,
   );
   const ogImage = resolveOgImage(website);
@@ -78,7 +82,7 @@ export async function generateMetadata({
       url: canonical,
       siteName,
       locale: localeToOgLocale(localeContext.resolvedLocale),
-      type: 'website',
+      type: "website",
       ...(ogImage && { images: [{ url: ogImage }] }),
     },
   };
@@ -86,19 +90,22 @@ export async function generateMetadata({
 
 function toArrayParam(raw: string | undefined): string[] {
   if (!raw) return [];
-  return raw.split(',').map((s) => s.trim()).filter(Boolean);
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
 }
 
 function normaliseActivities(raw: unknown[]): ExperienceItem[] {
   if (!Array.isArray(raw)) return [];
   return raw
     .map((r): ExperienceItem | null => {
-      if (!r || typeof r !== 'object') return null;
+      if (!r || typeof r !== "object") return null;
       const obj = r as Record<string, unknown>;
-      const id = typeof obj.id === 'string' ? obj.id : null;
+      const id = typeof obj.id === "string" ? obj.id : null;
       const name =
-        (typeof obj.name === 'string' && obj.name) ||
-        (typeof obj.title === 'string' && (obj.title as string)) ||
+        (typeof obj.name === "string" && obj.name) ||
+        (typeof obj.title === "string" && (obj.title as string)) ||
         null;
       if (!id || !name) return null;
       return {
@@ -109,7 +116,7 @@ function normaliseActivities(raw: unknown[]): ExperienceItem[] {
         description: (obj.description as string | undefined) ?? null,
         image:
           (obj.image as string | undefined) ??
-          (Array.isArray(obj.images) && typeof obj.images[0] === 'string'
+          (Array.isArray(obj.images) && typeof obj.images[0] === "string"
             ? (obj.images[0] as string)
             : null),
         location: (obj.location as string | undefined) ?? null,
@@ -143,13 +150,15 @@ export default async function ExperiencesPageRoute({
   const sp = await searchParams;
   const website = await getWebsiteBySubdomain(subdomain);
 
-  if (!website || website.status !== 'published') {
+  if (!website || website.status !== "published") {
     notFound();
   }
 
-  const localeContext = await resolvePublicMetadataLocale(website, '/experiencias');
-  const headerList = await headers();
-  const isCustomDomain = Boolean(headerList.get('x-custom-domain'));
+  const localeContext = await resolvePublicMetadataLocale(
+    website,
+    "/experiencias",
+  );
+  const isCustomDomain = inferIsCustomDomainWebsite(website);
   const websiteForRender = {
     ...website,
     resolvedLocale: localeContext.resolvedLocale,
@@ -164,23 +173,25 @@ export default async function ExperiencesPageRoute({
   // authored a section payload — previously we only read from the section
   // which resulted in "0 de 0" for sites like ColombiaTours.
   const activitiesSection = (website.sections || []).find(
-    (s) => s.section_type === 'activities' && s.is_enabled !== false,
+    (s) => s.section_type === "activities" && s.is_enabled !== false,
   );
   const authoredActivities = Array.isArray(
-    (activitiesSection?.content as Record<string, unknown> | undefined)?.activities,
+    (activitiesSection?.content as Record<string, unknown> | undefined)
+      ?.activities,
   )
-    ? ((activitiesSection!.content as Record<string, unknown>).activities as unknown[])
+    ? ((activitiesSection!.content as Record<string, unknown>)
+        .activities as unknown[])
     : [];
 
   let activities: ExperienceItem[];
   if (authoredActivities.length > 0) {
     activities = normaliseActivities(authoredActivities);
   } else {
-    const catalog = await getCategoryProducts(subdomain, 'activities', {
+    const catalog = await getCategoryProducts(subdomain, "activities", {
       limit: 100,
       offset: 0,
       locale: localeContext.resolvedLocale,
-      defaultLocale: localeContext.defaultLocale ?? 'es-CO',
+      defaultLocale: localeContext.defaultLocale ?? "es-CO",
       websiteId: String(website.id),
     });
     // toActivityItems returns the canonical editorial shape (name, image,
@@ -201,10 +212,10 @@ export default async function ExperiencesPageRoute({
           level: toArrayParam(sp.level),
           region: toArrayParam(sp.region),
           location: toArrayParam(sp.location),
-          category: sp.category || 'all',
-          duration: sp.duration || 'all',
-          sort: sp.sort || 'popular',
-          q: sp.q || '',
+          category: sp.category || "all",
+          duration: sp.duration || "all",
+          sort: sp.sort || "popular",
+          q: sp.q || "",
         },
       }}
     >

--- a/app/site/[subdomain]/layout.tsx
+++ b/app/site/[subdomain]/layout.tsx
@@ -1,35 +1,40 @@
-import { Metadata } from 'next';
-import { notFound } from 'next/navigation';
-import { Suspense } from 'react';
-import { preload } from 'react-dom';
-import { getWebsiteBySubdomain, type WebsiteData } from '@/lib/supabase/get-website';
-import { getWebsiteNavigation } from '@/lib/supabase/get-pages';
-import { M3ThemeProvider } from '@/lib/theme/m3-theme-provider';
-import { SiteHeader } from '@/components/site/site-header';
-import { SiteFooter } from '@/components/site/site-footer';
-import { SmoothScroll } from '@/components/ui/smooth-scroll';
-import { GoogleTagManager, GoogleTagManagerBody } from '@/components/analytics/google-tag-manager';
-import { buildNavTree, getDefaultNavigation } from '@/lib/utils/navigation';
-import { getBasePath } from '@/lib/utils/base-path';
-import type { ThemeInput } from '@/lib/theme/m3-theme-provider';
-import { compileTheme } from '@bukeer/theme-sdk';
-import type { DesignTokens, ThemeProfile } from '@bukeer/theme-sdk';
-import { resolvePublicMetadataLocale } from '@/lib/seo/public-metadata';
-import { localeToOgLocale } from '@/lib/seo/locale-routing';
-import { resolveSiteIcons } from '@/lib/seo/site-icons';
-import { WebsiteLocaleProvider } from '@/components/site/website-locale-provider';
-import { resolveTemplateSet } from '@/lib/sections/template-set';
-import { headers } from 'next/headers';
-import { isLandingPage } from '@/lib/utils/landing-pages';
-import { normalizeThemeInput } from '@/lib/theme/normalize-theme';
-import { supabaseImageUrl } from '@/lib/images/supabase-transform';
-import { EditorialSiteHeader } from '@/components/site/themes/editorial-v1/layout/site-header';
-import { EditorialSiteFooter } from '@/components/site/themes/editorial-v1/layout/site-footer';
-import { WaflowProvider } from '@/components/site/themes/editorial-v1/waflow/provider';
-import '@/app/globals.css';
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+import { preload } from "react-dom";
+import {
+  getWebsiteBySubdomain,
+  type WebsiteData,
+} from "@/lib/supabase/get-website";
+import { getWebsiteNavigation } from "@/lib/supabase/get-pages";
+import { M3ThemeProvider } from "@/lib/theme/m3-theme-provider";
+import { SiteHeader } from "@/components/site/site-header";
+import { SiteFooter } from "@/components/site/site-footer";
+import { SmoothScroll } from "@/components/ui/smooth-scroll";
+import {
+  GoogleTagManager,
+  GoogleTagManagerBody,
+} from "@/components/analytics/google-tag-manager";
+import { buildNavTree, getDefaultNavigation } from "@/lib/utils/navigation";
+import { getBasePath, inferIsCustomDomainWebsite } from "@/lib/utils/base-path";
+import type { ThemeInput } from "@/lib/theme/m3-theme-provider";
+import { compileTheme } from "@bukeer/theme-sdk";
+import type { DesignTokens, ThemeProfile } from "@bukeer/theme-sdk";
+import { resolvePublicMetadataLocale } from "@/lib/seo/public-metadata";
+import { localeToOgLocale } from "@/lib/seo/locale-routing";
+import { resolveSiteIcons } from "@/lib/seo/site-icons";
+import { WebsiteLocaleProvider } from "@/components/site/website-locale-provider";
+import { resolveTemplateSet } from "@/lib/sections/template-set";
+import { isLandingPage } from "@/lib/utils/landing-pages";
+import { normalizeThemeInput } from "@/lib/theme/normalize-theme";
+import { supabaseImageUrl } from "@/lib/images/supabase-transform";
+import { EditorialSiteHeader } from "@/components/site/themes/editorial-v1/layout/site-header";
+import { EditorialSiteFooter } from "@/components/site/themes/editorial-v1/layout/site-footer";
+import { WaflowProvider } from "@/components/site/themes/editorial-v1/waflow/provider";
+import "@/app/globals.css";
 // Editorial-v1 scoped CSS loads alongside globals but only emits rules under
 // `[data-template-set="editorial-v1"]`, so generic sites stay untouched.
-import '@/components/site/themes/editorial-v1/editorial-v1.css';
+import "@/components/site/themes/editorial-v1/editorial-v1.css";
 
 interface SiteLayoutProps {
   children: React.ReactNode;
@@ -46,18 +51,20 @@ interface ThemeOutput {
  * light-mode token map, mirroring `applyBridgeVariables` in m3-theme-provider.
  * Returns an array of `--name:value` strings ready to inject into `:root{}`.
  */
-function computeBridgeVars(lightVars: Array<{ name: string; value: string }>): string[] {
+function computeBridgeVars(
+  lightVars: Array<{ name: string; value: string }>,
+): string[] {
   const m = new Map(lightVars.map((v) => [v.name, v.value]));
-  const bg = m.get('background') || '';
-  const card = m.get('card') || '';
-  const fg = m.get('foreground') || '';
-  const primary = m.get('primary') || '';
-  const primaryFg = m.get('primary-foreground') || '';
-  const accent = m.get('accent') || '';
-  const accent2 = m.get('accent-2') || '';
-  const accent3 = m.get('accent-3') || '';
-  const mutedFg = m.get('muted-foreground') || '';
-  const border = m.get('border') || '';
+  const bg = m.get("background") || "";
+  const card = m.get("card") || "";
+  const fg = m.get("foreground") || "";
+  const primary = m.get("primary") || "";
+  const primaryFg = m.get("primary-foreground") || "";
+  const accent = m.get("accent") || "";
+  const accent2 = m.get("accent-2") || "";
+  const accent3 = m.get("accent-3") || "";
+  const mutedFg = m.get("muted-foreground") || "";
+  const border = m.get("border") || "";
   if (!bg) return [];
   return [
     `--bg:hsl(${bg})`,
@@ -106,14 +113,14 @@ function computeBridgeVars(lightVars: Array<{ name: string; value: string }>): s
  * Also returns Google Fonts URLs so they're discoverable in the initial HTML parse.
  */
 function generateThemeOutput(themeInput: ThemeInput | undefined): ThemeOutput {
-  if (!themeInput) return { css: '', fontUrls: [] };
+  if (!themeInput) return { css: "", fontUrls: [] };
   try {
     const compiled = compileTheme(
       themeInput.tokens as DesignTokens,
       themeInput.profile as ThemeProfile,
-      { target: 'web' },
+      { target: "web" },
     );
-    if (!compiled.web) return { css: '', fontUrls: [] };
+    if (!compiled.web) return { css: "", fontUrls: [] };
     const vars: string[] = [];
     for (const v of [...compiled.web.invariant, ...compiled.web.light]) {
       vars.push(`--${v.name}:${v.value}`);
@@ -122,36 +129,40 @@ function generateThemeOutput(themeInput: ThemeInput | undefined): ThemeOutput {
       vars.push(`--data-${k}:${v}`);
     }
     vars.push(...computeBridgeVars(compiled.web.light));
-    vars.push('--theme-ssr:1');
-    const css = vars.length ? `:root{${vars.join(';')}}` : '';
+    vars.push("--theme-ssr:1");
+    const css = vars.length ? `:root{${vars.join(";")}}` : "";
     return { css, fontUrls: compiled.web.fontImports ?? [] };
   } catch {
-    return { css: '', fontUrls: [] };
+    return { css: "", fontUrls: [] };
   }
 }
 
 // Generate metadata for SEO
-export async function generateMetadata({ params }: SiteLayoutProps): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: SiteLayoutProps): Promise<Metadata> {
   const { subdomain } = await params;
   const website = await getWebsiteBySubdomain(subdomain);
 
   if (!website) {
     return {
-      title: 'Sitio no encontrado',
+      title: "Sitio no encontrado",
     };
   }
 
   const { content } = website;
   const seoContent = content.seo as Record<string, unknown> | undefined;
   const siteName = content.account?.name || content.siteName;
-  const description = content?.seo?.description
-    || content?.tagline
-    || `${content?.siteName || subdomain} - Tu agencia de viajes de confianza`;
-  const localeContext = await resolvePublicMetadataLocale(website, '/');
+  const description =
+    content?.seo?.description ||
+    content?.tagline ||
+    `${content?.siteName || subdomain} - Tu agencia de viajes de confianza`;
+  const localeContext = await resolvePublicMetadataLocale(website, "/");
 
   // Resolve og:image from: seo.image > hero backgroundImage > account logo
   const heroSection = website.sections?.find(
-    (s: { section_type: string; is_enabled: boolean }) => s.section_type === 'hero' && s.is_enabled
+    (s: { section_type: string; is_enabled: boolean }) =>
+      s.section_type === "hero" && s.is_enabled,
   );
   const ogImage =
     (seoContent?.image as string | undefined) ||
@@ -167,43 +178,45 @@ export async function generateMetadata({ params }: SiteLayoutProps): Promise<Met
     description,
     keywords: Array.isArray(content.seo?.keywords)
       ? content.seo.keywords
-      : content.seo?.keywords?.split(',').map((k: string) => k.trim()),
+      : content.seo?.keywords?.split(",").map((k: string) => k.trim()),
     openGraph: {
       title: content.seo?.title || siteName,
       description,
       siteName: siteName,
-      type: 'website',
+      type: "website",
       locale: localeToOgLocale(localeContext.resolvedLocale),
       ...(ogImage ? { images: [{ url: ogImage as string }] } : {}),
     },
     twitter: {
-      card: 'summary_large_image',
+      card: "summary_large_image",
       title: content.seo?.title || siteName,
       description,
       ...(ogImage ? { images: [ogImage as string] } : {}),
     },
     robots: {
-      index: website.status === 'published',
-      follow: website.status === 'published',
+      index: website.status === "published",
+      follow: website.status === "published",
     },
     ...(icons ? { icons } : {}),
   };
 }
 
-export default async function SiteLayout({ children, params }: SiteLayoutProps) {
+export default async function SiteLayout({
+  children,
+  params,
+}: SiteLayoutProps) {
   const { subdomain } = await params;
   const website = await getWebsiteBySubdomain(subdomain);
 
   // If website not found or not published, show 404
-  if (!website || website.status !== 'published') {
+  if (!website || website.status !== "published") {
     notFound();
   }
 
   // Fetch dynamic navigation (RPC), fallback to section-based defaults
   const navItems = await getWebsiteNavigation(subdomain);
-  const localeContext = await resolvePublicMetadataLocale(website, '/');
-  const headerList = await headers();
-  const isCustomDomain = Boolean(headerList.get('x-custom-domain'));
+  const localeContext = await resolvePublicMetadataLocale(website, "/");
+  const isCustomDomain = inferIsCustomDomainWebsite(website);
   const websiteForRender = {
     ...website,
     resolvedLocale: localeContext.resolvedLocale,
@@ -211,11 +224,15 @@ export default async function SiteLayout({ children, params }: SiteLayoutProps) 
     isCustomDomain,
   };
   const basePath = getBasePath(subdomain, isCustomDomain);
-  const navigation = navItems.length > 0
-    ? buildNavTree(navItems)
-    : getDefaultNavigation(website.sections, basePath);
+  const navigation =
+    navItems.length > 0
+      ? buildNavTree(navItems)
+      : getDefaultNavigation(website.sections, basePath);
   const websiteWithEffectiveTheme = website as typeof website & {
-    effective_theme?: { tokens: Record<string, unknown>; profile: Record<string, unknown> };
+    effective_theme?: {
+      tokens: Record<string, unknown>;
+      profile: Record<string, unknown>;
+    };
   };
   const initialTheme = normalizeThemeInput(
     websiteWithEffectiveTheme.effective_theme ?? website.theme,
@@ -229,24 +246,28 @@ export default async function SiteLayout({ children, params }: SiteLayoutProps) 
   // browser discovering it late in the RSC streaming payload (~65% into doc).
   const heroSection = website.sections?.find(
     (s: { section_type: string; is_enabled: boolean }) =>
-      s.section_type?.startsWith('hero') && s.is_enabled
+      s.section_type?.startsWith("hero") && s.is_enabled,
   );
-  const heroContent = heroSection?.content as Record<string, unknown> | undefined;
-  const heroSlides = Array.isArray(heroContent?.slides) ? heroContent.slides : [];
-  const firstHeroSlide = heroSlides.find((slide): slide is Record<string, unknown> =>
-    Boolean(slide && typeof slide === 'object' && 'imageUrl' in slide),
+  const heroContent = heroSection?.content as
+    | Record<string, unknown>
+    | undefined;
+  const heroSlides = Array.isArray(heroContent?.slides)
+    ? heroContent.slides
+    : [];
+  const firstHeroSlide = heroSlides.find(
+    (slide): slide is Record<string, unknown> =>
+      Boolean(slide && typeof slide === "object" && "imageUrl" in slide),
   );
-  const heroImage = (
+  const heroImage =
     (heroContent?.backgroundImage as string | undefined) ||
-    (firstHeroSlide?.imageUrl as string | undefined)
-  );
+    (firstHeroSlide?.imageUrl as string | undefined);
   const heroPreloadImage = heroImage
     ? supabaseImageUrl(heroImage, { width: 1000, quality: 70 })
     : undefined;
   if (heroPreloadImage) {
     preload(heroPreloadImage, {
-      as: 'image',
-      fetchPriority: 'high',
+      as: "image",
+      fetchPriority: "high",
     });
   }
   // Wave 1.1 plumbing: resolve opt-in template set (editorial-v1). When null we
@@ -254,21 +275,23 @@ export default async function SiteLayout({ children, params }: SiteLayoutProps) 
   // Wave 1.2: swap header/footer for the editorial variants when opted in.
 
   // Detect if current route is a landing page to apply minimalist header/footer
-  const originalPathname = headerList.get('x-public-original-pathname') || '';
+  const originalPathname = "";
   const isLanding = isLandingPage(originalPathname);
 
   // Wave 1.1 plumbing: resolve opt-in template set (editorial-v1). When null we
   // skip the wrapper entirely to preserve byte-identical HTML for generic sites.
   // Wave 1.2: swap header/footer for the editorial variants when opted in.
-  const templateSet = resolveTemplateSet(website) || (subdomain.toLowerCase().includes('colombiatours') ? 'editorial-v1' : null);
-  const isEditorial = templateSet === 'editorial-v1';
+  const templateSet =
+    resolveTemplateSet(website) ||
+    (subdomain.toLowerCase().includes("colombiatours") ? "editorial-v1" : null);
+  const isEditorial = templateSet === "editorial-v1";
   const shouldInjectThemeFontStyles = !isEditorial;
   const analyticsContext = {
     accountId: website.account_id,
     websiteId: website.id,
     tenant: website.subdomain || subdomain,
     locale: localeContext.resolvedLocale,
-    market: localeContext.resolvedLocale.split('-')[1] ?? null,
+    market: localeContext.resolvedLocale.split("-")[1] ?? null,
   };
 
   const headerEl = isEditorial ? (
@@ -279,7 +302,11 @@ export default async function SiteLayout({ children, params }: SiteLayoutProps) 
       isLanding={isLanding}
     />
   ) : (
-    <SiteHeader website={websiteForRender} navigation={navigation} isCustomDomain={isCustomDomain} />
+    <SiteHeader
+      website={websiteForRender}
+      navigation={navigation}
+      isCustomDomain={isCustomDomain}
+    />
   );
   const footerEl = isEditorial ? (
     <EditorialSiteFooter
@@ -289,7 +316,11 @@ export default async function SiteLayout({ children, params }: SiteLayoutProps) 
       isLanding={isLanding}
     />
   ) : (
-    <SiteFooter website={websiteForRender} navigation={navigation} isCustomDomain={isCustomDomain} />
+    <SiteFooter
+      website={websiteForRender}
+      navigation={navigation}
+      isCustomDomain={isCustomDomain}
+    />
   );
 
   const smoothScrollContent = (
@@ -299,12 +330,8 @@ export default async function SiteLayout({ children, params }: SiteLayoutProps) 
         {/* GTM NoScript fallback */}
         <GoogleTagManagerBody analytics={website.analytics} defer />
 
-        <Suspense fallback={null}>
-          {headerEl}
-        </Suspense>
-        <main className="flex-1 overflow-x-hidden">
-          {children}
-        </main>
+        <Suspense fallback={null}>{headerEl}</Suspense>
+        <main className="flex-1 overflow-x-hidden">{children}</main>
         {footerEl}
       </div>
     </SmoothScroll>
@@ -313,12 +340,14 @@ export default async function SiteLayout({ children, params }: SiteLayoutProps) 
   // Resolve WhatsApp business number for the editorial waflow provider. The
   // Wave 2 schema adds `websites.contact_whatsapp` (preferred); we fall back
   // to the legacy `content.social.whatsapp` while tenants migrate.
-  const websiteRecord = website as WebsiteData & { contact_whatsapp?: string | null };
+  const websiteRecord = website as WebsiteData & {
+    contact_whatsapp?: string | null;
+  };
   const waflowBusinessNumber =
     websiteRecord.contact_whatsapp ||
     website.content?.social?.whatsapp ||
     website.content?.account?.phone ||
-    '';
+    "";
 
   const templatedBody = isEditorial ? (
     <WaflowProvider
@@ -337,35 +366,57 @@ export default async function SiteLayout({ children, params }: SiteLayoutProps) 
     <>
       {/* LCP hero image preload — must be first link in <head> to minimize Load Delay */}
       {heroPreloadImage ? (
-        <link rel="preload" as="image" href={heroPreloadImage} fetchPriority="high" />
+        <link
+          rel="preload"
+          as="image"
+          href={heroPreloadImage}
+          fetchPriority="high"
+        />
       ) : null}
       {/* Preconnect to common third-party origins */}
       <link rel="preconnect" href="https://fonts.googleapis.com" />
       <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
-      {!isEditorial ? <link rel="preconnect" href="https://images.unsplash.com" crossOrigin="" /> : null}
+      {!isEditorial ? (
+        <link
+          rel="preconnect"
+          href="https://images.unsplash.com"
+          crossOrigin=""
+        />
+      ) : null}
       {/* Preconnect to Supabase storage — hero images / assets served from here */}
-      <link rel="preconnect" href="https://wzlxbpicdcdvxvdcvgas.supabase.co" crossOrigin="" />
+      <link
+        rel="preconnect"
+        href="https://wzlxbpicdcdvxvdcvgas.supabase.co"
+        crossOrigin=""
+      />
       {/* Generic sites keep theme font imports; editorial-v1 relies on self-hosted next/font variables. */}
-      {shouldInjectThemeFontStyles && themeOutput.fontUrls.map((url) => (
-        <link key={url} rel="stylesheet" href={url} />
-      ))}
+      {shouldInjectThemeFontStyles &&
+        themeOutput.fontUrls.map((url) => (
+          <link key={url} rel="stylesheet" href={url} />
+        ))}
       {/* Inline theme CSS variables (incl. bridge vars) so they're available
           before JS, preventing mount-time style recalculation from delaying LCP. */}
-      {themeCSS ? <style dangerouslySetInnerHTML={{ __html: themeCSS }} /> : null}
+      {themeCSS ? (
+        <style dangerouslySetInnerHTML={{ __html: themeCSS }} />
+      ) : null}
       {/* SSR sentinel — client reads this to skip re-applying theme on mount */}
       {themeCSS ? <meta name="x-theme-ssr" content="1" /> : null}
-    <WebsiteLocaleProvider locale={localeContext.resolvedLocale}>
-      <M3ThemeProvider initialTheme={initialTheme}>
-        {/* Google Tag Manager and Analytics Scripts */}
-        <GoogleTagManager analytics={website.analytics} defer context={analyticsContext} />
+      <WebsiteLocaleProvider locale={localeContext.resolvedLocale}>
+        <M3ThemeProvider initialTheme={initialTheme}>
+          {/* Google Tag Manager and Analytics Scripts */}
+          <GoogleTagManager
+            analytics={website.analytics}
+            defer
+            context={analyticsContext}
+          />
 
-        {templateSet ? (
-          <div data-template-set={templateSet}>{templatedBody}</div>
-        ) : (
-          templatedBody
-        )}
-      </M3ThemeProvider>
-    </WebsiteLocaleProvider>
+          {templateSet ? (
+            <div data-template-set={templateSet}>{templatedBody}</div>
+          ) : (
+            templatedBody
+          )}
+        </M3ThemeProvider>
+      </WebsiteLocaleProvider>
     </>
   );
 }
@@ -373,7 +424,8 @@ export default async function SiteLayout({ children, params }: SiteLayoutProps) 
 // Generate static paths for all published websites
 export async function generateStaticParams() {
   // Import dynamically to avoid issues during build
-  const { getAllWebsiteSubdomains } = await import('@/lib/supabase/get-website');
+  const { getAllWebsiteSubdomains } =
+    await import("@/lib/supabase/get-website");
   const subdomains = await getAllWebsiteSubdomains();
 
   return subdomains.map((subdomain) => ({

--- a/app/site/[subdomain]/page.tsx
+++ b/app/site/[subdomain]/page.tsx
@@ -1,36 +1,47 @@
-import { Metadata } from 'next';
-import { headers } from 'next/headers';
-import { notFound } from 'next/navigation';
-import { Suspense } from 'react';
-import { SectionRenderer } from '@/components/site/section-renderer';
-import { JsonLd, generateHomepageSchemas } from '@/lib/schema';
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+import { SectionRenderer } from "@/components/site/section-renderer";
+import { JsonLd, generateHomepageSchemas } from "@/lib/schema";
 import {
   buildLocaleAwareAlternateLanguages,
   resolvePublicMetadataLocale,
-} from '@/lib/seo/public-metadata';
-import { localeToOgLocale } from '@/lib/seo/locale-routing';
-import { resolveOgImage } from '@/lib/seo/og-helpers';
-import { getWebsiteBySubdomain, getBlogPosts } from '@/lib/supabase/get-website';
-import type { WebsiteData, WebsiteSection } from '@/lib/supabase/get-website';
-import { getCachedGoogleReviews, getCategoryProducts, getDestinations } from '@/lib/supabase/get-pages';
-import { getPlanners } from '@/lib/supabase/get-planners';
-import type { PlannerData } from '@/lib/supabase/get-planners';
-import { getBrandClaims } from '@/lib/supabase/get-brand-claims';
-import { getFeaturedDestinations } from '@/lib/supabase/get-featured-destinations';
-import { SECTION_TYPES } from '@bukeer/website-contract';
-import { hydrateSections } from '@/lib/sections/hydrate-sections';
-import { toPackageItems, toActivityItems, toHotelItems } from '@/lib/products/to-items';
-import { resolveTemplateSet } from '@/lib/sections/template-set';
+} from "@/lib/seo/public-metadata";
+import { localeToOgLocale } from "@/lib/seo/locale-routing";
+import { resolveOgImage } from "@/lib/seo/og-helpers";
+import {
+  getWebsiteBySubdomain,
+  getBlogPosts,
+} from "@/lib/supabase/get-website";
+import type { WebsiteData, WebsiteSection } from "@/lib/supabase/get-website";
+import {
+  getCachedGoogleReviews,
+  getCategoryProducts,
+  getDestinations,
+} from "@/lib/supabase/get-pages";
+import { getPlanners } from "@/lib/supabase/get-planners";
+import type { PlannerData } from "@/lib/supabase/get-planners";
+import { getBrandClaims } from "@/lib/supabase/get-brand-claims";
+import { getFeaturedDestinations } from "@/lib/supabase/get-featured-destinations";
+import { SECTION_TYPES } from "@bukeer/website-contract";
+import { hydrateSections } from "@/lib/sections/hydrate-sections";
+import {
+  toPackageItems,
+  toActivityItems,
+  toHotelItems,
+} from "@/lib/products/to-items";
+import { resolveTemplateSet } from "@/lib/sections/template-set";
 import {
   buildHomeSectionPlan,
   resolveHomeEnabledSections,
   type DeferredHomeDataInput,
-} from '@/lib/site/home-rendering';
+} from "@/lib/site/home-rendering";
+import { inferIsCustomDomainWebsite } from "@/lib/utils/base-path";
 
-const SECTION_PACKAGES = SECTION_TYPES.find((t) => t === 'packages')!;
-const SECTION_ACTIVITIES = SECTION_TYPES.find((t) => t === 'activities')!;
-const SECTION_HOTELS = SECTION_TYPES.find((t) => t === 'hotels')!;
-const SECTION_BLOG = SECTION_TYPES.find((t) => t === 'blog')!;
+const SECTION_PACKAGES = SECTION_TYPES.find((t) => t === "packages")!;
+const SECTION_ACTIVITIES = SECTION_TYPES.find((t) => t === "activities")!;
+const SECTION_HOTELS = SECTION_TYPES.find((t) => t === "hotels")!;
+const SECTION_BLOG = SECTION_TYPES.find((t) => t === "blog")!;
 
 // ISR: Revalidate every 5 minutes for fresh content with edge caching
 export const revalidate = 300;
@@ -39,14 +50,14 @@ interface SitePageProps {
   params: Promise<{ subdomain: string }>;
 }
 
-const PLANNER_TYPES = new Set(['planners', 'team', 'travel_planners']);
+const PLANNER_TYPES = new Set(["planners", "team", "travel_planners"]);
 
 function titleFromSlug(slug: string): string {
   return slug
-    .split('-')
+    .split("-")
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(' ');
+    .join(" ");
 }
 
 function featuredDestinationsAsSectionItems(
@@ -68,23 +79,33 @@ function contentHasArray(section: WebsiteSection, key: string): boolean {
   return Array.isArray(value) && value.length > 0;
 }
 
-export async function generateMetadata({ params }: SitePageProps): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: SitePageProps): Promise<Metadata> {
   const { subdomain } = await params;
   const website = await getWebsiteBySubdomain(subdomain);
-  if (!website) return { title: 'Sitio no encontrado' };
+  if (!website) return { title: "Sitio no encontrado" };
 
   const baseUrl = website.custom_domain
     ? `https://${website.custom_domain}`
     : `https://${subdomain}.bukeer.com`;
-  const localeContext = await resolvePublicMetadataLocale(website, '/');
-  const languages = buildLocaleAwareAlternateLanguages(baseUrl, '/', localeContext);
-  const canonical = localeContext.localizedPathname === '/'
-    ? baseUrl
-    : `${baseUrl}${localeContext.localizedPathname}`;
+  const localeContext = await resolvePublicMetadataLocale(website, "/");
+  const languages = buildLocaleAwareAlternateLanguages(
+    baseUrl,
+    "/",
+    localeContext,
+  );
+  const canonical =
+    localeContext.localizedPathname === "/"
+      ? baseUrl
+      : `${baseUrl}${localeContext.localizedPathname}`;
 
-  const title = website.content.seo?.title || website.content.siteName || subdomain;
-  const description = website.content.seo?.description || website.content.tagline || '';
-  const siteName = website.content?.account?.name || website.content?.siteName || subdomain;
+  const title =
+    website.content.seo?.title || website.content.siteName || subdomain;
+  const description =
+    website.content.seo?.description || website.content.tagline || "";
+  const siteName =
+    website.content?.account?.name || website.content?.siteName || subdomain;
   const ogImage = resolveOgImage(website);
 
   return {
@@ -101,11 +122,11 @@ export async function generateMetadata({ params }: SitePageProps): Promise<Metad
       url: canonical,
       siteName,
       locale: localeToOgLocale(localeContext.resolvedLocale),
-      type: 'website',
+      type: "website",
       ...(ogImage && { images: [{ url: ogImage }] }),
     },
     twitter: {
-      card: 'summary_large_image',
+      card: "summary_large_image",
       title,
       description,
       ...(ogImage && { images: [ogImage] }),
@@ -122,13 +143,14 @@ async function DeferredHomeSections({
   criticalSectionIds,
   templateSet,
 }: DeferredHomeDataInput) {
-  const accountContent = ((website.content as unknown as Record<string, unknown>)?.account as Record<string, unknown> | undefined);
+  const accountContent = (website.content as unknown as Record<string, unknown>)
+    ?.account as Record<string, unknown> | undefined;
   const googleReviewsEnabled = accountContent?.google_reviews_enabled === true;
-  const hasPlannersSection = enabledSections.some(
-    (s) => PLANNER_TYPES.has(s.section_type)
+  const hasPlannersSection = enabledSections.some((s) =>
+    PLANNER_TYPES.has(s.section_type),
   );
   const hasBlogSection = enabledSections.some(
-    (s) => s.section_type === SECTION_BLOG
+    (s) => s.section_type === SECTION_BLOG,
   );
 
   const [
@@ -158,12 +180,12 @@ async function DeferredHomeSections({
     website.account_id
       ? getBrandClaims(website.account_id)
       : Promise.resolve(null),
-    website.id
-      ? getFeaturedDestinations(website.id, 4)
-      : Promise.resolve([]),
+    website.id ? getFeaturedDestinations(website.id, 4) : Promise.resolve([]),
   ]);
 
-  const curatedDynamicDestinations = dynamicDestinations.filter((d) => d.total > 1);
+  const curatedDynamicDestinations = dynamicDestinations.filter(
+    (d) => d.total > 1,
+  );
   const sectionDynamicDestinations = (
     curatedDynamicDestinations.length > 0
       ? curatedDynamicDestinations
@@ -176,7 +198,8 @@ async function DeferredHomeSections({
   const activityItems = toActivityItems(activitiesCatalog.items);
   const hotelItems = toHotelItems(hotelsCatalog.items);
 
-  let googleReviews: Parameters<typeof hydrateSections>[0]['googleReviews'] = null;
+  let googleReviews: Parameters<typeof hydrateSections>[0]["googleReviews"] =
+    null;
   if (googleReviewsCache && googleReviewsCache.reviews.length > 0) {
     googleReviews = {
       ...googleReviewsCache,
@@ -207,10 +230,13 @@ async function DeferredHomeSections({
     .filter((section) => !criticalSectionIds.has(section.id))
     .filter((section) => {
       if (section.section_type === SECTION_PACKAGES) {
-        return packageItems.length > 0 || contentHasArray(section, 'packages');
+        return packageItems.length > 0 || contentHasArray(section, "packages");
       }
-      if (section.section_type === 'destinations') {
-        return sectionDynamicDestinations.length > 0 || contentHasArray(section, 'destinations');
+      if (section.section_type === "destinations") {
+        return (
+          sectionDynamicDestinations.length > 0 ||
+          contentHasArray(section, "destinations")
+        );
       }
       return true;
     });
@@ -222,7 +248,9 @@ async function DeferredHomeSections({
           key={section.id}
           section={section}
           website={websiteForRender}
-          dbPlanners={PLANNER_TYPES.has(section.section_type) ? dbPlanners : undefined}
+          dbPlanners={
+            PLANNER_TYPES.has(section.section_type) ? dbPlanners : undefined
+          }
         />
       ))}
     </>
@@ -233,7 +261,7 @@ export default async function SitePage({ params }: SitePageProps) {
   const { subdomain } = await params;
   const website = await getWebsiteBySubdomain(subdomain);
 
-  if (!website || website.status !== 'published') {
+  if (!website || website.status !== "published") {
     notFound();
   }
 
@@ -242,9 +270,8 @@ export default async function SitePage({ params }: SitePageProps) {
     : `https://${subdomain}.bukeer.com`;
 
   const templateSet = resolveTemplateSet(website);
-  const localeContext = await resolvePublicMetadataLocale(website, '/');
-  const headerList = await headers();
-  const isCustomDomain = Boolean(headerList.get('x-custom-domain'));
+  const localeContext = await resolvePublicMetadataLocale(website, "/");
+  const isCustomDomain = inferIsCustomDomainWebsite(website);
   const websiteForRender = {
     ...website,
     resolvedLocale: localeContext.resolvedLocale,
@@ -263,7 +290,8 @@ export default async function SitePage({ params }: SitePageProps) {
     locale: localeContext.resolvedLocale,
     defaultLocale: localeContext.defaultLocale,
   });
-  const { criticalSections, criticalSectionIds } = buildHomeSectionPlan(enabledSections);
+  const { criticalSections, criticalSectionIds } =
+    buildHomeSectionPlan(enabledSections);
 
   return (
     <>

--- a/app/site/[subdomain]/paquetes/[slug]/page.tsx
+++ b/app/site/[subdomain]/paquetes/[slug]/page.tsx
@@ -1,11 +1,10 @@
 import { Metadata } from "next";
-import { headers } from "next/headers";
 import { notFound, permanentRedirect, redirect } from "next/navigation";
 
 import { ProductLandingPage } from "@/components/pages/product-landing-page";
 import { TemplateSlot } from "@/components/site/themes/editorial-v1/template-slot";
 import type { EditorialPackageDetailPayload } from "@/components/site/themes/editorial-v1/pages/package-detail";
-import { getBasePath } from "@/lib/utils/base-path";
+import { getBasePath, inferIsCustomDomainWebsite } from "@/lib/utils/base-path";
 import {
   getCategoryProducts,
   getLocalizedProductOverlay,
@@ -330,8 +329,7 @@ export default async function PackageSlugPage({ params }: PackagePageProps) {
           .filter(Boolean)
           .join(", "),
     ) || null;
-  const headerList = await headers();
-  const isCustomDomain = Boolean(headerList.get("x-custom-domain"));
+  const isCustomDomain = inferIsCustomDomainWebsite(website);
   const websiteForRender = {
     ...website,
     resolvedLocale: localeContext.resolvedLocale,

--- a/app/site/[subdomain]/paquetes/page.tsx
+++ b/app/site/[subdomain]/paquetes/page.tsx
@@ -7,7 +7,6 @@
  */
 
 import type { Metadata } from "next";
-import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 
 import { PackagesListingPage } from "@/components/pages/packages-listing-page";
@@ -25,6 +24,7 @@ import {
   normalizeLocale,
 } from "@/lib/seo/locale-routing";
 import { resolveOgImage } from "@/lib/seo/og-helpers";
+import { inferIsCustomDomainWebsite } from "@/lib/utils/base-path";
 
 interface PaquetesPageProps {
   params: Promise<{ subdomain: string }>;
@@ -132,7 +132,10 @@ export async function generateMetadata({
   const ogImage = resolveOgImage(website);
   const isEnglish = localeContext.resolvedLanguage === "en";
   const title = isEnglish ? "Travel Packages" : "Paquetes de Viaje";
-  const description = buildPackagesDescription(siteName, localeContext.resolvedLocale);
+  const description = buildPackagesDescription(
+    siteName,
+    localeContext.resolvedLocale,
+  );
 
   return {
     title,
@@ -171,8 +174,7 @@ export default async function PaquetesPage({ params }: PaquetesPageProps) {
     notFound();
   }
 
-  const headerList = await headers();
-  const isCustomDomain = Boolean(headerList.get("x-custom-domain"));
+  const isCustomDomain = inferIsCustomDomainWebsite(website);
   const localeContext = await resolvePublicMetadataLocale(website, PAGE_PATH);
   const { items: packageProducts } = await getCategoryProducts(
     subdomain,

--- a/lib/supabase/get-website.ts
+++ b/lib/supabase/get-website.ts
@@ -264,7 +264,7 @@ export async function getWebsiteBySubdomain(
     const cacheKey = subdomain.toLowerCase();
     const cached = websiteBySubdomainCache.get(cacheKey);
     if (cached && cached.expiresAt > Date.now()) {
-      return applyThemeDesignerV1Resolution(cached.value);
+      return cached.value;
     }
 
     const { data, error } = await supabase.rpc("get_website_by_subdomain", {
@@ -316,12 +316,15 @@ export async function getWebsiteBySubdomain(
         packages: featuredProducts.packages || [],
       },
     };
+    const resolvedWebsite =
+      await applyThemeDesignerV1Resolution(hydratedWebsite);
+
     websiteBySubdomainCache.set(cacheKey, {
-      value: hydratedWebsite,
+      value: resolvedWebsite,
       expiresAt: Date.now() + WEBSITE_CACHE_TTL_MS,
     });
 
-    return applyThemeDesignerV1Resolution(hydratedWebsite);
+    return resolvedWebsite;
   } catch (e) {
     console.error("[getWebsiteBySubdomain] Exception:", e);
     return null;
@@ -373,13 +376,18 @@ export async function getBlogPosts(
       let totalAcrossLocales = 0;
 
       for (const localeCandidate of uniqueLocales) {
-        const { data, error } = await supabase.rpc("get_website_blog_posts", {
-          p_website_id: websiteId,
-          p_limit: perLocaleWindow,
-          p_offset: 0,
-          p_category_slug: options.categorySlug || null,
-          p_locale: localeCandidate || null,
-        });
+        const { data, error } = await supabase.rpc(
+          "get_website_blog_post_summaries",
+          {
+            p_website_id: websiteId,
+            p_limit: perLocaleWindow,
+            p_offset: 0,
+            p_category_slug: options.categorySlug || null,
+            p_tag_slug: null,
+            p_locale: localeCandidate || null,
+            p_search: null,
+          },
+        );
 
         if (error) continue;
         atLeastOneSuccess = true;
@@ -415,13 +423,18 @@ export async function getBlogPosts(
       }
     }
 
-    const { data, error } = await supabase.rpc("get_website_blog_posts", {
-      p_website_id: websiteId,
-      p_limit: limit,
-      p_offset: offset,
-      p_category_slug: options.categorySlug || null,
-      p_locale: locale || null,
-    });
+    const { data, error } = await supabase.rpc(
+      "get_website_blog_post_summaries",
+      {
+        p_website_id: websiteId,
+        p_limit: limit,
+        p_offset: offset,
+        p_category_slug: options.categorySlug || null,
+        p_tag_slug: null,
+        p_locale: locale || null,
+        p_search: null,
+      },
+    );
 
     if (error) {
       console.error("[getBlogPosts] Error:", error);
@@ -543,30 +556,27 @@ export async function getBlogPostBySlug(
       localeCandidates.push("");
     }
 
-    const uniqueLocales = [...new Set(localeCandidates)];
-    const perLocaleLimit = 1200;
-    const mergedById = new Map<string, BlogPost>();
+    for (const localeCandidate of [...new Set(localeCandidates)]) {
+      let fallbackQuery = supabase
+        .from("website_blog_posts")
+        .select("*")
+        .eq("website_id", websiteId)
+        .eq("slug", normalizedSlug)
+        .eq("status", "published")
+        .is("deleted_at", null);
 
-    for (const localeCandidate of uniqueLocales) {
-      const { data: rpcData, error: rpcError } = await supabase.rpc(
-        "get_website_blog_posts",
-        {
-          p_website_id: websiteId,
-          p_limit: perLocaleLimit,
-          p_offset: 0,
-          p_category_slug: null,
-          p_locale: localeCandidate || null,
-        },
-      );
-      if (rpcError) continue;
-      const posts = (rpcData?.posts || []) as BlogPost[];
-      for (const post of posts) {
-        if (post?.id && !mergedById.has(post.id)) mergedById.set(post.id, post);
+      if (localeCandidate)
+        fallbackQuery = fallbackQuery.eq("locale", localeCandidate);
+
+      const { data: fallbackPost, error: fallbackError } = await fallbackQuery
+        .order("published_at", { ascending: false, nullsFirst: false })
+        .order("updated_at", { ascending: false, nullsFirst: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (!fallbackError && fallbackPost) {
+        return fallbackPost as BlogPost;
       }
-    }
-
-    for (const post of mergedById.values()) {
-      if (post.slug === normalizedSlug) return post;
     }
 
     return null;

--- a/lib/utils/base-path.ts
+++ b/lib/utils/base-path.ts
@@ -18,20 +18,29 @@ export function getBasePath(
   defaultLocale?: string,
 ): string {
   // Base path from subdomain/custom domain context
-  const base = isCustomDomain ? '' : `/site/${subdomain}`;
+  const base = isCustomDomain ? "" : `/site/${subdomain}`;
 
   // No locale → return base as-is (backwards compatible)
   if (!locale) return base;
 
   // Normalize: check if this is a non-default locale
-  const def = (defaultLocale || 'es-CO').toLowerCase();
+  const def = (defaultLocale || "es-CO").toLowerCase();
   const loc = locale.toLowerCase();
-  const defLang = def.split('-')[0];
-  const locLang = loc.split('-')[0];
+  const defLang = def.split("-")[0];
+  const locLang = loc.split("-")[0];
 
   // Default locale or same language → no prefix needed
   if (loc === def || locLang === defLang) return base;
 
   // Non-default locale → prepend language prefix
   return `${base}/${locLang}`;
+}
+
+export function inferIsCustomDomainWebsite(website: {
+  custom_domain?: string | null;
+}): boolean {
+  return (
+    typeof website.custom_domain === "string" &&
+    website.custom_domain.trim().length > 0
+  );
 }


### PR DESCRIPTION
## Summary
- removes request-header reads from public ISR site routes to fix production DYNAMIC_SERVER_USAGE 500s
- caches resolved website/theme data and moves blog listings to summary RPCs to reduce Supabase pressure
- makes Chatwoot webhook event capture idempotent on duplicate provider/event IDs

## Verification
- npm run typecheck
- npm run build
- production local smoke with Host: colombiatours.travel: home/blog/paquetes 200
- deployed Cloudflare Worker bukeer-web-public version 371450c2-c02b-4792-b3f2-1c169a973a65
- production smoke: colombiatours.travel home/blog/paquetes 200