### PR TITLE
fix(seo): remove duplicate San Andrés blog H1

### DIFF
--- a/app/site/[subdomain]/blog/[slug]/page.tsx
+++ b/app/site/[subdomain]/blog/[slug]/page.tsx
@@ -220,9 +220,6 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     <>
       {/* JSON-LD Structured Data for SEO and AI crawlers */}
       <JsonLd data={schemas} />
-      <h1 className="sr-only" aria-hidden="true">
-        {post.title}
-      </h1>
       <BlogDetail
         subdomain={subdomain}
         locale={resolvedLocale}


### PR DESCRIPTION
Clean branch from origin/main with only the San Andrés duplicate-H1 fix. Removes hidden sr-only aria-hidden H1 before BlogDetail; visible BlogDetail H1 remains. Kanban t_bf8e0371.