### PR TITLE
fix: stabilize localized canonical hreflang routes

### DIFF
--- a/__tests__/lib/seo/public-metadata-locale.test.ts
+++ b/__tests__/lib/seo/public-metadata-locale.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildLocaleAwareAlternateLanguages,
   isValidPublicLocale,
   publicLocaleSchema,
 } from '@/lib/seo/public-metadata';
@@ -29,5 +30,25 @@ describe('publicLocaleSchema (#208)', () => {
   it('publicLocaleSchema.safeParse surfaces the same decision', () => {
     expect(publicLocaleSchema.safeParse('es-CO').success).toBe(true);
     expect(publicLocaleSchema.safeParse('not-a-locale').success).toBe(false);
+  });
+});
+
+describe('buildLocaleAwareAlternateLanguages (#208)', () => {
+  it('keeps the current resolved locale in hreflang alternates when translated locales are sparse', () => {
+    const languages = buildLocaleAwareAlternateLanguages(
+      'https://colombiatours.travel',
+      '/paquetes/amazon-adventure',
+      {
+        defaultLocale: 'es-CO',
+        supportedLocales: ['es-CO', 'en-US', 'pt-BR'],
+        resolvedLocale: 'pt-BR',
+      },
+      { translatedLocales: ['en-US'] },
+    );
+
+    expect(languages['es-CO']).toBe('https://colombiatours.travel/paquetes/amazon-adventure');
+    expect(languages['en-US']).toBe('https://colombiatours.travel/en/packages/amazon-adventure');
+    expect(languages['pt-BR']).toBe('https://colombiatours.travel/pt-br/pacotes/amazon-adventure');
+    expect(languages['x-default']).toBe('https://colombiatours.travel/paquetes/amazon-adventure');
   });
 });

--- a/__tests__/middleware/locale-site-route.test.ts
+++ b/__tests__/middleware/locale-site-route.test.ts
@@ -144,6 +144,21 @@ describe('locale resolution for /site/<sub>/<lang>/... (contract)', () => {
     expect(resolution.canonicalPathname).toBe('/terms');
   });
 
+  it('decodes percent-encoded UTF-8 slugs before middleware canonicalization', () => {
+    const internal = parseInternalSitePath(
+      '/site/colombiatours/en/packages/medell%C3%ADn-city-tour',
+    );
+    const resolution = resolveLocaleFromPublicPath(
+      internal!.innerPathname,
+      localeSettings,
+    );
+
+    expect(resolution.hasLanguageSegment).toBe(true);
+    expect(resolution.resolvedLocale).toBe('en-US');
+    expect(resolution.pathnameWithoutLang).toBe('/packages/medellín-city-tour');
+    expect(resolution.canonicalPathname).toBe('/paquetes/medellín-city-tour');
+  });
+
   it('does NOT intervene when inner path is default-locale (no /<lang>/ segment)', () => {
     const internal = parseInternalSitePath(
       '/site/colombiatours/paquetes/amazon-adventure',

--- a/lib/seo/locale-routing.ts
+++ b/lib/seo/locale-routing.ts
@@ -254,10 +254,17 @@ function normalizePathname(pathname: string): string {
   if (!pathname || pathname.trim().length === 0) return '/';
   const withSlash = pathname.startsWith('/') ? pathname : `/${pathname}`;
   const compact = withSlash.replace(/\/{2,}/g, '/');
-  if (compact !== '/' && compact.endsWith('/')) {
-    return compact.slice(0, -1);
+  const decoded = (() => {
+    try {
+      return decodeURI(compact);
+    } catch {
+      return compact;
+    }
+  })();
+  if (decoded !== '/' && decoded.endsWith('/')) {
+    return decoded.slice(0, -1);
   }
-  return compact;
+  return decoded;
 }
 
 function normalizeLocaleToken(value: string): string {

--- a/lib/seo/public-metadata.ts
+++ b/lib/seo/public-metadata.ts
@@ -81,7 +81,7 @@ export function buildLocaleAwareAlternateLanguages(
   pathname: string,
   localeContext: Pick<
     PublicMetadataLocaleContext,
-    "defaultLocale" | "supportedLocales"
+    "defaultLocale" | "supportedLocales" | "resolvedLocale"
   >,
   options?: {
     translatedLocales?: string[];
@@ -95,7 +95,7 @@ export function buildLocaleAwareAlternateLanguages(
         defaultLocale: localeContext.defaultLocale,
         supportedLocales: localeContext.supportedLocales,
       },
-      options?.translatedLocales,
+      [...new Set([localeContext.resolvedLocale, ...(options?.translatedLocales || [])])],
     ),
   );
 }


### PR DESCRIPTION
Follow-up to #587 after FR verifier retry. Stabilizes localized canonical/hreflang route generation: decode percent-encoded public paths before canonicalization and preserve current resolved locale in alternate languages when translatedLocales is sparse.

Validation: targeted Jest 19/19 PASS, typecheck PASS.