### PR TITLE
fix(seo): remove duplicate blog H1 for San Andrés traffic gate

### DIFF
--- a/app/site/[subdomain]/blog/[slug]/page.tsx
+++ b/app/site/[subdomain]/blog/[slug]/page.tsx
@@ -220,9 +220,6 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     <>
       {/* JSON-LD Structured Data for SEO and AI crawlers */}
       <JsonLd data={schemas} />
-      <h1 className="sr-only" aria-hidden="true">
-        {post.title}
-      </h1>
       <BlogDetail
         subdomain={subdomain}
         locale={resolvedLocale}


### PR DESCRIPTION
Fixes San Andrés duplicate rendered H1 blocking SEO360 traffic-readiness. Removes hidden sr-only aria-hidden H1 before BlogDetail; BlogDetail visible article H1 remains.

Verification from worker: independent review PASS, security scan no findings, hardcoded UI lint PASS, typecheck PASS, build worker PASS. Live remains h1_count=2 until this is merged/deployed.

Kanban: t_bf8e0371. Related San Andrés media canary: t_ff273ea9.