### PR TITLE
chore: add ColombiaTours public home timing probe

### DIFF
--- a/__tests__/lib/site/home-first-load-budget-contract.test.ts
+++ b/__tests__/lib/site/home-first-load-budget-contract.test.ts
@@ -22,7 +22,7 @@ describe("home first-load data budget contract", () => {
       /hasPackagesSection[\s\S]*getCategoryProducts\(subdomain, SECTION_PACKAGES/,
     );
     expect(deferredSource).toMatch(
-      /hasBlogSection[\s\S]*getBlogPosts\(website\.id/,
+      /hasBlogSection[\s\S]*getBlogPosts\(websiteId/,
     );
   });
 
@@ -33,5 +33,18 @@ describe("home first-load data budget contract", () => {
     expect(source).toContain("deferredSections");
     expect(source).toContain("enabledSections={deferredSections}");
     expect(source).not.toContain("criticalSectionIds={criticalSectionIds}");
+  });
+
+  it("keeps public timing instrumentation behind an explicit probe header", () => {
+    const source = readSource("app/site/[subdomain]/page.tsx");
+
+    expect(source).toContain(
+      'const PUBLIC_HOME_TIMING_HEADER = "x-bukeer-debug-timing"',
+    );
+    expect(source).toContain("timedPublicHome");
+    expect(source).toContain("[public_home_timing]");
+    expect(source).toContain(
+      'requestHeaders.get(PUBLIC_HOME_TIMING_HEADER) === "1"',
+    );
   });
 });

--- a/app/site/[subdomain]/page.tsx
+++ b/app/site/[subdomain]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { SectionRenderer } from "@/components/site/section-renderer";
@@ -42,6 +43,7 @@ const SECTION_PACKAGES = SECTION_TYPES.find((t) => t === "packages")!;
 const SECTION_ACTIVITIES = SECTION_TYPES.find((t) => t === "activities")!;
 const SECTION_HOTELS = SECTION_TYPES.find((t) => t === "hotels")!;
 const SECTION_BLOG = SECTION_TYPES.find((t) => t === "blog")!;
+const PUBLIC_HOME_TIMING_HEADER = "x-bukeer-debug-timing";
 
 // ISR: Revalidate every 5 minutes for fresh content with edge caching
 export const revalidate = 300;
@@ -51,6 +53,86 @@ interface SitePageProps {
 }
 
 const PLANNER_TYPES = new Set(["planners", "team", "travel_planners"]);
