### PR TITLE
perf: tighten ColombiaTours public cache and homepage fetches

### DIFF
--- a/__tests__/lib/site/home-first-load-budget-contract.test.ts
+++ b/__tests__/lib/site/home-first-load-budget-contract.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+function readSource(relativePath: string): string {
+  return readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+describe("home first-load data budget contract", () => {
+  it("does not fetch below-fold catalog/blog data unless the section is enabled", () => {
+    const source = readSource("app/site/[subdomain]/page.tsx");
+    const deferredSource = source.match(
+      /async function DeferredHomeSections[\s\S]*?\n}\n\nexport default async function SitePage/,
+    )?.[0];
+
+    expect(deferredSource).toBeDefined();
+    expect(deferredSource).toContain("hasDestinationsSection");
+    expect(deferredSource).toContain("hasPackagesSection");
+    expect(deferredSource).toContain("hasActivitiesSection");
+    expect(deferredSource).toContain("hasHotelsSection");
+    expect(deferredSource).toContain("hasBlogSection");
+    expect(deferredSource).toMatch(
+      /hasPackagesSection[\s\S]*getCategoryProducts\(subdomain, SECTION_PACKAGES/,
+    );
+    expect(deferredSource).toMatch(
+      /hasBlogSection[\s\S]*getBlogPosts\(website\.id/,
+    );
+  });
+});

--- a/__tests__/supabase/public-cache-invalidation-contract.test.ts
+++ b/__tests__/supabase/public-cache-invalidation-contract.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+function readSource(relativePath: string): string {
+  return readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+describe("public cache invalidation contract", () => {
+  it("clears navigation cache together with product/category caches", () => {
+    const source = readSource("lib/supabase/get-pages.ts");
+    const invalidatorSource = source.match(
+      /export function invalidatePublicDataCache[\s\S]*?\n}\n\nfunction logProductV2ParseWarning/,
+    )?.[0];
+
+    expect(invalidatorSource).toBeDefined();
+    expect(invalidatorSource).toContain("navigationCache.delete");
+    expect(invalidatorSource).toContain("navigationInflight.delete");
+  });
+
+  it("revalidation clears website, theme and blog caches for the published site", () => {
+    const source = readSource("app/api/revalidate/route.ts");
+
+    expect(source).toContain("invalidateWebsiteDataCache");
+    expect(source).toContain("websiteId: website.id");
+  });
+
+  it("public data loaders de-duplicate in-flight Supabase reads", () => {
+    const websiteSource = readSource("lib/supabase/get-website.ts");
+    const pagesSource = readSource("lib/supabase/get-pages.ts");
+
+    expect(websiteSource).toContain("websiteBySubdomainInflight");
+    expect(websiteSource).toContain("blogPostsInflight");
+    expect(pagesSource).toContain("navigationInflight");
+  });
+});

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,30 +1,42 @@
-import { revalidatePath } from 'next/cache';
-import { NextRequest } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
-import { z } from 'zod';
-import { createLogger } from '@/lib/logger';
-import { apiSuccess, apiError, apiUnauthorized, apiValidationError, apiInternalError } from '@/lib/api';
-import { invalidatePublicDataCache } from '@/lib/supabase/get-pages';
+import { revalidatePath } from "next/cache";
+import { NextRequest } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { z } from "zod";
+import { createLogger } from "@/lib/logger";
+import {
+  apiSuccess,
+  apiError,
+  apiUnauthorized,
+  apiValidationError,
+  apiInternalError,
+} from "@/lib/api";
+import { invalidatePublicDataCache } from "@/lib/supabase/get-pages";
+import { invalidateWebsiteDataCache } from "@/lib/supabase/get-website";
 
-const log = createLogger('revalidate');
+const log = createLogger("revalidate");
 
 // Maps a content type to the public URL segment used in site routes.
 const TYPE_TO_SEGMENT: Record<string, string> = {
-  package: 'paquetes',
-  activity: 'actividades',
-  hotel: 'hoteles',
-  transfer: 'traslados',
-  destination: 'destinos',
+  package: "paquetes",
+  activity: "actividades",
+  hotel: "hoteles",
+  transfer: "traslados",
+  destination: "destinos",
 };
 
 const RevalidateBodySchema = z.object({
-  subdomain: z.string().min(1).transform((s) => s.toLowerCase().trim()),
+  subdomain: z
+    .string()
+    .min(1)
+    .transform((s) => s.toLowerCase().trim()),
   path: z.string().optional(),
   // Optional structured payload for content-type-aware revalidation.
   // Callers (e.g. Supabase Edge Functions / DB triggers) can pass
   // { type: 'package', slug: 'machu-picchu-7d' } to invalidate the
   // specific product page without computing the route segment themselves.
-  type: z.enum(['package', 'activity', 'hotel', 'transfer', 'destination']).optional(),
+  type: z
+    .enum(["package", "activity", "hotel", "transfer", "destination"])
+    .optional(),
   slug: z.string().min(1).optional(),
   secret: z.string().optional(), // Legacy body-based auth
 });
@@ -51,16 +63,16 @@ export async function POST(request: NextRequest) {
   try {
     // 1. Extract IP for logging
     const ip =
-      request.headers.get('x-forwarded-for')?.split(',')[0] ||
-      request.headers.get('x-real-ip') ||
-      'anonymous';
+      request.headers.get("x-forwarded-for")?.split(",")[0] ||
+      request.headers.get("x-real-ip") ||
+      "anonymous";
 
     // 2. Authentication via Bearer token
-    const authHeader = request.headers.get('authorization');
+    const authHeader = request.headers.get("authorization");
     const expectedSecret = process.env.REVALIDATE_SECRET;
 
     if (!expectedSecret) {
-      log.error('REVALIDATE_SECRET not configured');
+      log.error("REVALIDATE_SECRET not configured");
       // Keep auth contract deterministic in non-configured environments.
       return apiUnauthorized();
     }
@@ -78,7 +90,7 @@ export async function POST(request: NextRequest) {
     // Check auth: Bearer token or legacy body secret
     if (authHeader !== `Bearer ${expectedSecret}`) {
       if (parsed.data.secret !== expectedSecret) {
-        log.error('Invalid or missing authorization');
+        log.error("Invalid or missing authorization");
         return apiUnauthorized();
       }
     }
@@ -89,37 +101,38 @@ export async function POST(request: NextRequest) {
     const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
     if (!supabaseUrl || !supabaseServiceKey) {
-      log.error('Missing Supabase configuration');
-      return apiInternalError('Server configuration error');
+      log.error("Missing Supabase configuration");
+      return apiInternalError("Server configuration error");
     }
 
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
     const { data: website, error: websiteError } = await supabase
-      .from('websites')
-      .select('id, subdomain, status')
-      .eq('subdomain', subdomain)
-      .is('deleted_at', null)
+      .from("websites")
+      .select("id, subdomain, status")
+      .eq("subdomain", subdomain)
+      .is("deleted_at", null)
       .maybeSingle();
 
     if (websiteError) {
-      log.error('Database error', { message: websiteError.message });
-      return apiInternalError('Database error');
+      log.error("Database error", { message: websiteError.message });
+      return apiInternalError("Database error");
     }
 
     if (!website) {
       log.warn(`Invalid subdomain: ${subdomain}`);
-      return apiError('VALIDATION_ERROR', 'Invalid subdomain');
+      return apiError("VALIDATION_ERROR", "Invalid subdomain");
     }
 
     // 5. Perform revalidation
     invalidatePublicDataCache(subdomain);
+    invalidateWebsiteDataCache({ subdomain, websiteId: website.id });
     const sitePath = `/site/${subdomain}`;
     const revalidatedPaths: string[] = [sitePath];
     revalidatePath(sitePath);
 
     // Also revalidate specific path if provided
-    if (path && typeof path === 'string') {
+    if (path && typeof path === "string") {
       revalidatePath(path);
       revalidatedPaths.push(path);
     }
@@ -146,17 +159,17 @@ export async function POST(request: NextRequest) {
 
     // 6. Log revalidation (fire and forget)
     supabase
-      .from('revalidation_logs')
+      .from("revalidation_logs")
       .insert({
         website_id: website.id,
         subdomain,
         path: path || sitePath,
         ip,
-        user_agent: request.headers.get('user-agent') || null,
+        user_agent: request.headers.get("user-agent") || null,
       })
       .then(({ error }) => {
         if (error) {
-          log.warn('Failed to write audit log', { message: error.message });
+          log.warn("Failed to write audit log", { message: error.message });
         }
       });
 
@@ -168,7 +181,7 @@ export async function POST(request: NextRequest) {
       duration_ms: duration,
     });
   } catch (error) {
-    log.error('Unexpected error', { message: String(error) });
+    log.error("Unexpected error", { message: String(error) });
     return apiInternalError();
   }
 }
@@ -176,19 +189,19 @@ export async function POST(request: NextRequest) {
 // Health check
 export async function GET() {
   return apiSuccess({
-    status: 'ok',
-    endpoint: '/api/revalidate',
-    method: 'POST',
-    description: 'ISR revalidation endpoint for website content updates',
+    status: "ok",
+    endpoint: "/api/revalidate",
+    method: "POST",
+    description: "ISR revalidation endpoint for website content updates",
     required_headers: {
-      Authorization: 'Bearer <REVALIDATE_SECRET>',
-      'Content-Type': 'application/json',
+      Authorization: "Bearer <REVALIDATE_SECRET>",
+      "Content-Type": "application/json",
     },
     required_body: {
-      subdomain: 'string (required)',
-      path: 'string (optional)',
-      type: 'package|activity|hotel|transfer|destination (optional)',
-      slug: 'string (optional, paired with type to target a specific product page)',
+      subdomain: "string (required)",
+      path: "string (optional)",
+      type: "package|activity|hotel|transfer|destination (optional)",
+      slug: "string (optional, paired with type to target a specific product page)",
     },
   });
 }

--- a/app/site/[subdomain]/page.tsx
+++ b/app/site/[subdomain]/page.tsx
@@ -152,6 +152,18 @@ async function DeferredHomeSections({
   const hasBlogSection = enabledSections.some(
     (s) => s.section_type === SECTION_BLOG,
   );
+  const hasDestinationsSection = enabledSections.some(
+    (s) => s.section_type === "destinations",
+  );
+  const hasPackagesSection = enabledSections.some(
+    (s) => s.section_type === SECTION_PACKAGES,
+  );
+  const hasActivitiesSection = enabledSections.some(
+    (s) => s.section_type === SECTION_ACTIVITIES,
+  );
+  const hasHotelsSection = enabledSections.some(
+    (s) => s.section_type === SECTION_HOTELS,
+  );
 
   const [
     googleReviewsCache,
@@ -167,10 +179,16 @@ async function DeferredHomeSections({
     googleReviewsEnabled && website.account_id
       ? getCachedGoogleReviews(website.account_id)
       : Promise.resolve(null),
-    getDestinations(subdomain),
-    getCategoryProducts(subdomain, SECTION_PACKAGES, { limit: 8, locale }),
-    getCategoryProducts(subdomain, SECTION_ACTIVITIES, { limit: 8, locale }),
-    getCategoryProducts(subdomain, SECTION_HOTELS, { limit: 8, locale }),
+    hasDestinationsSection ? getDestinations(subdomain) : Promise.resolve([]),
+    hasPackagesSection
+      ? getCategoryProducts(subdomain, SECTION_PACKAGES, { limit: 8, locale })
+      : Promise.resolve({ items: [], total: 0 }),
+    hasActivitiesSection
+      ? getCategoryProducts(subdomain, SECTION_ACTIVITIES, { limit: 8, locale })
+      : Promise.resolve({ items: [], total: 0 }),
+    hasHotelsSection
+      ? getCategoryProducts(subdomain, SECTION_HOTELS, { limit: 8, locale })
+      : Promise.resolve({ items: [], total: 0 }),
     hasPlannersSection && website.account_id
       ? getPlanners(website.account_id, { locale })
       : Promise.resolve<PlannerData[]>([]),

--- a/lib/supabase/get-pages.ts
+++ b/lib/supabase/get-pages.ts
@@ -60,6 +60,7 @@ const navigationCache = new Map<
   string,
   { value: NavigationItem[]; expiresAt: number }
 >();
+const navigationInflight = new Map<string, Promise<NavigationItem[]>>();
 const UUID_PATTERN =
   /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
@@ -73,6 +74,7 @@ function isUuid(value: unknown): value is string {
  */
 export function invalidatePublicDataCache(subdomain: string): void {
   const prefix = `${subdomain.toLowerCase()}::`;
+  const navigationKey = subdomain.toLowerCase();
 
   for (const key of productPageCache.keys()) {
     if (key.startsWith(prefix)) {
@@ -85,6 +87,9 @@ export function invalidatePublicDataCache(subdomain: string): void {
       categoryProductsCache.delete(key);
     }
   }
+
+  navigationCache.delete(navigationKey);
+  navigationInflight.delete(navigationKey);
 }
 
 function logProductV2ParseWarning(
@@ -1743,21 +1748,33 @@ export async function getWebsiteNavigation(
     const cached = navigationCache.get(cacheKey);
     if (cached && cached.expiresAt > Date.now()) return cached.value;
 
-    const { data, error } = await supabase.rpc("get_website_navigation", {
-      p_subdomain: subdomain,
-    });
+    const inflight = navigationInflight.get(cacheKey);
+    if (inflight) return inflight;
 
-    if (error) {
-      console.error("[getWebsiteNavigation] Error:", error);
-      return [];
+    const load = (async () => {
+      const { data, error } = await supabase.rpc("get_website_navigation", {
+        p_subdomain: subdomain,
+      });
+
+      if (error) {
+        console.error("[getWebsiteNavigation] Error:", error);
+        return [];
+      }
+
+      const items = (data as NavigationItem[]) || [];
+      navigationCache.set(cacheKey, {
+        value: items,
+        expiresAt: Date.now() + NAVIGATION_CACHE_TTL_MS,
+      });
+      return items;
+    })();
+
+    navigationInflight.set(cacheKey, load);
+    try {
+      return await load;
+    } finally {
+      navigationInflight.delete(cacheKey);
     }
-
-    const items = (data as NavigationItem[]) || [];
-    navigationCache.set(cacheKey, {
-      value: items,
-      expiresAt: Date.now() + NAVIGATION_CACHE_TTL_MS,
-    });
-    return items;
   } catch (e) {
     console.error("[getWebsiteNavigation] Exception:", e);
     return [];

--- a/lib/supabase/get-website.ts
+++ b/lib/supabase/get-website.ts
@@ -54,6 +54,14 @@ const blogPostsCache = new Map<
   string,
   { value: { posts: BlogPost[]; total: number }; expiresAt: number }
 >();
+const websiteBySubdomainInflight = new Map<
+  string,
+  Promise<WebsiteData | null>
+>();
+const blogPostsInflight = new Map<
+  string,
+  Promise<{ posts: BlogPost[]; total: number }>
+>();
 
 type WebsiteWithEffectiveTheme = WebsiteData & {
   effective_theme?: ThemeV3;
@@ -62,6 +70,37 @@ type WebsiteWithEffectiveTheme = WebsiteData & {
     | "snapshot_fallback"
     | "website_theme_default";
 };
+
+export function invalidateWebsiteDataCache(input: {
+  subdomain?: string | null;
+  websiteId?: string | null;
+}): void {
+  const subdomain = input.subdomain?.trim().toLowerCase();
+  const websiteId = input.websiteId?.trim();
+
+  if (subdomain) {
+    websiteBySubdomainCache.delete(subdomain);
+    websiteBySubdomainInflight.delete(subdomain);
+  }
+
+  for (const key of themeResolutionCache.keys()) {
+    if (!websiteId || key.startsWith(`${websiteId}:`)) {
+      themeResolutionCache.delete(key);
+    }
+  }
+
+  for (const key of blogPostsCache.keys()) {
+    if (!websiteId || key.includes(`"websiteId":"${websiteId}"`)) {
+      blogPostsCache.delete(key);
+    }
+  }
+
+  for (const key of blogPostsInflight.keys()) {
+    if (!websiteId || key.includes(`"websiteId":"${websiteId}"`)) {
+      blogPostsInflight.delete(key);
+    }
+  }
+}
 
 interface AccountCurrencyColumns {
   primary_currency: string | null;
@@ -290,64 +329,76 @@ export async function getWebsiteBySubdomain(
       return cached.value;
     }
 
-    const { data, error } = await supabase.rpc("get_website_by_subdomain", {
-      p_subdomain: subdomain,
-    });
+    const inflight = websiteBySubdomainInflight.get(cacheKey);
+    if (inflight) return inflight;
 
-    if (error) {
-      console.error("[getWebsiteBySubdomain] Error:", error);
-      return null;
-    }
+    const load = (async () => {
+      const { data, error } = await supabase.rpc("get_website_by_subdomain", {
+        p_subdomain: subdomain,
+      });
 
-    if (!data) return null;
-
-    let website = await hydrateWebsiteLocaleColumns(
-      data as WebsiteData,
-      subdomain,
-    );
-    website = await hydrateWebsiteAnalyticsColumns(website, subdomain);
-    const featuredProducts = website.featured_products || {
-      destinations: [],
-      hotels: [],
-      activities: [],
-      transfers: [],
-      packages: [],
-    };
-
-    if (website.account_id && website.content.account) {
-      const accountCurrencyColumns = await getAccountCurrencyColumns(
-        website.account_id,
-      );
-      if (accountCurrencyColumns) {
-        website.content = {
-          ...website.content,
-          account: {
-            ...website.content.account,
-            ...accountCurrencyColumns,
-          },
-        };
+      if (error) {
+        console.error("[getWebsiteBySubdomain] Error:", error);
+        return null;
       }
+
+      if (!data) return null;
+
+      let website = await hydrateWebsiteLocaleColumns(
+        data as WebsiteData,
+        subdomain,
+      );
+      website = await hydrateWebsiteAnalyticsColumns(website, subdomain);
+      const featuredProducts = website.featured_products || {
+        destinations: [],
+        hotels: [],
+        activities: [],
+        transfers: [],
+        packages: [],
+      };
+
+      if (website.account_id && website.content.account) {
+        const accountCurrencyColumns = await getAccountCurrencyColumns(
+          website.account_id,
+        );
+        if (accountCurrencyColumns) {
+          website.content = {
+            ...website.content,
+            account: {
+              ...website.content.account,
+              ...accountCurrencyColumns,
+            },
+          };
+        }
+      }
+
+      const hydratedWebsite = {
+        ...website,
+        featured_products: {
+          destinations: featuredProducts.destinations || [],
+          hotels: featuredProducts.hotels || [],
+          activities: featuredProducts.activities || [],
+          transfers: featuredProducts.transfers || [],
+          packages: featuredProducts.packages || [],
+        },
+      };
+      const resolvedWebsite =
+        await applyThemeDesignerV1Resolution(hydratedWebsite);
+
+      websiteBySubdomainCache.set(cacheKey, {
+        value: resolvedWebsite,
+        expiresAt: Date.now() + WEBSITE_CACHE_TTL_MS,
+      });
+
+      return resolvedWebsite;
+    })();
+
+    websiteBySubdomainInflight.set(cacheKey, load);
+    try {
+      return await load;
+    } finally {
+      websiteBySubdomainInflight.delete(cacheKey);
     }
-
-    const hydratedWebsite = {
-      ...website,
-      featured_products: {
-        destinations: featuredProducts.destinations || [],
-        hotels: featuredProducts.hotels || [],
-        activities: featuredProducts.activities || [],
-        transfers: featuredProducts.transfers || [],
-        packages: featuredProducts.packages || [],
-      },
-    };
-    const resolvedWebsite =
-      await applyThemeDesignerV1Resolution(hydratedWebsite);
-
-    websiteBySubdomainCache.set(cacheKey, {
-      value: resolvedWebsite,
-      expiresAt: Date.now() + WEBSITE_CACHE_TTL_MS,
-    });
-
-    return resolvedWebsite;
   } catch (e) {
     console.error("[getWebsiteBySubdomain] Exception:", e);
     return null;
@@ -380,118 +431,134 @@ export async function getBlogPosts(
     });
     const cached = blogPostsCache.get(cacheKey);
     if (cached && cached.expiresAt > Date.now()) return cached.value;
-    const localeCandidates: string[] = [];
+    const inflight = blogPostsInflight.get(cacheKey);
+    if (inflight) return inflight;
 
-    if (locale) {
-      localeCandidates.push(locale);
-      const lang = locale.split("-")[0]?.toLowerCase();
-      if (lang && lang !== locale) localeCandidates.push(lang);
+    const load = (async () => {
+      const localeCandidates: string[] = [];
 
-      // Legacy blog rows may still store ISO-639 locales (`es`, `en`, etc.).
-      if (locale === "es") localeCandidates.push("es-CO");
-      if (locale === "en") localeCandidates.push("en-US");
-      if (locale === "pt") localeCandidates.push("pt-BR");
-      if (locale === "fr") localeCandidates.push("fr-FR");
-      if (locale === "de") localeCandidates.push("de-DE");
-      if (locale === "es-CO") localeCandidates.push("es");
-      if (locale === "en-US") localeCandidates.push("en");
-      if (locale === "pt-BR") localeCandidates.push("pt");
-      if (locale === "fr-FR") localeCandidates.push("fr");
-      if (locale === "de-DE") localeCandidates.push("de");
-    } else {
-      localeCandidates.push("");
-    }
+      if (locale) {
+        localeCandidates.push(locale);
+        const lang = locale.split("-")[0]?.toLowerCase();
+        if (lang && lang !== locale) localeCandidates.push(lang);
 
-    const uniqueLocales = [...new Set(localeCandidates.filter(Boolean))];
-    // Locale-aware listing: include legacy + canonical locale variants of the
-    // same language (e.g., `es` + `es-CO`) using the public RPC path to avoid
-    // direct-table RLS differences in runtime.
-    if (uniqueLocales.length > 1) {
-      const perLocaleWindow = Math.max(limit + offset, limit);
-      const mergedById = new Map<string, BlogPost>();
-      let atLeastOneSuccess = false;
-      let totalAcrossLocales = 0;
+        // Legacy blog rows may still store ISO-639 locales (`es`, `en`, etc.).
+        if (locale === "es") localeCandidates.push("es-CO");
+        if (locale === "en") localeCandidates.push("en-US");
+        if (locale === "pt") localeCandidates.push("pt-BR");
+        if (locale === "fr") localeCandidates.push("fr-FR");
+        if (locale === "de") localeCandidates.push("de-DE");
+        if (locale === "es-CO") localeCandidates.push("es");
+        if (locale === "en-US") localeCandidates.push("en");
+        if (locale === "pt-BR") localeCandidates.push("pt");
+        if (locale === "fr-FR") localeCandidates.push("fr");
+        if (locale === "de-DE") localeCandidates.push("de");
+      } else {
+        localeCandidates.push("");
+      }
 
-      for (const localeCandidate of uniqueLocales) {
-        const { data, error } = await supabase.rpc(
-          "get_website_blog_post_summaries",
-          {
-            p_website_id: websiteId,
-            p_limit: perLocaleWindow,
-            p_offset: 0,
-            p_category_slug: options.categorySlug || null,
-            p_tag_slug: null,
-            p_locale: localeCandidate || null,
-            p_search: null,
-          },
-        );
+      const uniqueLocales = [...new Set(localeCandidates.filter(Boolean))];
+      // Locale-aware listing: include legacy + canonical locale variants of the
+      // same language (e.g., `es` + `es-CO`) using the public RPC path to avoid
+      // direct-table RLS differences in runtime.
+      if (uniqueLocales.length > 1) {
+        const perLocaleWindow = Math.max(limit + offset, limit);
+        const mergedById = new Map<string, BlogPost>();
+        let atLeastOneSuccess = false;
+        let totalAcrossLocales = 0;
 
-        if (error) continue;
-        atLeastOneSuccess = true;
-        const localePosts = (data?.posts || []) as BlogPost[];
-        totalAcrossLocales += Number(data?.total || 0);
-        for (const post of localePosts) {
-          if (!post?.id) continue;
-          if (!mergedById.has(post.id)) mergedById.set(post.id, post);
+        for (const localeCandidate of uniqueLocales) {
+          const { data, error } = await supabase.rpc(
+            "get_website_blog_post_summaries",
+            {
+              p_website_id: websiteId,
+              p_limit: perLocaleWindow,
+              p_offset: 0,
+              p_category_slug: options.categorySlug || null,
+              p_tag_slug: null,
+              p_locale: localeCandidate || null,
+              p_search: null,
+            },
+          );
+
+          if (error) continue;
+          atLeastOneSuccess = true;
+          const localePosts = (data?.posts || []) as BlogPost[];
+          totalAcrossLocales += Number(data?.total || 0);
+          for (const post of localePosts) {
+            if (!post?.id) continue;
+            if (!mergedById.has(post.id)) mergedById.set(post.id, post);
+          }
+        }
+
+        if (atLeastOneSuccess) {
+          const merged = Array.from(mergedById.values()).sort((a, b) => {
+            const publishedA = a.published_at
+              ? new Date(a.published_at).getTime()
+              : 0;
+            const publishedB = b.published_at
+              ? new Date(b.published_at).getTime()
+              : 0;
+            if (publishedA !== publishedB) return publishedB - publishedA;
+
+            const updatedA = a.updated_at
+              ? new Date(a.updated_at).getTime()
+              : 0;
+            const updatedB = b.updated_at
+              ? new Date(b.updated_at).getTime()
+              : 0;
+            return updatedB - updatedA;
+          });
+
+          const paginated = merged.slice(offset, offset + limit);
+          const total = Math.max(totalAcrossLocales, mergedById.size);
+          const result = {
+            posts: paginated,
+            total,
+          };
+          blogPostsCache.set(cacheKey, {
+            value: result,
+            expiresAt: Date.now() + BLOG_LIST_CACHE_TTL_MS,
+          });
+          return result;
         }
       }
 
-      if (atLeastOneSuccess) {
-        const merged = Array.from(mergedById.values()).sort((a, b) => {
-          const publishedA = a.published_at
-            ? new Date(a.published_at).getTime()
-            : 0;
-          const publishedB = b.published_at
-            ? new Date(b.published_at).getTime()
-            : 0;
-          if (publishedA !== publishedB) return publishedB - publishedA;
+      const { data, error } = await supabase.rpc(
+        "get_website_blog_post_summaries",
+        {
+          p_website_id: websiteId,
+          p_limit: limit,
+          p_offset: offset,
+          p_category_slug: options.categorySlug || null,
+          p_tag_slug: null,
+          p_locale: locale || null,
+          p_search: null,
+        },
+      );
 
-          const updatedA = a.updated_at ? new Date(a.updated_at).getTime() : 0;
-          const updatedB = b.updated_at ? new Date(b.updated_at).getTime() : 0;
-          return updatedB - updatedA;
-        });
-
-        const paginated = merged.slice(offset, offset + limit);
-        const total = Math.max(totalAcrossLocales, mergedById.size);
-        const result = {
-          posts: paginated,
-          total,
-        };
-        blogPostsCache.set(cacheKey, {
-          value: result,
-          expiresAt: Date.now() + BLOG_LIST_CACHE_TTL_MS,
-        });
-        return result;
+      if (error) {
+        console.error("[getBlogPosts] Error:", error);
+        return { posts: [], total: 0 };
       }
+
+      const result = {
+        posts: data?.posts || [],
+        total: data?.total || 0,
+      };
+      blogPostsCache.set(cacheKey, {
+        value: result,
+        expiresAt: Date.now() + BLOG_LIST_CACHE_TTL_MS,
+      });
+      return result;
+    })();
+
+    blogPostsInflight.set(cacheKey, load);
+    try {
+      return await load;
+    } finally {
+      blogPostsInflight.delete(cacheKey);
     }
-
-    const { data, error } = await supabase.rpc(
-      "get_website_blog_post_summaries",
-      {
-        p_website_id: websiteId,
-        p_limit: limit,
-        p_offset: offset,
-        p_category_slug: options.categorySlug || null,
-        p_tag_slug: null,
-        p_locale: locale || null,
-        p_search: null,
-      },
-    );
-
-    if (error) {
-      console.error("[getBlogPosts] Error:", error);
-      return { posts: [], total: 0 };
-    }
-
-    const result = {
-      posts: data?.posts || [],
-      total: data?.total || 0,
-    };
-    blogPostsCache.set(cacheKey, {
-      value: result,
-      expiresAt: Date.now() + BLOG_LIST_CACHE_TTL_MS,
-    });
-    return result;
   } catch (e) {
     console.error("[getBlogPosts] Exception:", e);
     return { posts: [], total: 0 };


### PR DESCRIPTION
## Summary
- Dedupe public website/blog/navigation Supabase calls during a render.
- Invalidate website, navigation, theme, and blog caches on publish/revalidate.
- Gate below-the-fold homepage fetches behind enabled sections.

## Test Plan
- `npx prettier --check app/api/revalidate/route.ts 'app/site/[subdomain]/page.tsx' lib/supabase/get-pages.ts lib/supabase/get-website.ts __tests__/lib/site/home-first-load-budget-contract.test.ts __tests__/supabase/public-cache-invalidation-contract.test.ts`
- `yarn jest __tests__/supabase/blog-list-summary-contract.test.ts __tests__/supabase/public-cache-invalidation-contract.test.ts __tests__/lib/site/home-first-load-budget-contract.test.ts __tests__/middleware/public-cache.test.ts --runInBand`
- `yarn typecheck`

## Production Follow-up
- Merge to `main` to trigger Studio deploy.
- Re-measure ColombiaTours warm cache TTFB, total curl time, and HTML bytes after deployment.