### PR TITLE
fix: render localized static fallbacks

### DIFF
--- a/app/site/[subdomain]/paquetes/[slug]/page.tsx
+++ b/app/site/[subdomain]/paquetes/[slug]/page.tsx
@@ -2,11 +2,14 @@ import { Metadata } from "next";
 import { notFound, permanentRedirect, redirect } from "next/navigation";
 
 import { ProductLandingPage } from "@/components/pages/product-landing-page";
+import { StaticPage } from "@/components/pages/static-page";
 import { TemplateSlot } from "@/components/site/themes/editorial-v1/template-slot";
 import type { EditorialPackageDetailPayload } from "@/components/site/themes/editorial-v1/pages/package-detail";
 import { getBasePath, inferIsCustomDomainWebsite } from "@/lib/utils/base-path";
 import {
   getCategoryProducts,
+  getDestinations,
+  getPageBySlugForLocale,
   getLocalizedProductOverlay,
   getProductPage,
   getProductSlugRedirect,
@@ -56,6 +59,14 @@ function looksLikeLegacyId(value: string): boolean {
   );
 }
 
+function localizedStaticPackageSlug(slug: string, localizedPathname: string): string | null {
+  const path = localizedPathname.replace(/^\/+|\/+$/g, "");
+  if (!path || path === `paquetes/${slug}`) return null;
+  const parts = path.split("/");
+  if (parts.length < 2 || parts[parts.length - 1] !== slug) return null;
+  return path;
+}
+
 async function resolveLegacyPackageSlug(
   subdomain: string,
   value: string,
@@ -103,6 +114,46 @@ export async function generateMetadata({
     locale: localeContext.resolvedLocale,
   });
   if (!productPage?.product) {
+    const staticSlug = localizedStaticPackageSlug(
+      slug,
+      localeContext.localizedPathname,
+    );
+    const staticPage = staticSlug
+      ? await getPageBySlugForLocale(
+          subdomain,
+          staticSlug,
+          localeContext.resolvedLocale,
+        )
+      : null;
+    if (staticPage?.is_published) {
+      const pageTitle = normalizePublicMetadataTitle(
+        staticPage.seo_title || staticPage.title,
+        siteName,
+      );
+      const description = staticPage.seo_description || fallbackDescription;
+      const metadata: Metadata = {
+        title: pageTitle,
+        description,
+        alternates: {
+          canonical: `${baseUrl}${localeContext.localizedPathname}`,
+          languages: buildLocaleAwareAlternateLanguages(
+            baseUrl,
+            `/paquetes/${slug}`,
+            localeContext,
+          ),
+        },
+        openGraph: {
+          title: pageTitle,
+          description,
+          type: "website",
+          locale: localeToOgLocale(localeContext.resolvedLocale),
+        },
+      };
+      if (staticPage.robots_noindex) {
+        metadata.robots = { index: false, follow: true };
+      }
+      return metadata;
+    }
     return {
       title: "Paquete no encontrado",
       description: fallbackDescription,
@@ -250,6 +301,28 @@ export default async function PackageSlugPage({ params }: PackagePageProps) {
     locale: resolvedLocale,
   });
   if (!productPage?.product) {
+    const staticSlug = localizedStaticPackageSlug(
+      slug,
+      localeContext.localizedPathname,
+    );
+    const staticPage = staticSlug
+      ? await getPageBySlugForLocale(subdomain, staticSlug, resolvedLocale)
+      : null;
+    if (staticPage?.is_published) {
+      const dynamicDestinations = await getDestinations(subdomain);
+      const websiteForStaticRender = {
+        ...website,
+        defaultLocale: localeContext.defaultLocale ?? "es-CO",
+        isCustomDomain: inferIsCustomDomainWebsite(website),
+      };
+      return (
+        <StaticPage
+          website={websiteForStaticRender}
+          page={staticPage}
+          dynamicDestinations={dynamicDestinations}
+        />
+      );
+    }
     const redirectedSlug = website.account_id
       ? await getProductSlugRedirect(
           String(website.account_id),

--- a/app/site/[subdomain]/terms/page.tsx
+++ b/app/site/[subdomain]/terms/page.tsx
@@ -2,11 +2,13 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
 import { getWebsiteBySubdomain } from '@/lib/supabase/get-website';
+import { getDestinations, getPageBySlugForLocale } from '@/lib/supabase/get-pages';
 import { SafeHtml } from '@/lib/sanitize';
+import { StaticPage } from '@/components/pages/static-page';
 import { getBasePath } from '@/lib/utils/base-path';
 import { getDefaultLegalContent } from '@/lib/legal-defaults';
 import { getPublicUiMessages } from '@/lib/site/public-ui-messages';
-import { resolvePublicMetadataLocale } from '@/lib/seo/public-metadata';
+import { buildLocaleAwareAlternateLanguages, resolvePublicMetadataLocale } from '@/lib/seo/public-metadata';
 
 interface TermsPageProps {
   params: Promise<{ subdomain: string }>;
@@ -27,6 +29,34 @@ export async function generateMetadata({ params }: TermsPageProps): Promise<Meta
     ? `https://${website.custom_domain}`
     : `https://${subdomain}.bukeer.com`;
   const canonical = `${baseUrl}${localeContext.localizedPathname}`;
+  const localizedSlug = localeContext.localizedPathname.replace(/^\/+|\/+$/g, '');
+  const publishedPage = localizedSlug
+    ? await getPageBySlugForLocale(
+        subdomain,
+        localizedSlug,
+        localeContext.resolvedLocale,
+      )
+    : null;
+
+  if (publishedPage?.is_published) {
+    return {
+      title: publishedPage.seo_title || publishedPage.title,
+      description:
+        publishedPage.seo_description ||
+        `${messages.legalPages.termsDescriptionPrefix} ${siteName}`,
+      alternates: {
+        canonical,
+        languages: buildLocaleAwareAlternateLanguages(
+          baseUrl,
+          '/terms',
+          localeContext,
+        ),
+      },
+      ...(publishedPage.robots_noindex
+        ? { robots: { index: false, follow: true } }
+        : {}),
+    };
+  }
 
   return {
     title: messages.legalPages.termsTitle,
@@ -48,6 +78,26 @@ export default async function TermsPage({ params }: TermsPageProps) {
   const siteName = website.content.account?.name || website.content.siteName;
   const localeContext = await resolvePublicMetadataLocale(website, '/terms');
   const messages = getPublicUiMessages(localeContext.resolvedLocale);
+  const localizedSlug = localeContext.localizedPathname.replace(/^\/+|\/+$/g, '');
+  const publishedPage = localizedSlug
+    ? await getPageBySlugForLocale(subdomain, localizedSlug, localeContext.resolvedLocale)
+    : null;
+  if (publishedPage?.is_published) {
+    const dynamicDestinations = await getDestinations(subdomain);
+    const websiteForStaticRender = {
+      ...website,
+      defaultLocale: localeContext.defaultLocale,
+      isCustomDomain: Boolean(website.custom_domain),
+    };
+    return (
+      <StaticPage
+        website={websiteForStaticRender}
+        page={publishedPage}
+        dynamicDestinations={dynamicDestinations}
+      />
+    );
+  }
+
   const customContent = website.content.account?.legal?.terms_conditions;
 
   // If content is a URL, redirect to it


### PR DESCRIPTION
Fix remaining FR critical URL issues after verifier retries: package slug route falls back to published localized StaticPage when no product package exists; terms route renders localized CMS static page instead of default noindex legal fallback.

Validation: typecheck PASS, lint hardcoded-ui PASS, targeted locale routing/middleware tests 47 PASS, tech-validator quick PASS.