+
+interface PublicHomeTimingProbe {
+  enabled: boolean;
+  subdomain: string;
+  startedAt: number;
+  marks: Array<{ label: string; durationMs: number }>;
+}
+
+type DeferredHomeSectionsProps = DeferredHomeDataInput & {
+  timing?: PublicHomeTimingProbe;
+};
+
+function nowMs(): number {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
+}
+
+function createPublicHomeTimingProbe(
+  requestHeaders: Headers,
+  subdomain: string,
+): PublicHomeTimingProbe {
+  const enabled =
+    requestHeaders.get(PUBLIC_HOME_TIMING_HEADER) === "1" ||
+    process.env.PUBLIC_SITE_TIMING_LOGS === "true";
+
+  return {
+    enabled,
+    subdomain,
+    startedAt: nowMs(),
+    marks: [],
+  };
+}
+
+async function timedPublicHome<T>(
+  timing: PublicHomeTimingProbe | undefined,
+  label: string,
+  work: () => Promise<T>,
+): Promise<T> {
+  if (!timing?.enabled) return work();
+
+  const startedAt = nowMs();
+  try {
+    return await work();
+  } finally {
+    timing.marks.push({
+      label,
+      durationMs: Math.round((nowMs() - startedAt) * 10) / 10,
+    });
+  }
+}
+
+function markPublicHome(
+  timing: PublicHomeTimingProbe | undefined,
+  label: string,
+  startedAt: number,
+) {
+  if (!timing?.enabled) return;
+  timing.marks.push({
+    label,
+    durationMs: Math.round((nowMs() - startedAt) * 10) / 10,
+  });
+}
+
+function logPublicHomeTiming(
+  timing: PublicHomeTimingProbe | undefined,
+  phase: "critical" | "deferred",
+  details: Record<string, unknown>,
+) {
+  if (!timing?.enabled) return;
+
+  console.info(
+    "[public_home_timing]",
+    JSON.stringify({
+      subdomain: timing.subdomain,
+      phase,
+      totalMs: Math.round((nowMs() - timing.startedAt) * 10) / 10,
+      marks: timing.marks,
+      ...details,
+    }),
+  );
+}
 
 function titleFromSlug(slug: string): string {
   return slug
@@ -141,7 +223,8 @@ async function DeferredHomeSections({
   locale,
   enabledSections,
   templateSet,
-}: DeferredHomeDataInput) {
+  timing,
+}: DeferredHomeSectionsProps) {
   const accountContent = (website.content as unknown as Record<string, unknown>)
     ?.account as Record<string, unknown> | undefined;
   const googleReviewsEnabled = accountContent?.google_reviews_enabled === true;
@@ -163,6 +246,8 @@ async function DeferredHomeSections({
   const hasHotelsSection = enabledSections.some(
     (s) => s.section_type === SECTION_HOTELS,
   );
+  const accountId = website.account_id;
+  const websiteId = website.id;
 
   const [
     googleReviewsCache,
@@ -175,29 +260,57 @@ async function DeferredHomeSections({
     brandClaims,
     featuredDestinations,
   ] = await Promise.all([
-    googleReviewsEnabled && website.account_id
-      ? getCachedGoogleReviews(website.account_id)
+    googleReviewsEnabled && accountId
+      ? timedPublicHome(timing, "deferred.google_reviews", () =>
+          getCachedGoogleReviews(accountId),
+        )
       : Promise.resolve(null),
-    hasDestinationsSection ? getDestinations(subdomain) : Promise.resolve([]),
+    hasDestinationsSection
+      ? timedPublicHome(timing, "deferred.destinations", () =>
+          getDestinations(subdomain),
+        )
+      : Promise.resolve([]),
     hasPackagesSection
-      ? getCategoryProducts(subdomain, SECTION_PACKAGES, { limit: 8, locale })
+      ? timedPublicHome(timing, "deferred.packages", () =>
+          getCategoryProducts(subdomain, SECTION_PACKAGES, {
+            limit: 8,
+            locale,
+          }),
+        )
       : Promise.resolve({ items: [], total: 0 }),
     hasActivitiesSection
-      ? getCategoryProducts(subdomain, SECTION_ACTIVITIES, { limit: 8, locale })
+      ? timedPublicHome(timing, "deferred.activities", () =>
+          getCategoryProducts(subdomain, SECTION_ACTIVITIES, {
+            limit: 8,
+            locale,
+          }),
+        )
       : Promise.resolve({ items: [], total: 0 }),
     hasHotelsSection
-      ? getCategoryProducts(subdomain, SECTION_HOTELS, { limit: 8, locale })
+      ? timedPublicHome(timing, "deferred.hotels", () =>
+          getCategoryProducts(subdomain, SECTION_HOTELS, { limit: 8, locale }),
+        )
       : Promise.resolve({ items: [], total: 0 }),
-    hasPlannersSection && website.account_id
-      ? getPlanners(website.account_id, { locale })
+    hasPlannersSection && accountId
+      ? timedPublicHome(timing, "deferred.planners", () =>
+          getPlanners(accountId, { locale }),
+        )
       : Promise.resolve<PlannerData[]>([]),
-    hasBlogSection && website.id
-      ? getBlogPosts(website.id, { limit: 6 })
+    hasBlogSection && websiteId
+      ? timedPublicHome(timing, "deferred.blog", () =>
+          getBlogPosts(websiteId, { limit: 6 }),
+        )
       : Promise.resolve({ posts: [], total: 0 }),
-    website.account_id
-      ? getBrandClaims(website.account_id)
+    accountId
+      ? timedPublicHome(timing, "deferred.brand_claims", () =>
+          getBrandClaims(accountId),
+        )
       : Promise.resolve(null),
-    website.id ? getFeaturedDestinations(website.id, 4) : Promise.resolve([]),
+    websiteId
+      ? timedPublicHome(timing, "deferred.featured_destinations", () =>
+          getFeaturedDestinations(websiteId, 4),
+        )
+      : Promise.resolve([]),
   ]);
 
   const curatedDynamicDestinations = dynamicDestinations.filter(
@@ -256,6 +369,15 @@ async function DeferredHomeSections({
     return true;
   });
 
+  logPublicHomeTiming(timing, "deferred", {
+    enabledSections: enabledSections.length,
+    renderedSections: hydratedSections.length,
+    hasBlogSection,
+    hasPackagesSection,
+    hasActivitiesSection,
+    hasHotelsSection,
+  });
+
   return (
     <>
       {hydratedSections.map((section) => (
@@ -274,7 +396,11 @@ async function DeferredHomeSections({
 
 export default async function SitePage({ params }: SitePageProps) {
   const { subdomain } = await params;
-  const website = await getWebsiteBySubdomain(subdomain);
+  const requestHeaders = await headers();
+  const timing = createPublicHomeTimingProbe(requestHeaders, subdomain);
+  const website = await timedPublicHome(timing, "critical.website", () =>
+    getWebsiteBySubdomain(subdomain),
+  );
 
   if (!website || website.status !== "published") {
     notFound();
@@ -285,7 +411,9 @@ export default async function SitePage({ params }: SitePageProps) {
     : `https://${subdomain}.bukeer.com`;
 
   const templateSet = resolveTemplateSet(website);
-  const localeContext = await resolvePublicMetadataLocale(website, "/");
+  const localeContext = await timedPublicHome(timing, "critical.locale", () =>
+    resolvePublicMetadataLocale(website, "/"),
+  );
   const isCustomDomain = inferIsCustomDomainWebsite(website);
   const websiteForRender = {
     ...website,
@@ -294,20 +422,31 @@ export default async function SitePage({ params }: SitePageProps) {
     defaultLocale: localeContext.defaultLocale,
     isCustomDomain,
   } as WebsiteData & { resolvedLocale?: string; isCustomDomain?: boolean };
+  const schemaStartedAt = nowMs();
   const schemas = generateHomepageSchemas(
     website,
     baseUrl,
     undefined,
     localeContext.resolvedLocale,
   );
+  markPublicHome(timing, "critical.schemas", schemaStartedAt);
+  const enabledStartedAt = nowMs();
   const enabledSections = resolveHomeEnabledSections({
     website,
     templateSet,
     locale: localeContext.resolvedLocale,
     defaultLocale: localeContext.defaultLocale,
   });
+  markPublicHome(timing, "critical.enabled_sections", enabledStartedAt);
   const { criticalSections, deferredSections } =
     buildHomeSectionPlan(enabledSections);
+
+  logPublicHomeTiming(timing, "critical", {
+    enabledSections: enabledSections.length,
+    criticalSections: criticalSections.length,
+    deferredSections: deferredSections.length,
+    customDomain: Boolean(website.custom_domain),
+  });
 
   return (
     <>
@@ -330,6 +469,7 @@ export default async function SitePage({ params }: SitePageProps) {
           defaultLocale={localeContext.defaultLocale}
           enabledSections={deferredSections}
           templateSet={templateSet}
+          timing={timing}
         />
       </Suspense>
     </>


### PR DESCRIPTION
## Summary
- Adds an opt-in public home timing probe for `/site/[subdomain]` renders.
- The probe is activated only with `x-bukeer-debug-timing: 1` or `PUBLIC_SITE_TIMING_LOGS=true`.
- Records critical and deferred section timings so ColombiaTours first-load reports can be diagnosed from Worker logs without changing public UX/cache behavior.

## Validation
- `yarn jest __tests__/lib/site/home-first-load-budget-contract.test.ts __tests__/supabase/blog-list-summary-contract.test.ts --runInBand`
- `yarn typecheck`