### PR TITLE
feat(growth): add SEO360 MediaPack contract

### DIFF
--- a/__tests__/schema/growth-media-pack.test.ts
+++ b/__tests__/schema/growth-media-pack.test.ts
@@ -1,0 +1,251 @@
+import {
+  GrowthMediaPackSchema,
+  evaluateGrowthMediaPackReadiness,
+} from "@bukeer/website-contract";
+
+const scope = {
+  account_id: "11111111-1111-4111-8111-111111111111",
+  website_id: "22222222-2222-4222-8222-222222222222",
+  locale: "es-CO",
+  market: "CO",
+};
+
+const baseSlot = {
+  slot_index: 1,
+  section_key: "hero",
+  visual_intent: "Spratt Bight beach hero with visible San Andres shoreline",
+  status: "filled",
+  image_url: "https://cdn.colombiatours.travel/media/san-andres-spratt-bight.webp",
+  source_url: "https://colombiatours.travel/media-library/san-andres-spratt-bight",
+  source_ref: "media_assets:asset-001",
+  license_status: "approved",
+  provenance_type: "first_party_media_library",
+  destination_match: "pass",
+  section_match: "pass",
+  alt: "Playa Spratt Bight en San Andrés con mar turquesa",
+  caption: "Spratt Bight, San Andrés",
+  dimensions: { width: 1600, height: 1067 },
+  hash: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  duplicate_check: "unique",
+  visual_quality_score: 92,
+};
+
+const makeSlots = (count: number) =>
+  Array.from({ length: count }, (_, index) => ({
+    ...baseSlot,
+    slot_index: index + 1,
+    source_ref: `media_assets:asset-${String(index + 1).padStart(3, "0")}`,
+    hash: `sha256:${String(index + 1).padStart(64, "a")}`,
+  }));
+
+describe("Growth MediaPack contract", () => {
+  it("accepts a traffic-ready pack with 25 approved real-image slots", () => {
+    const pack = GrowthMediaPackSchema.parse({
+      ...scope,
+      pack_version: "growth-media-pack-v1",
+      requested_by: "growth-content-agent",
+      owned_by_lane: "growth-media-agent",
+      canonical_url: "https://colombiatours.travel/blog/san-andres",
+      keyword: "San Andrés Colombia",
+      destination_entities: ["San Andrés", "Spratt Bight"],
+      target_image_count: 25,
+      required_visual_intents: makeSlots(25).map((slot) => ({
+        section_key: slot.section_key,
+        visual_intent: slot.visual_intent,
+        required_count: 1,
+      })),
+      slots: makeSlots(25),
+      human_approved_exception: null,
+      generated_at: "2026-05-20T23:00:00.000Z",
+    });
+
+    const readiness = evaluateGrowthMediaPackReadiness(pack);
+
+    expect(pack.slots).toHaveLength(25);
+    expect(readiness.status).toBe("traffic_ready");
+    expect(readiness.filled_approved_slots).toBe(25);
+  });
+
+  it("holds traffic readiness when only 4 slots are filled and the remaining benchmark slots are missing", () => {
+    const slots = [
+      ...makeSlots(4),
+      ...Array.from({ length: 21 }, (_, index) => ({
+        slot_index: index + 5,
+        section_key: "body",
+        visual_intent: `Required San Andres supporting visual ${index + 1}`,
+        status: "missing",
+        license_status: "missing",
+        provenance_type: "not_sourced",
+        destination_match: "unknown",
+        section_match: "unknown",
+        duplicate_check: "not_checked",
+        visual_quality_score: null,
+      })),
+    ];
+
+    const pack = GrowthMediaPackSchema.parse({
+      ...scope,
+      pack_version: "growth-media-pack-v1",
+      requested_by: "growth-content-agent",
+      owned_by_lane: "growth-media-agent",
+      canonical_url: "https://colombiatours.travel/blog/san-andres",
+      keyword: "San Andrés Colombia",
+      destination_entities: ["San Andrés"],
+      target_image_count: 25,
+      required_visual_intents: [],
+      slots,
+      generated_at: "2026-05-20T23:00:00.000Z",
+    });
+
+    const readiness = evaluateGrowthMediaPackReadiness(pack);
+
+    expect(readiness.status).toBe("hold_scale");
+    expect(readiness.filled_approved_slots).toBe(4);
+    expect(readiness.missing_slots).toBe(21);
+  });
+
+  it("does not let a human exception override missing explicit slots", () => {
+    const slots = [
+      ...makeSlots(4),
+      ...Array.from({ length: 21 }, (_, index) => ({
+        slot_index: index + 5,
+        section_key: "body",
+        visual_intent: `Required San Andres supporting visual ${index + 1}`,
+        status: "missing",
+        license_status: "missing",
+        provenance_type: "not_sourced",
+        destination_match: "unknown",
+        section_match: "unknown",
+        duplicate_check: "not_checked",
+        visual_quality_score: null,
+      })),
+    ];
+
+    const pack = GrowthMediaPackSchema.parse({
+      ...scope,
+      pack_version: "growth-media-pack-v1",
+      requested_by: "growth-content-agent",
+      owned_by_lane: "growth-media-agent",
+      canonical_url: "https://colombiatours.travel/blog/san-andres",
+      keyword: "San Andrés Colombia",
+      destination_entities: ["San Andrés"],
+      target_image_count: 25,
+      required_visual_intents: [],
+      slots,
+      human_approved_exception: {
+        approved_by: "SEO Council",
+        approved_at: "2026-05-20T23:30:00.000Z",
+        reason: "Temporary launch exception still cannot hide missing slots.",
+        minimum_publishable_slots: 4,
+      },
+      generated_at: "2026-05-20T23:00:00.000Z",
+    });
+
+    const readiness = evaluateGrowthMediaPackReadiness(pack);
+
+    expect(readiness.status).toBe("hold_scale");
+    expect(readiness.blockers).toContain("missing_slots");
+  });
+
+  it("rejects Google image candidates without license proof as publishable slots", () => {
+    const parsed = GrowthMediaPackSchema.safeParse({
+      ...scope,
+      pack_version: "growth-media-pack-v1",
+      requested_by: "growth-content-agent",
+      owned_by_lane: "growth-media-agent",
+      canonical_url: "https://colombiatours.travel/blog/san-andres",
+      keyword: "San Andrés Colombia",
+      destination_entities: ["San Andrés"],
+      target_image_count: 1,
+      required_visual_intents: [],
+      slots: [
+        {
+          ...baseSlot,
+          source_url: "https://www.google.com/maps/contrib/example/photo",
+          source_ref: "google_places:photo_reference:abc123",
+          license_status: "reference_only",
+          provenance_type: "google_places_discovery",
+        },
+      ],
+      generated_at: "2026-05-20T23:00:00.000Z",
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("allows reference-only Google imagery only as a visual brief that still requires a publishable base", () => {
+    const pack = GrowthMediaPackSchema.parse({
+      ...scope,
+      pack_version: "growth-media-pack-v1",
+      requested_by: "growth-content-agent",
+      owned_by_lane: "growth-media-agent",
+      canonical_url: "https://colombiatours.travel/blog/san-andres",
+      keyword: "San Andrés Colombia",
+      destination_entities: ["San Andrés"],
+      target_image_count: 1,
+      required_visual_intents: [],
+      slots: [
+        {
+          slot_index: 1,
+          section_key: "hero",
+          visual_intent: "Spratt Bight factual visual brief",
+          status: "needs_human_asset",
+          license_status: "reference_only",
+          provenance_type: "google_places_discovery",
+          source_url: "https://www.google.com/maps/contrib/example/photo",
+          source_ref: "google_places:photo_reference:abc123",
+          destination_match: "pass",
+          section_match: "pass",
+          duplicate_check: "not_checked",
+          visual_quality_score: null,
+          reference_only_visual_brief: {
+            allowed: true,
+            non_publishable_source_url: "https://www.google.com/maps/contrib/example/photo",
+            factual_observations: ["turquoise water", "urban beachfront"],
+          },
+          publishable_base_required: true,
+          generated_or_edited_final: null,
+          reality_preservation_pass: false,
+        },
+      ],
+      generated_at: "2026-05-20T23:00:00.000Z",
+    });
+
+    const readiness = evaluateGrowthMediaPackReadiness(pack);
+
+    expect(readiness.status).toBe("hold_scale");
+    expect(readiness.blockers).toContain("publishable_base_required");
+  });
+
+  it("rejects AI-assisted derivatives that change destination reality or are based on reference-only pixels", () => {
+    const parsed = GrowthMediaPackSchema.safeParse({
+      ...scope,
+      pack_version: "growth-media-pack-v1",
+      requested_by: "growth-content-agent",
+      owned_by_lane: "growth-media-agent",
+      canonical_url: "https://colombiatours.travel/blog/san-andres",
+      keyword: "San Andrés Colombia",
+      destination_entities: ["San Andrés"],
+      target_image_count: 1,
+      required_visual_intents: [],
+      slots: [
+        {
+          ...baseSlot,
+          provenance_type: "ai_assisted_real_photo_derivative",
+          license_status: "approved",
+          generated_or_edited_final: {
+            model: "image-editor-v1",
+            base_provenance_type: "google_places_discovery",
+            base_license_status: "reference_only",
+            editing_actions: ["replace cloudy sky with impossible mountains"],
+            disclosure_label: "AI-assisted real-photo derivative",
+          },
+          reality_preservation_pass: false,
+        },
+      ],
+      generated_at: "2026-05-20T23:00:00.000Z",
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/app/dashboard/[websiteId]/growth/agents/page.tsx
+++ b/app/dashboard/[websiteId]/growth/agents/page.tsx
@@ -34,6 +34,7 @@ const LANE_LABELS: Record<AgentLane, string> = {
   transcreation: "Transcreation",
   content_creator: "Content Creator",
   content_curator: "Content Curator",
+  media: "Media",
 };
 
 const LANE_MISSIONS: Record<AgentLane, string> = {
@@ -42,6 +43,7 @@ const LANE_MISSIONS: Record<AgentLane, string> = {
   transcreation: "Adaptacion por mercado/locale con quality gate humano.",
   content_creator: "Briefs y updates con SERP, baseline y ventaja competitiva.",
   content_curator: "Curaduria, Council packet y control de experimentos.",
+  media: "Sourcing de imagenes reales con licencia, provenance y QA visual.",
 };
 
 const LANE_SAFETY: Record<AgentLane, string> = {
@@ -50,6 +52,7 @@ const LANE_SAFETY: Record<AgentLane, string> = {
   transcreation: "Live gated solo con quality gate y rollback completo.",
   content_creator: "Live gated solo organico con caps, smoke y outcome.",
   content_curator: "Paid, experimentos y outreach siguen bloqueados.",
+  media: "Nunca usa imagenes generadas como prueba de destino; bloquea slots sin licencia.",
 };
 
 const MODE_LABELS: Record<string, string> = {
@@ -76,6 +79,7 @@ const TOOL_ACTIONS: ReadonlyArray<ToolAction> = [
       transcreation: "allowed",
       content_creator: "allowed",
       content_curator: "allowed",
+      media: "allowed",
     },
   },
   {
@@ -87,6 +91,7 @@ const TOOL_ACTIONS: ReadonlyArray<ToolAction> = [
       transcreation: "allowed",
       content_creator: "allowed",
       content_curator: "allowed",
+      media: "allowed",
     },
   },
   {
@@ -98,6 +103,7 @@ const TOOL_ACTIONS: ReadonlyArray<ToolAction> = [
       transcreation: "blocked",
       content_creator: "blocked",
       content_curator: "blocked",
+      media: "blocked",
     },
   },
   {
@@ -109,6 +115,7 @@ const TOOL_ACTIONS: ReadonlyArray<ToolAction> = [
       transcreation: "blocked",
       content_creator: "live_gated",
       content_curator: "live_gated",
+      media: "blocked",
     },
   },
   {
@@ -120,6 +127,7 @@ const TOOL_ACTIONS: ReadonlyArray<ToolAction> = [
       transcreation: "live_gated",
       content_creator: "blocked",
       content_curator: "blocked",
+      media: "blocked",
     },
   },
   {
@@ -131,6 +139,7 @@ const TOOL_ACTIONS: ReadonlyArray<ToolAction> = [
       transcreation: "blocked",
       content_creator: "blocked",
       content_curator: "gated",
+      media: "blocked",
     },
   },
   {
@@ -142,6 +151,7 @@ const TOOL_ACTIONS: ReadonlyArray<ToolAction> = [
       transcreation: "blocked",
       content_creator: "blocked",
       content_curator: "gated",
+      media: "blocked",
     },
   },
   {
@@ -153,6 +163,7 @@ const TOOL_ACTIONS: ReadonlyArray<ToolAction> = [
       transcreation: "blocked",
       content_creator: "gated",
       content_curator: "gated",
+      media: "blocked",
     },
   },
 ];

--- a/app/dashboard/[websiteId]/growth/backlog/page.tsx
+++ b/app/dashboard/[websiteId]/growth/backlog/page.tsx
@@ -42,6 +42,7 @@ const LANES: ReadonlyArray<AgentLane> = [
   "transcreation",
   "content_creator",
   "content_curator",
+  "media",
 ];
 
 const LANE_LABELS: Record<AgentLane, string> = {
@@ -50,6 +51,7 @@ const LANE_LABELS: Record<AgentLane, string> = {
   transcreation: "Transcreación",
   content_creator: "Creación de contenido",
   content_curator: "Curaduría",
+  media: "Media",
 };
 
 const LANE_HELP: Record<AgentLane, string> = {
@@ -62,6 +64,8 @@ const LANE_HELP: Record<AgentLane, string> = {
     "Convierte demanda SEO en briefs, mejoras o borradores revisables.",
   content_curator:
     "Valida evidencia, riesgos y si una propuesta puede pasar a Council.",
+  media:
+    "Verifica imagenes reales, licencia/provenance y slots necesarios para traffic_ready.",
 };
 
 const STATUS_LABELS: Record<string, string> = {

--- a/app/dashboard/[websiteId]/growth/workboard/page.tsx
+++ b/app/dashboard/[websiteId]/growth/workboard/page.tsx
@@ -26,6 +26,7 @@ const LANE_LABELS: Record<AgentLane, string> = {
   transcreation: "Transcreación",
   content_creator: "Creación de contenido",
   content_curator: "Curaduría de contenido",
+  media: "Media",
 };
 
 const SearchParamsSchema = z.object({

--- a/app/dashboard/[websiteId]/growth/workboard/workboard-client.tsx
+++ b/app/dashboard/[websiteId]/growth/workboard/workboard-client.tsx
@@ -46,6 +46,7 @@ const LANE_LABELS: Record<AgentLane, string> = {
   transcreation: "Transcreación",
   content_creator: "Creación de contenido",
   content_curator: "Curaduría de contenido",
+  media: "Media",
 };
 
 const WORK_TYPE_LABELS: Record<string, string> = {

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -13,6 +13,8 @@ Latest update: 2026-05-01 (SPEC_GROWTH_OS_SYMPHONY_ORCHESTRATOR audit revision f
 
 Latest spec addition: 2026-05-15 - [[SPEC_PUBLIC_TEMPLATE_SYSTEMIC_FIX_V1]] defines the ColombiaTours public-template systemic fix for PT-BR blog routing, reciprocal hreflang, localized custom pages, BlogPosting/FAQPage JSON-LD, and non-ES template chrome.
 
+Latest ops addition: 2026-05-20 - [[growth-media-pack-real-image-sourcing]] defines the SEO360 MediaPack lane for real-image sourcing, legal/provenance boundaries, reference-only visual briefs, AI-assisted reality preservation, and traffic_ready/hold_scale gating.
+
 Latest spec addition: 2026-05-15 - [[SPEC_MEDIA_ASSET_LIBRARY_V1]] defines Studio as the primary tenant Media Asset Library surface over `public.media_assets`, with Flutter registration/reuse as the cross-repo v1 contract.
 
 Latest spec addition: 2026-05-14 - [[SPEC_GROWTH_OS_PROVIDER_PROFILE_ARCHITECTURE_V2]] redirects Epic #521 into the Neo/Hermes Provider Profile Beta: GitHub remains planning SSOT, Supabase remains operational SSOT, Neo/Hermes acts as architect-orchestrator, provider profiles own API access, workers consume context packets/facts, and paid media profiles enter the same read-only/freshness-governed architecture.
@@ -209,6 +211,7 @@ Feature requests formalized. Status tracked inline. GitHub Issues = source of tr
 | [[growth-provider-profiles]]             | [file](./ops/growth-provider-profiles.md)             | Epic #310 Max Performance provider profiles: DataForSEO, GSC, GA4, tracking, AI/GEO, translation cadence, paid-call approvals and joint facts.          |
 | [[growth-ai-search-geo-profile]]         | [file](./ops/growth-ai-search-geo-profile.md)         | Epic #310 AI Search / GEO profile: crawler readiness, DataForSEO AI Optimization, normalized visibility facts and `ai_search` inventory rows.           |
 | [[growth-translation-quality-gate]]      | [file](./ops/growth-translation-quality-gate.md)      | Epic #310 transcreation lane gate: translation quality checks, QA findings, Growth backlog content status and Council approval rules.                   |
+| [[growth-media-pack-real-image-sourcing]] | [file](./ops/growth-media-pack-real-image-sourcing.md) | SMART SEO / SEO360 media lane runbook: real-image sourcing hierarchy, MediaPack schema, legal reference-only boundaries and traffic_ready gating.        |
 | [[growth-data-automation-cadence]]       | [file](./ops/growth-data-automation-cadence.md)       | Epic #310 Max Performance automation contract: raw/cache -> normalized facts -> joint facts -> `growth_inventory` -> Council, health and backlog rules. |
 | [[growth-mass-execution-vs-experiments]] | [file](./ops/growth-mass-execution-vs-experiments.md) | Epic #310 operating runbook: execute large backlog batches while Council keeps only five active measurable readouts.                                    |
 | [[waflow-crm-lifecycle-parity]]          | [file](./ops/waflow-crm-lifecycle-parity.md)          | Epic #310/#322 WAFlow parity and shared CRM lifecycle contract: WAFlow -> `requests` -> Chatwoot -> itinerary -> `funnel_events`.                       |

--- a/docs/ops/growth-data-automation-cadence.md
+++ b/docs/ops/growth-data-automation-cadence.md
@@ -65,6 +65,7 @@ GA4 and translation quality.
 | Tracking facts                             | Continuous ingestion where webhooks exist; weekly smoke.     | Automatic where configured.                                                          | `funnel_events`, `meta_conversion_events`, conversion status in `growth_inventory`.                                                       |
 | AI Search/GEO `geo_ai_visibility_v1`       | Monthly baseline; weekly only for active AI/GEO experiments. | Manual approval for pilot/full run; automatic follow-up after start.                 | `seo_ai_visibility_runs`, `seo_ai_visibility_facts`, `growth_inventory` rows with `channel = 'ai_search'`.                                |
 | Translation quality gate                   | Before target-locale content scale or Council approval.      | Automatic scoring can run after draft/review; publish still requires human approval. | `seo_translation_quality_checks`, `seo_translation_qa_findings`, content status rows in `growth_inventory`.                               |
+| MediaPack real-image sourcing              | Before SEO360 content is marked `traffic_ready`, and whenever image benchmarks exceed approved assets. | Media lane can prepare packs automatically from first-party/approved sources; reference-only discovery never publishes without license/permission or human legal exception. | `GrowthMediaPackSchema` artifacts, `media_assets` refs, MediaPack readiness (`traffic_ready` / `hold_scale`) for content QA and publisher gates. |
 
 ## Paid-Call Approval Rules
 

--- a/docs/ops/growth-media-pack-real-image-sourcing.md
+++ b/docs/ops/growth-media-pack-real-image-sourcing.md
@@ -1,0 +1,113 @@
+# Growth MediaPack real-image sourcing lane
+
+Status: v1 contract implemented in `@bukeer/website-contract`
+Owner lane: `growth-media-agent`
+Applies to: ColombiaTours SMART SEO / SEO360 pages, blogs, products, and target-market transcreation
+
+## Why this exists
+
+Content workers must not invent destination proof images or count generic/unsafe images toward traffic readiness. If SEO360 benchmarking says a San Andrés page needs 25 images, the content worker requests a governed MediaPack from the media lane. The MediaPack can contain 25 target slots, but each slot is explicitly `filled`, `missing`, or `needs_human_asset`.
+
+This keeps the Growth OS measurement language honest:
+
+- `technical_published`: a URL can exist and render.
+- `traffic_ready`: the URL has enough approved evidence, including approved MediaPack coverage, to receive SEO traffic.
+- `hold_scale`: the URL must not be scaled because evidence is incomplete, unsafe, or legally blocked.
+
+## Request contract
+
+A content/transcreation worker sends the media lane the SEO360 ContextPacket plus media requirements:
+
+- keyword and target market;
+- canonical URL / destination entities;
+- section plan;
+- target image count from the benchmark;
+- required visual intents per section;
+- any known first-party asset refs or operator/customer-approved asset leads.
+
+The request owner remains the content worker, but image sourcing and publishability decisions are owned by `growth-media-agent`.
+
+## Source hierarchy
+
+Use sources in this order:
+
+1. First-party ColombiaTours / Supabase `media_assets` library and existing CMS assets.
+2. Internal operator photos, WhatsApp assets, or customer-approved assets when permission is explicit.
+3. Licensed external sources with commercial-use proof, such as Unsplash/Pexels or vendor libraries, only when first-party coverage is insufficient.
+4. Google Places, Google Images, SerpAPI, Tripadvisor/reviews, and similar sources only as discovery/provenance candidates or non-published visual briefs. They are not publishable unless permission/license is explicit.
+5. AI generation is prohibited for deceptive destination/travel proof photos. AI is allowed only for non-deceptive editing, crop, color, format, or clean illustrative imagery that passes disclosure and destination-truth gates.
+
+Important legal boundary: editing or AI-transforming a copyrighted Google/Tripadvisor/Places image does not remove the licensing requirement. Reference-only pixels must not become the production base.
+
+## MediaPack slot fields
+
+Each slot records:
+
+- `slot_index`
+- `section_key`
+- `visual_intent`
+- `status`: `filled`, `missing`, `needs_human_asset`
+- `image_url`
+- `source_url` / `source_ref`
+- `license_status`
+- `provenance_type`
+- `destination_match`
+- `section_match`
+- `alt`
+- `caption`
+- `dimensions`
+- `hash`
+- `duplicate_check`
+- `visual_quality_score`
+- `reference_only_visual_brief`
+- `publishable_base_required`
+- `generated_or_edited_final`
+- `reality_preservation_pass`
+
+The Zod schema lives at `packages/website-contract/src/schemas/growth-media-pack.ts` and is exported from `@bukeer/website-contract` as `GrowthMediaPackSchema` plus `evaluateGrowthMediaPackReadiness()`.
+
+## Readiness rules
+
+The evaluator returns `traffic_ready` only when:
+
+- filled approved slots meet `target_image_count`, or a human-approved exception explicitly lowers the required count;
+- each filled slot has an approved/permissioned/commercial license or human legal exception;
+- discovery-only provenance is not counted as publishable;
+- destination and section match both pass;
+- duplicate check is `unique`;
+- visual quality score is at least 70;
+- AI-assisted final images use a publishable base and pass reality preservation.
+
+The evaluator returns `hold_scale` when slots are missing, need human assets, rely on reference-only discovery sources, or require a publishable base.
+
+## Google/review reference-only flow (Option B)
+
+Allowed:
+
+1. Temporarily download or inspect a Google Places / Reviews / Tripadvisor image as a non-published factual reference.
+2. Extract factual observations into `reference_only_visual_brief`, such as shoreline layout, water color, visible skyline, or landmark relationships.
+3. Require a separate publishable base: first-party, licensed, permissioned, or clean AI illustrative material.
+4. Generate/edit the final asset from the publishable base, not from reference-only pixels.
+5. Validate destination truth against the visual brief and set `reality_preservation_pass` only when no landmarks/features were hallucinated or moved.
+6. Label the result as AI-assisted when applicable via `generated_or_edited_final.disclosure_label`.
+
+Rejected:
+
+- direct publishing of Google/Tripadvisor/Places pixels without license proof;
+- AI derivatives where the base image has only `reference_only` license status;
+- edits that add impossible landmarks, wrong beaches, wrong city skylines, fake wildlife, fake rooms, or other reality-changing details;
+- inflated image counts from unlicensed, generic, duplicate, or wrong-destination images.
+
+## Publisher rule
+
+Publishers only publish images from an approved MediaPack. If a content item has raw image URLs outside the MediaPack, those URLs do not count toward `traffic_ready` and should be treated as legacy/unverified until registered or backfilled through `media_assets` and a MediaPack.
+
+## QA fixtures covered
+
+`__tests__/schema/growth-media-pack.test.ts` covers:
+
+- PASS fixture with 25 valid slots;
+- HOLD fixture with 4 valid slots and 21 missing slots;
+- HOLD/reject fixture with Google candidates but no license proof;
+- reference-image-to-AI-brief flow with `publishable_base_required`;
+- rejection of reality-changing or reference-pixel-based AI-assisted derivatives.

--- a/docs/specs/SPEC_GROWTH_OS_AGENT_LANES.md
+++ b/docs/specs/SPEC_GROWTH_OS_AGENT_LANES.md
@@ -26,8 +26,9 @@ the operational Growth SSOT.
 
 ## Agent Lanes V1
 
-The approved v1 model uses five core lanes. DataForSEO, GSC, GA4, tracking,
-browser and Playwright are shared tools, not independent agents.
+The approved v1 model uses five core lanes plus the governed SEO360 media lane.
+DataForSEO, GSC, GA4, tracking, browser and Playwright are shared tools, not
+independent agents.
 
 | Lane                                     | Primary purpose                                                                        | Inputs                                                                           | Writes                                                               | Owner issues                |
 | ---------------------------------------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | -------------------------------------------------------------------- | --------------------------- |
@@ -36,6 +37,7 @@ browser and Playwright are shared tools, not independent agents.
 | Transcreation Growth Agent               | Manage locale expansion as transcreation, not literal translation.                     | GSC/GA4 market facts, SERP intent, `seo_transcreation_jobs`, quality checks.     | transcreation jobs, quality findings, locale backlog status.         | #314, #315, #316, #367      |
 | Content Creator Agent                    | Generate briefs, content updates and new content candidates with measurable baselines. | GSC/GA4 facts, DataForSEO Labs/SERP/Content Analysis, existing briefs.           | `growth_content_briefs`, draft content tasks, source refs.           | #314-#320, #368, #369       |
 | Content Curator + Council Operator Agent | Review content quality, promote backlog, prepare Council and enforce experiment rules. | briefs, tasks, backlog items, experiments, QA results.                           | review decisions, Council packets, experiment status.                | #321, #311, #399            |
+| Growth Media Agent                       | Source real, publishable image packs for SEO360; block unlicensed/generic/wrong-destination visuals. | ContextPacket SEO360, section plans, target image counts, visual intents, `media_assets`, operator/customer-approved leads, licensed-source evidence. | `MediaPack` artifacts, media sourcing decisions, readiness blockers, approved asset refs. | media lane / ADR-028        |
 
 ## Project Preferences And 2026 Content Standard
 
@@ -192,6 +194,25 @@ Rules:
   batches can be executed in bulk without becoming experiments.
 - Required evidence: review decision, reasons, accepted/rejected risks,
   experiment status and Council packet artifact.
+
+### Growth Media Agent
+
+- Owns SEO360 real-image sourcing and returns a `MediaPack` instead of letting
+  content workers invent images or blindly count raw image URLs.
+- Uses the source hierarchy: first-party `media_assets` / CMS assets, operator
+  or customer-approved assets, then commercially licensed external sources when
+  first-party coverage is insufficient.
+- Treats Google Images, Google Places, SerpAPI and review photos as discovery or
+  non-published visual briefs only unless license/permission is explicit.
+- Prohibits AI generation for deceptive destination proof photos. AI-assisted
+  editing is allowed only on publishable base material, with disclosure and
+  destination-truth/reality-preservation evidence.
+- Returns every benchmark slot as `filled`, `missing` or `needs_human_asset` so
+  a 25-image benchmark cannot be inflated by generic, duplicate, unlicensed or
+  wrong-destination images.
+- Required evidence: source/provenance ref, license status, destination/section
+  match, alt/caption, dimensions/hash, duplicate check, quality score and
+  readiness verdict (`traffic_ready` or `hold_scale`).
 
 ## Tool And Permission Matrix
 

--- a/lib/growth/agentic/orchestrator-brain.ts
+++ b/lib/growth/agentic/orchestrator-brain.ts
@@ -927,6 +927,7 @@ function freshSignals(context: JsonRecord, lane: AgentLane | null = null, limit 
     transcreation: /translation|hreflang|locale|transcreation/i,
     content_creator: /keyword|gsc|query|serp|content|internal_link/i,
     content_curator: /decay|refresh|stale|content/i,
+    media: /media|image|asset|photo|license|provenance|alt_text/i,
     orchestrator: /funnel|lead|crm|conversion/i,
   };
   const matched = signals.filter((signal) =>

--- a/lib/growth/console/queries-backlog.ts
+++ b/lib/growth/console/queries-backlog.ts
@@ -146,6 +146,7 @@ const EMPTY_LANE_TOTALS: Record<AgentLane, number> = {
   transcreation: 0,
   content_creator: 0,
   content_curator: 0,
+  media: 0,
 };
 
 const EMPTY_STATUS_TOTALS: Record<BacklogStatusBucket, number> = {

--- a/lib/growth/console/queries-ceo-cockpit.ts
+++ b/lib/growth/console/queries-ceo-cockpit.ts
@@ -16,6 +16,7 @@ const LANE_LABELS: Record<AgentLane, string> = {
   transcreation: "Transcreation",
   content_creator: "Content Creator",
   content_curator: "Content Curator",
+  media: "Media",
 };
 
 const LANE_MISSIONS: Record<AgentLane, string> = {
@@ -24,6 +25,7 @@ const LANE_MISSIONS: Record<AgentLane, string> = {
   transcreation: "Adapta contenido por mercado sin romper calidad locale.",
   content_creator: "Convierte evidencia en contenido organico publicable.",
   content_curator: "Protege calidad, Council y aprendizajes aprobados.",
+  media: "Verifica imagenes reales, licencias y readiness de MediaPack.",
 };
 
 export type AgentCompanyStatus =

--- a/lib/growth/console/queries-workboard.ts
+++ b/lib/growth/console/queries-workboard.ts
@@ -173,6 +173,7 @@ const AGENT_PROFILE_BY_LANE: Record<AgentLane, string> = {
   transcreation: "Transcreation Agent",
   content_creator: "Content Creator",
   content_curator: "Curator",
+  media: "Media Agent",
 };
 
 const DEFAULT_CAPABILITIES_BY_LANE: Record<AgentLane, string[]> = {
@@ -181,6 +182,7 @@ const DEFAULT_CAPABILITIES_BY_LANE: Record<AgentLane, string[]> = {
   transcreation: ["adaptación por mercado", "QA de idioma", "tono de marca"],
   content_creator: ["briefs", "drafts", "previews", "contenido SEO"],
   content_curator: ["calidad editorial", "evidencia", "riesgo", "Council"],
+  media: ["imagenes reales", "licencias", "provenance", "alt text"],
 };
 
 const STALE_RUNTIME_MS = 60 * 60 * 1000;

--- a/packages/website-contract/src/index.ts
+++ b/packages/website-contract/src/index.ts
@@ -800,6 +800,26 @@ export {
   GrowthProviderContextPacketSchema,
   GrowthProviderContextPacketInputSchema,
 } from './schemas/growth-provider-context-packet';
+
+export {
+  GrowthMediaPackVersionSchema,
+  GrowthMediaPackSlotStatusSchema,
+  GrowthMediaLicenseStatusSchema,
+  GrowthMediaProvenanceTypeSchema,
+  GrowthMediaMatchStatusSchema,
+  GrowthMediaDuplicateCheckSchema,
+  GrowthMediaPackReadinessStatusSchema,
+  GrowthMediaVisualIntentSchema,
+  GrowthMediaDimensionsSchema,
+  GrowthMediaReferenceOnlyVisualBriefSchema,
+  GrowthMediaGeneratedOrEditedFinalSchema,
+  GrowthMediaPackSlotSchema,
+  GrowthMediaHumanApprovedExceptionSchema,
+  GrowthMediaPackSchema,
+  GrowthMediaPackReadinessSchema,
+  GrowthMediaPackInputSchema,
+  evaluateGrowthMediaPackReadiness,
+} from './schemas/growth-media-pack';
 export type {
   GrowthProviderContextPacketVersion,
   GrowthProviderContextPacketStatus,
@@ -816,6 +836,25 @@ export type {
   GrowthProviderContextPacket,
   GrowthProviderContextPacketInput,
 } from './schemas/growth-provider-context-packet';
+
+export type {
+  GrowthMediaPackVersion,
+  GrowthMediaPackSlotStatus,
+  GrowthMediaLicenseStatus,
+  GrowthMediaProvenanceType,
+  GrowthMediaMatchStatus,
+  GrowthMediaDuplicateCheck,
+  GrowthMediaPackReadinessStatus,
+  GrowthMediaVisualIntent,
+  GrowthMediaDimensions,
+  GrowthMediaReferenceOnlyVisualBrief,
+  GrowthMediaGeneratedOrEditedFinal,
+  GrowthMediaPackSlot,
+  GrowthMediaHumanApprovedException,
+  GrowthMediaPack,
+  GrowthMediaPackReadiness,
+  GrowthMediaPackInput,
+} from './schemas/growth-media-pack';
 
 export {
   GrowthRuntimeCycleStatusSchema,

--- a/packages/website-contract/src/schemas/growth-agent-definitions.ts
+++ b/packages/website-contract/src/schemas/growth-agent-definitions.ts
@@ -24,10 +24,10 @@ import { GrowthTenantScopeSchema } from './growth-attribution';
  */
 
 /**
- * Canonical agent lanes per SPEC_GROWTH_OS_AGENT_LANES.md §"Agent Lanes V1".
- * Five lanes only. Gating action classes (paid mutation, experiment activation,
- * publish, transcreation merge) are NOT lanes — they are action policies
- * applied across lanes by the lane-level autonomy gate (#408).
+ * Canonical agent lanes per SPEC_GROWTH_OS_AGENT_LANES.md §"Agent Lanes V1"
+ * plus the governed SEO360 media lane. Gating action classes (paid mutation,
+ * experiment activation, publish, transcreation merge) are NOT lanes — they are
+ * action policies applied across lanes by the lane-level autonomy gate (#408).
  */
 export const AgentLaneSchema = z.enum([
   'orchestrator',
@@ -35,6 +35,7 @@ export const AgentLaneSchema = z.enum([
   'transcreation',
   'content_creator',
   'content_curator',
+  'media',
 ]);
 export type AgentLane = z.infer<typeof AgentLaneSchema>;
 

--- a/packages/website-contract/src/schemas/growth-media-pack.ts
+++ b/packages/website-contract/src/schemas/growth-media-pack.ts
@@ -1,0 +1,374 @@
+import { z } from 'zod';
+
+import { GrowthTenantScopeSchema } from './growth-attribution';
+
+const DateTimeSchema = z.string().datetime();
+const NullableUrlSchema = z.string().url().max(2048).nullable().default(null);
+const NullableShortStringSchema = z.string().min(1).max(500).nullable().default(null);
+
+export const GrowthMediaPackVersionSchema = z.literal('growth-media-pack-v1');
+export type GrowthMediaPackVersion = z.infer<typeof GrowthMediaPackVersionSchema>;
+
+export const GrowthMediaPackSlotStatusSchema = z.enum([
+  'filled',
+  'missing',
+  'needs_human_asset',
+]);
+export type GrowthMediaPackSlotStatus = z.infer<
+  typeof GrowthMediaPackSlotStatusSchema
+>;
+
+export const GrowthMediaLicenseStatusSchema = z.enum([
+  'approved',
+  'permissioned',
+  'commercial_license_verified',
+  'human_legal_exception',
+  'reference_only',
+  'unverified',
+  'missing',
+  'rejected',
+]);
+export type GrowthMediaLicenseStatus = z.infer<
+  typeof GrowthMediaLicenseStatusSchema
+>;
+
+export const GrowthMediaProvenanceTypeSchema = z.enum([
+  'first_party_media_library',
+  'existing_cms_asset',
+  'operator_photo',
+  'customer_approved_asset',
+  'licensed_external',
+  'google_places_discovery',
+  'serpapi_discovery',
+  'reviews_discovery',
+  'reference_only_visual_brief',
+  'ai_assisted_real_photo_derivative',
+  'clean_ai_illustrative',
+  'not_sourced',
+]);
+export type GrowthMediaProvenanceType = z.infer<
+  typeof GrowthMediaProvenanceTypeSchema
+>;
+
+export const GrowthMediaMatchStatusSchema = z.enum([
+  'pass',
+  'watch',
+  'fail',
+  'unknown',
+]);
+export type GrowthMediaMatchStatus = z.infer<typeof GrowthMediaMatchStatusSchema>;
+
+export const GrowthMediaDuplicateCheckSchema = z.enum([
+  'unique',
+  'duplicate',
+  'near_duplicate',
+  'not_checked',
+]);
+export type GrowthMediaDuplicateCheck = z.infer<
+  typeof GrowthMediaDuplicateCheckSchema
+>;
+
+export const GrowthMediaPackReadinessStatusSchema = z.enum([
+  'technical_published',
+  'traffic_ready',
+  'hold_scale',
+]);
+export type GrowthMediaPackReadinessStatus = z.infer<
+  typeof GrowthMediaPackReadinessStatusSchema
+>;
+
+export const GrowthMediaVisualIntentSchema = z.object({
+  section_key: z.string().min(1).max(120),
+  visual_intent: z.string().min(1).max(1000),
+  required_count: z.number().int().min(1).max(100).default(1),
+});
+export type GrowthMediaVisualIntent = z.infer<
+  typeof GrowthMediaVisualIntentSchema
+>;
+
+export const GrowthMediaDimensionsSchema = z.object({
+  width: z.number().int().min(1).max(20000),
+  height: z.number().int().min(1).max(20000),
+});
+export type GrowthMediaDimensions = z.infer<typeof GrowthMediaDimensionsSchema>;
+
+export const GrowthMediaReferenceOnlyVisualBriefSchema = z.object({
+  allowed: z.literal(true),
+  non_publishable_source_url: z.string().url().max(2048),
+  factual_observations: z.array(z.string().min(1).max(500)).min(1).max(30),
+});
+export type GrowthMediaReferenceOnlyVisualBrief = z.infer<
+  typeof GrowthMediaReferenceOnlyVisualBriefSchema
+>;
+
+export const GrowthMediaGeneratedOrEditedFinalSchema = z.object({
+  model: z.string().min(1).max(200).nullable().default(null),
+  base_provenance_type: GrowthMediaProvenanceTypeSchema,
+  base_license_status: GrowthMediaLicenseStatusSchema,
+  editing_actions: z.array(z.string().min(1).max(500)).default([]),
+  disclosure_label: z.string().min(1).max(200),
+});
+export type GrowthMediaGeneratedOrEditedFinal = z.infer<
+  typeof GrowthMediaGeneratedOrEditedFinalSchema
+>;
+
+export const GrowthMediaPackSlotSchema = z
+  .object({
+    slot_index: z.number().int().min(1).max(500),
+    section_key: z.string().min(1).max(120),
+    visual_intent: z.string().min(1).max(1000),
+    status: GrowthMediaPackSlotStatusSchema,
+
+    image_url: NullableUrlSchema,
+    source_url: NullableUrlSchema,
+    source_ref: NullableShortStringSchema,
+    license_status: GrowthMediaLicenseStatusSchema,
+    provenance_type: GrowthMediaProvenanceTypeSchema,
+
+    destination_match: GrowthMediaMatchStatusSchema,
+    section_match: GrowthMediaMatchStatusSchema,
+    alt: z.string().min(1).max(300).nullable().default(null),
+    caption: z.string().min(1).max(500).nullable().default(null),
+    dimensions: GrowthMediaDimensionsSchema.nullable().default(null),
+    hash: z
+      .string()
+      .regex(/^sha256:[a-f0-9]{64}$/)
+      .nullable()
+      .default(null),
+    duplicate_check: GrowthMediaDuplicateCheckSchema,
+    visual_quality_score: z.number().int().min(0).max(100).nullable().default(null),
+
+    reference_only_visual_brief:
+      GrowthMediaReferenceOnlyVisualBriefSchema.nullable().default(null),
+    publishable_base_required: z.boolean().default(false),
+    generated_or_edited_final:
+      GrowthMediaGeneratedOrEditedFinalSchema.nullable().default(null),
+    reality_preservation_pass: z.boolean().default(false),
+  })
+  .superRefine((slot, ctx) => {
+    const publishableLicenseStatuses = new Set<GrowthMediaLicenseStatus>([
+      'approved',
+      'permissioned',
+      'commercial_license_verified',
+      'human_legal_exception',
+    ]);
+    const discoveryOnlyProvenance = new Set<GrowthMediaProvenanceType>([
+      'google_places_discovery',
+      'serpapi_discovery',
+      'reviews_discovery',
+      'reference_only_visual_brief',
+    ]);
+
+    if (slot.status === 'filled') {
+      if (!slot.image_url) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['image_url'],
+          message: 'filled MediaPack slots must include image_url.',
+        });
+      }
+      if (!slot.source_url && !slot.source_ref) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['source_ref'],
+          message: 'filled MediaPack slots must include source_url or source_ref.',
+        });
+      }
+      if (!publishableLicenseStatuses.has(slot.license_status)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['license_status'],
+          message:
+            'filled MediaPack slots require approved, permissioned, commercial_license_verified, or human_legal_exception license status.',
+        });
+      }
+      if (discoveryOnlyProvenance.has(slot.provenance_type)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['provenance_type'],
+          message:
+            'Google/SerpAPI/review discovery images are reference-only and cannot be filled publishable MediaPack slots.',
+        });
+      }
+      if (slot.destination_match !== 'pass' || slot.section_match !== 'pass') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['destination_match'],
+          message: 'filled MediaPack slots must pass destination and section match.',
+        });
+      }
+      if (slot.duplicate_check !== 'unique') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['duplicate_check'],
+          message: 'filled MediaPack slots must pass duplicate check as unique.',
+        });
+      }
+      if (slot.visual_quality_score == null || slot.visual_quality_score < 70) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['visual_quality_score'],
+          message: 'filled MediaPack slots require visual_quality_score >= 70.',
+        });
+      }
+    }
+
+    if (slot.license_status === 'reference_only') {
+      if (!slot.reference_only_visual_brief) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['reference_only_visual_brief'],
+          message:
+            'reference_only assets must be stored only as a non-published visual brief.',
+        });
+      }
+      if (!slot.publishable_base_required) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['publishable_base_required'],
+          message:
+            'reference_only assets must require a separate publishable base.',
+        });
+      }
+    }
+
+    if (slot.generated_or_edited_final) {
+      const baseLicense = slot.generated_or_edited_final.base_license_status;
+      const baseProvenance = slot.generated_or_edited_final.base_provenance_type;
+      if (!publishableLicenseStatuses.has(baseLicense)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['generated_or_edited_final', 'base_license_status'],
+          message:
+            'AI-assisted real-photo derivatives require a publishable base license; reference-only pixels are not enough.',
+        });
+      }
+      if (discoveryOnlyProvenance.has(baseProvenance)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['generated_or_edited_final', 'base_provenance_type'],
+          message:
+            'AI-assisted final images cannot be based on Google/SerpAPI/review reference-only pixels.',
+        });
+      }
+      if (!slot.reality_preservation_pass) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['reality_preservation_pass'],
+          message:
+            'AI-assisted final images must pass destination-truth/reality preservation.',
+        });
+      }
+    }
+  });
+export type GrowthMediaPackSlot = z.infer<typeof GrowthMediaPackSlotSchema>;
+
+export const GrowthMediaHumanApprovedExceptionSchema = z.object({
+  approved_by: z.string().min(1).max(200),
+  approved_at: DateTimeSchema,
+  reason: z.string().min(1).max(1000),
+  minimum_publishable_slots: z.number().int().min(0).max(500),
+});
+export type GrowthMediaHumanApprovedException = z.infer<
+  typeof GrowthMediaHumanApprovedExceptionSchema
+>;
+
+export const GrowthMediaPackSchema = GrowthTenantScopeSchema.extend({
+  pack_version: GrowthMediaPackVersionSchema,
+  requested_by: z.string().min(1).max(120),
+  owned_by_lane: z.literal('growth-media-agent'),
+  canonical_url: z.string().url().max(2048),
+  keyword: z.string().min(1).max(300),
+  destination_entities: z.array(z.string().min(1).max(200)).default([]),
+  target_image_count: z.number().int().min(0).max(500),
+  required_visual_intents: z.array(GrowthMediaVisualIntentSchema).default([]),
+  slots: z.array(GrowthMediaPackSlotSchema).max(500),
+  human_approved_exception:
+    GrowthMediaHumanApprovedExceptionSchema.nullable().default(null),
+  generated_at: DateTimeSchema,
+}).superRefine((pack, ctx) => {
+  if (pack.slots.length !== pack.target_image_count) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['slots'],
+      message:
+        'MediaPack must include one slot per target_image_count; unfilled benchmark slots are explicit missing or needs_human_asset rows.',
+    });
+  }
+
+  const slotIndexes = new Set<number>();
+  for (const slot of pack.slots) {
+    if (slotIndexes.has(slot.slot_index)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['slots'],
+        message: `Duplicate MediaPack slot_index ${slot.slot_index}.`,
+      });
+    }
+    slotIndexes.add(slot.slot_index);
+  }
+});
+export type GrowthMediaPack = z.infer<typeof GrowthMediaPackSchema>;
+
+export const GrowthMediaPackReadinessSchema = z.object({
+  status: GrowthMediaPackReadinessStatusSchema,
+  target_image_count: z.number().int().min(0).max(500),
+  filled_approved_slots: z.number().int().min(0).max(500),
+  missing_slots: z.number().int().min(0).max(500),
+  needs_human_asset_slots: z.number().int().min(0).max(500),
+  blockers: z.array(z.string().min(1).max(200)).default([]),
+});
+export type GrowthMediaPackReadiness = z.infer<
+  typeof GrowthMediaPackReadinessSchema
+>;
+
+export function evaluateGrowthMediaPackReadiness(
+  pack: GrowthMediaPack,
+): GrowthMediaPackReadiness {
+  const publishableLicenseStatuses = new Set<GrowthMediaLicenseStatus>([
+    'approved',
+    'permissioned',
+    'commercial_license_verified',
+    'human_legal_exception',
+  ]);
+  const filledApprovedSlots = pack.slots.filter(
+    (slot) => slot.status === 'filled' && publishableLicenseStatuses.has(slot.license_status),
+  ).length;
+  const missingSlots = pack.slots.filter((slot) => slot.status === 'missing').length;
+  const needsHumanAssetSlots = pack.slots.filter(
+    (slot) => slot.status === 'needs_human_asset',
+  ).length;
+  const blockers = new Set<string>();
+
+  if (missingSlots > 0) {
+    blockers.add('missing_slots');
+  }
+  if (needsHumanAssetSlots > 0) {
+    blockers.add('needs_human_asset');
+  }
+  if (pack.slots.some((slot) => slot.publishable_base_required)) {
+    blockers.add('publishable_base_required');
+  }
+  if (pack.slots.some((slot) => slot.license_status === 'reference_only')) {
+    blockers.add('reference_only_not_publishable');
+  }
+
+  const exceptionMinimum = pack.human_approved_exception?.minimum_publishable_slots;
+  const exceptionAllowsTrafficReady =
+    typeof exceptionMinimum === 'number' && filledApprovedSlots >= exceptionMinimum;
+  const trafficReady =
+    blockers.size === 0 &&
+    (filledApprovedSlots >= pack.target_image_count || exceptionAllowsTrafficReady);
+
+  return GrowthMediaPackReadinessSchema.parse({
+    status: trafficReady ? 'traffic_ready' : 'hold_scale',
+    target_image_count: pack.target_image_count,
+    filled_approved_slots: filledApprovedSlots,
+    missing_slots: missingSlots,
+    needs_human_asset_slots: needsHumanAssetSlots,
+    blockers: trafficReady ? [] : Array.from(blockers),
+  });
+}
+
+export const GrowthMediaPackInputSchema = GrowthMediaPackSchema;
+export type GrowthMediaPackInput = z.input<typeof GrowthMediaPackSchema>;

--- a/packages/website-contract/src/schemas/growth-provider-context-packet.ts
+++ b/packages/website-contract/src/schemas/growth-provider-context-packet.ts
@@ -38,6 +38,7 @@ export const GrowthProviderWorkerLaneSchema = z
     'technical',
     'cro',
     'campaign_optimizer',
+    'media',
     'all',
   ])
   .or(z.string().min(1).max(80));


### PR DESCRIPTION
## Summary
- Add GrowthMediaPack v1 contract for explicit real-image slots, provenance, license state, destination/section match, duplicate checks, and readiness evaluation.
- Add media as a governed Growth OS lane across contracts, dashboard/workboard/backlog/cockpit UI, and orchestrator signal matching.
- Document real-image sourcing runbook and SEO360 traffic_ready gating expectations.

## Test Plan
- npm test -- __tests__/schema/growth-media-pack.test.ts
- npm run typecheck
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key SUPABASE_SERVICE_ROLE_KEY=dummy-service-role-key npm run build:worker

Note: build:worker also passes with dummy non-secret Supabase env values; static generation logs expected ENOTFOUND warnings against example.supabase.co but exits 0.