### PR TITLE
perf: slim ColombiaTours home payload

### DIFF
--- a/__tests__/lib/site/home-first-load-budget-contract.test.ts
+++ b/__tests__/lib/site/home-first-load-budget-contract.test.ts
@@ -25,4 +25,13 @@ describe("home first-load data budget contract", () => {
       /hasBlogSection[\s\S]*getBlogPosts\(website\.id/,
     );
   });
+
+  it("keeps repeated home section data out of the render payload", () => {
+    const source = readSource("app/site/[subdomain]/page.tsx");
+
+    expect(source).toContain("sections: []");
+    expect(source).toContain("deferredSections");
+    expect(source).toContain("enabledSections={deferredSections}");
+    expect(source).not.toContain("criticalSectionIds={criticalSectionIds}");
+  });
 });

--- a/app/site/[subdomain]/page.tsx
+++ b/app/site/[subdomain]/page.tsx
@@ -140,7 +140,6 @@ async function DeferredHomeSections({
   subdomain,
   locale,
   enabledSections,
-  criticalSectionIds,
   templateSet,
 }: DeferredHomeDataInput) {
   const accountContent = (website.content as unknown as Record<string, unknown>)
@@ -244,20 +243,18 @@ async function DeferredHomeSections({
     blogPosts: blogResult.posts.length > 0 ? blogResult.posts : undefined,
     brandClaims,
     featuredDestinations,
-  })
-    .filter((section) => !criticalSectionIds.has(section.id))
-    .filter((section) => {
-      if (section.section_type === SECTION_PACKAGES) {
-        return packageItems.length > 0 || contentHasArray(section, "packages");
-      }
-      if (section.section_type === "destinations") {
-        return (
-          sectionDynamicDestinations.length > 0 ||
-          contentHasArray(section, "destinations")
-        );
-      }
-      return true;
-    });
+  }).filter((section) => {
+    if (section.section_type === SECTION_PACKAGES) {
+      return packageItems.length > 0 || contentHasArray(section, "packages");
+    }
+    if (section.section_type === "destinations") {
+      return (
+        sectionDynamicDestinations.length > 0 ||
+        contentHasArray(section, "destinations")
+      );
+    }
+    return true;
+  });
 
   return (
     <>
@@ -292,6 +289,7 @@ export default async function SitePage({ params }: SitePageProps) {
   const isCustomDomain = inferIsCustomDomainWebsite(website);
   const websiteForRender = {
     ...website,
+    sections: [],
     resolvedLocale: localeContext.resolvedLocale,
     defaultLocale: localeContext.defaultLocale,
     isCustomDomain,
@@ -308,7 +306,7 @@ export default async function SitePage({ params }: SitePageProps) {
     locale: localeContext.resolvedLocale,
     defaultLocale: localeContext.defaultLocale,
   });
-  const { criticalSections, criticalSectionIds } =
+  const { criticalSections, deferredSections } =
     buildHomeSectionPlan(enabledSections);
 
   return (
@@ -330,8 +328,7 @@ export default async function SitePage({ params }: SitePageProps) {
           subdomain={subdomain}
           locale={localeContext.resolvedLocale}
           defaultLocale={localeContext.defaultLocale}
-          enabledSections={enabledSections}
-          criticalSectionIds={criticalSectionIds}
+          enabledSections={deferredSections}
           templateSet={templateSet}
         />
       </Suspense>

--- a/lib/site/home-rendering.ts
+++ b/lib/site/home-rendering.ts
@@ -1,18 +1,18 @@
-import { SECTION_TYPES } from '@bukeer/website-contract';
-import type { WebsiteData, WebsiteSection } from '@/lib/supabase/get-website';
-import { applyContentTranslations } from '@/lib/sections/apply-content-translations';
-import { resolveTemplateSet } from '@/lib/sections/template-set';
+import { SECTION_TYPES } from "@bukeer/website-contract";
+import type { WebsiteData, WebsiteSection } from "@/lib/supabase/get-website";
+import { applyContentTranslations } from "@/lib/sections/apply-content-translations";
+import { resolveTemplateSet } from "@/lib/sections/template-set";
 
-const SECTION_HERO = SECTION_TYPES.find((t) => t === 'hero')!;
-const SECTION_DESTINATIONS = SECTION_TYPES.find((t) => t === 'destinations')!;
-const SECTION_PACKAGES = SECTION_TYPES.find((t) => t === 'packages')!;
-const SECTION_ACTIVITIES = SECTION_TYPES.find((t) => t === 'activities')!;
-const SECTION_HOTELS = SECTION_TYPES.find((t) => t === 'hotels')!;
-const SECTION_TESTIMONIALS = SECTION_TYPES.find((t) => t === 'testimonials')!;
-const SECTION_STATS = SECTION_TYPES.find((t) => t === 'stats')!;
-const SECTION_CTA = SECTION_TYPES.find((t) => t === 'cta')!;
-const SECTION_CONTACT = SECTION_TYPES.find((t) => t === 'contact')!;
-const SECTION_CONTACT_FORM = SECTION_TYPES.find((t) => t === 'contact_form')!;
+const SECTION_HERO = SECTION_TYPES.find((t) => t === "hero")!;
+const SECTION_DESTINATIONS = SECTION_TYPES.find((t) => t === "destinations")!;
+const SECTION_PACKAGES = SECTION_TYPES.find((t) => t === "packages")!;
+const SECTION_ACTIVITIES = SECTION_TYPES.find((t) => t === "activities")!;
+const SECTION_HOTELS = SECTION_TYPES.find((t) => t === "hotels")!;
+const SECTION_TESTIMONIALS = SECTION_TYPES.find((t) => t === "testimonials")!;
+const SECTION_STATS = SECTION_TYPES.find((t) => t === "stats")!;
+const SECTION_CTA = SECTION_TYPES.find((t) => t === "cta")!;
+const SECTION_CONTACT = SECTION_TYPES.find((t) => t === "contact")!;
+const SECTION_CONTACT_FORM = SECTION_TYPES.find((t) => t === "contact_form")!;
 
 const SINGLETON_SECTION_TYPES = new Set<string>([
   SECTION_HERO,
@@ -28,7 +28,7 @@ const SINGLETON_SECTION_TYPES = new Set<string>([
 const EDITORIAL_DEFERRED_OMIT_TYPES = new Set<string>([
   SECTION_ACTIVITIES,
   SECTION_HOTELS,
-  SECTION_TYPES.find((t) => t === 'blog')!,
+  SECTION_TYPES.find((t) => t === "blog")!,
 ]);
 
 export interface CriticalHomeData {
@@ -46,7 +46,6 @@ export interface DeferredHomeDataInput {
   locale: string;
   defaultLocale: string;
   enabledSections: WebsiteSection[];
-  criticalSectionIds: Set<string>;
   templateSet: string | null;
 }
 
@@ -72,9 +71,13 @@ export function resolveHomeEnabledSections(input: {
   );
 
   return localeAwareSections
-    .filter((section) => section.section_type !== SECTION_CONTACT && section.section_type !== SECTION_CONTACT_FORM)
+    .filter(
+      (section) =>
+        section.section_type !== SECTION_CONTACT &&
+        section.section_type !== SECTION_CONTACT_FORM,
+    )
     .filter((section) => {
-      if (templateSet !== 'editorial-v1') return true;
+      if (templateSet !== "editorial-v1") return true;
       return !EDITORIAL_DEFERRED_OMIT_TYPES.has(section.section_type);
     })
     .sort((a, b) => a.display_order - b.display_order)
@@ -86,18 +89,24 @@ export function resolveHomeEnabledSections(input: {
     });
 }
 
-export function buildHomeSectionPlan(enabledSections: WebsiteSection[]): HomeSectionPlan {
-  const heroSection = enabledSections.find((section) => section.section_type === SECTION_HERO);
+export function buildHomeSectionPlan(
+  enabledSections: WebsiteSection[],
+): HomeSectionPlan {
+  const heroSection = enabledSections.find(
+    (section) => section.section_type === SECTION_HERO,
+  );
   const criticalSections = heroSection ? [heroSection] : [];
   const criticalSectionIds = new Set(
     criticalSections
       .map((section) => section.id)
-      .filter((id): id is string => typeof id === 'string' && id.length > 0),
+      .filter((id): id is string => typeof id === "string" && id.length > 0),
   );
 
   return {
     criticalSections,
-    deferredSections: enabledSections.filter((section) => !criticalSectionIds.has(section.id)),
+    deferredSections: enabledSections.filter(
+      (section) => !criticalSectionIds.has(section.id),
+    ),
     enabledSections,
     criticalSectionIds,
   };


### PR DESCRIPTION
## Summary
- Avoid passing the full `website.sections` array through each home section render payload.
- Render only deferred sections in the deferred home block instead of passing all enabled sections plus critical IDs.
- Add a first-load budget contract test for the slim home payload.

## Test Plan
- `npx prettier --write app/api/revalidate/route.ts 'app/site/[subdomain]/page.tsx' lib/site/home-rendering.ts __tests__/lib/site/home-first-load-budget-contract.test.ts __tests__/supabase/public-cache-invalidation-contract.test.ts lib/supabase/get-pages.ts lib/supabase/get-website.ts`
- `yarn jest __tests__/supabase/blog-list-summary-contract.test.ts __tests__/supabase/public-cache-invalidation-contract.test.ts __tests__/lib/site/home-first-load-budget-contract.test.ts __tests__/middleware/public-cache.test.ts --runInBand`
- `yarn typecheck`

## Production Follow-up
- Re-measure ColombiaTours HTML bytes, compressed size, TTFB, and total curl time after deployment.