### PR TITLE
perf: trim ColombiaTours home render payload

### DIFF
--- a/__tests__/lib/site/home-first-load-budget-contract.test.ts
+++ b/__tests__/lib/site/home-first-load-budget-contract.test.ts
@@ -28,11 +28,33 @@ describe("home first-load data budget contract", () => {
 
   it("keeps repeated home section data out of the render payload", () => {
     const source = readSource("app/site/[subdomain]/page.tsx");
+    const layoutSource = readSource("app/site/[subdomain]/layout.tsx");
+    const helperSource = readSource("lib/site/home-rendering.ts");
 
-    expect(source).toContain("sections: []");
+    expect(source).toContain("createHomeRenderWebsite");
+    expect(layoutSource).toContain("createHomeRenderWebsite");
+    expect(layoutSource).toContain("includeSectionSummaries: true");
+    expect(helperSource).toContain("sections: includeSectionSummaries");
+    expect(helperSource).toContain("featured_products: {");
+    expect(source).not.toMatch(/const websiteForRender = \{\s*\.\.\.website/);
+    expect(layoutSource).not.toMatch(/const websiteForRender = \{\s*\.\.\.website/);
     expect(source).toContain("deferredSections");
     expect(source).toContain("enabledSections={deferredSections}");
     expect(source).not.toContain("criticalSectionIds={criticalSectionIds}");
+  });
+
+  it("does not serialize account legal copy into the public home render payload", () => {
+    const source = readSource("lib/site/home-rendering.ts");
+    const renderWebsiteSource = source.match(
+      /export function createHomeRenderWebsite[\s\S]*?\n}\n\nexport function resolveHomeEnabledSections/,
+    )?.[0];
+
+    expect(renderWebsiteSource).toBeDefined();
+    expect(renderWebsiteSource).toContain("account: account");
+    expect(renderWebsiteSource).not.toContain("legal");
+    expect(renderWebsiteSource).not.toContain("terms_conditions");
+    expect(renderWebsiteSource).not.toContain("cancellation_policy");
+    expect(renderWebsiteSource).not.toContain("privacy_policy");
   });
 
   it("keeps public timing instrumentation behind an explicit probe header", () => {

--- a/app/site/[subdomain]/layout.tsx
+++ b/app/site/[subdomain]/layout.tsx
@@ -31,6 +31,7 @@ import { supabaseImageUrl } from "@/lib/images/supabase-transform";
 import { EditorialSiteHeader } from "@/components/site/themes/editorial-v1/layout/site-header";
 import { EditorialSiteFooter } from "@/components/site/themes/editorial-v1/layout/site-footer";
 import { WaflowProvider } from "@/components/site/themes/editorial-v1/waflow/provider";
+import { createHomeRenderWebsite } from "@/lib/site/home-rendering";
 import "@/app/globals.css";
 // Editorial-v1 scoped CSS loads alongside globals but only emits rules under
 // `[data-template-set="editorial-v1"]`, so generic sites stay untouched.
@@ -217,12 +218,13 @@ export default async function SiteLayout({
   const navItems = await getWebsiteNavigation(subdomain);
   const localeContext = await resolvePublicMetadataLocale(website, "/");
   const isCustomDomain = inferIsCustomDomainWebsite(website);
-  const websiteForRender = {
-    ...website,
+  const websiteForRender = createHomeRenderWebsite({
+    website,
     resolvedLocale: localeContext.resolvedLocale,
     defaultLocale: localeContext.defaultLocale,
     isCustomDomain,
-  };
+    includeSectionSummaries: true,
+  });
   const basePath = getBasePath(subdomain, isCustomDomain);
   const navigation =
     navItems.length > 0

--- a/app/site/[subdomain]/page.tsx
+++ b/app/site/[subdomain]/page.tsx
@@ -14,7 +14,7 @@ import {
   getWebsiteBySubdomain,
   getBlogPosts,
 } from "@/lib/supabase/get-website";
-import type { WebsiteData, WebsiteSection } from "@/lib/supabase/get-website";
+import type { WebsiteSection } from "@/lib/supabase/get-website";
 import {
   getCachedGoogleReviews,
   getCategoryProducts,
@@ -34,6 +34,7 @@ import {
 import { resolveTemplateSet } from "@/lib/sections/template-set";
 import {
   buildHomeSectionPlan,
+  createHomeRenderWebsite,
   resolveHomeEnabledSections,
   type DeferredHomeDataInput,
 } from "@/lib/site/home-rendering";
@@ -415,13 +416,12 @@ export default async function SitePage({ params }: SitePageProps) {
     resolvePublicMetadataLocale(website, "/"),
   );
   const isCustomDomain = inferIsCustomDomainWebsite(website);
-  const websiteForRender = {
-    ...website,
-    sections: [],
+  const websiteForRender = createHomeRenderWebsite({
+    website,
     resolvedLocale: localeContext.resolvedLocale,
     defaultLocale: localeContext.defaultLocale,
     isCustomDomain,
-  } as WebsiteData & { resolvedLocale?: string; isCustomDomain?: boolean };
+  });
   const schemaStartedAt = nowMs();
   const schemas = generateHomepageSchemas(
     website,

--- a/lib/site/home-rendering.ts
+++ b/lib/site/home-rendering.ts
@@ -56,6 +56,116 @@ export interface HomeSectionPlan {
   criticalSectionIds: Set<string>;
 }
 
+export type HomeRenderWebsiteData = WebsiteData & {
+  resolvedLocale?: string;
+  isCustomDomain?: boolean;
+  effective_theme?: WebsiteData["theme"];
+  effective_theme_source?: string;
+};
+
+function toSectionSummary(section: WebsiteSection): WebsiteSection {
+  return {
+    id: section.id,
+    section_type: section.section_type,
+    variant: section.variant,
+    display_order: section.display_order,
+    is_enabled: section.is_enabled,
+    config: {},
+    content: {},
+  };
+}
+
+export function createHomeRenderWebsite(input: {
+  website: WebsiteData;
+  resolvedLocale: string;
+  defaultLocale: string;
+  isCustomDomain: boolean;
+  includeSectionSummaries?: boolean;
+}): HomeRenderWebsiteData {
+  const {
+    website,
+    resolvedLocale,
+    defaultLocale,
+    isCustomDomain,
+    includeSectionSummaries = false,
+  } = input;
+  const content = website.content;
+  const account = content.account;
+
+  return {
+    id: website.id,
+    account_id: website.account_id,
+    subdomain: website.subdomain,
+    custom_domain: website.custom_domain,
+    default_locale: defaultLocale,
+    supported_locales: website.supported_locales,
+    status: website.status,
+    template_id: website.template_id,
+    theme: website.theme,
+    effective_theme: (website as HomeRenderWebsiteData).effective_theme,
+    effective_theme_source: (website as HomeRenderWebsiteData)
+      .effective_theme_source,
+    analytics: undefined,
+    featured_products: {
+      destinations: [],
+      hotels: [],
+      activities: [],
+      transfers: [],
+      packages: [],
+    },
+    sections: includeSectionSummaries
+      ? (website.sections || []).map(toSectionSummary)
+      : [],
+    site_parts: website.site_parts,
+    content: {
+      siteName: content.siteName,
+      tagline: content.tagline,
+      logo: content.logo,
+      logoLight: content.logoLight,
+      logoDark: content.logoDark,
+      locale: resolvedLocale || content.locale,
+      headerCta: content.headerCta,
+      seo: {
+        title: content.seo?.title ?? content.siteName ?? website.subdomain,
+        description: content.seo?.description ?? content.tagline ?? "",
+        keywords: content.seo?.keywords ?? "",
+      },
+      contact: {
+        email: content.contact?.email ?? account?.email ?? "",
+        phone: content.contact?.phone ?? account?.phone ?? "",
+        address: content.contact?.address ?? account?.location ?? "",
+      },
+      social: {
+        facebook: content.social?.facebook,
+        instagram: content.social?.instagram,
+        twitter: content.social?.twitter,
+        youtube: content.social?.youtube,
+        linkedin: content.social?.linkedin,
+        tiktok: content.social?.tiktok,
+        whatsapp: content.social?.whatsapp,
+      },
+      account: account
+        ? {
+            name: account.name,
+            logo: account.logo,
+            email: account.email,
+            phone: account.phone,
+            phone2: account.phone2,
+            website: account.website,
+            location: account.location,
+            primary_currency: account.primary_currency,
+            enabled_currencies: account.enabled_currencies,
+            currency: account.currency,
+          }
+        : undefined,
+      market_experience: content.market_experience,
+      trust: content.trust,
+    },
+    resolvedLocale,
+    isCustomDomain,
+  } as HomeRenderWebsiteData;
+}
+
 export function resolveHomeEnabledSections(input: {
   website: WebsiteData;
   locale: string;


### PR DESCRIPTION
## Summary
- trims the website object serialized through the public home shell and home sections
- keeps only render-critical content, currency, social, theme, and section summaries
- prevents account legal copy and full featured product payloads from entering the initial RSC stream

## Local validation
- npm test -- __tests__/lib/site/home-first-load-budget-contract.test.ts --runInBand
- npm run typecheck
- npm run lint (passes with existing warnings)
- npm run build

## Local measurement
- colombiatours.travel via local Host rewrite: HTML ~225 KB uncompressed, gzip ~48 KB
- previous live/local baseline: ~289 KB uncompressed
