### PR TITLE
fix(seo): resolve FR terms metadata and forfait 404 semantics

### DIFF
--- a/__tests__/app/site/package-metadata-route.test.ts
+++ b/__tests__/app/site/package-metadata-route.test.ts
@@ -1,0 +1,94 @@
+import { notFound } from 'next/navigation';
+import { getProductPage, getPageBySlugForLocale } from '@/lib/supabase/get-pages';
+import { getWebsiteBySubdomain } from '@/lib/supabase/get-website';
+
+jest.mock('next/navigation', () => ({
+  notFound: jest.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+  permanentRedirect: jest.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+  redirect: jest.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+
+jest.mock('@/components/pages/product-landing-page', () => ({
+  ProductLandingPage: () => null,
+}));
+jest.mock('@/components/pages/static-page', () => ({
+  StaticPage: () => null,
+}));
+jest.mock('@/components/site/themes/editorial-v1/template-slot', () => ({
+  TemplateSlot: ({ children }: { children: React.ReactNode }) => children,
+}));
+jest.mock('@/lib/supabase/get-reviews', () => ({
+  getReviewsForContext: jest.fn(),
+}));
+jest.mock('@/lib/supabase/get-planners', () => ({
+  getPlanners: jest.fn(),
+}));
+jest.mock('@/lib/seo/public-metadata', () => ({
+  buildLocaleAwareAlternateLanguages: jest.fn(() => ({
+    'fr-FR': 'https://colombiatours.travel/fr/forfaits/bogota-medellin-carthagene',
+    'x-default': 'https://colombiatours.travel/paquetes/bogota-medellin-carthagene',
+  })),
+  resolvePublicMetadataLocale: jest.fn(async () => ({
+    defaultLocale: 'es-CO',
+    supportedLocales: ['es-CO', 'fr-FR'],
+    resolvedLocale: 'fr-FR',
+    resolvedLanguage: 'fr',
+    languageSegment: 'fr',
+    localizedPathname: '/fr/forfaits/bogota-medellin-carthagene',
+  })),
+}));
+jest.mock('@/lib/supabase/get-pages', () => ({
+  getCategoryProducts: jest.fn(),
+  getDestinations: jest.fn(),
+  getPageBySlugForLocale: jest.fn(),
+  getLocalizedProductOverlay: jest.fn(),
+  getProductPage: jest.fn(),
+  getProductSlugRedirect: jest.fn(),
+}));
+jest.mock('@/lib/supabase/get-website', () => ({
+  getWebsiteBySubdomain: jest.fn(),
+}));
+
+describe('package metadata route semantics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getWebsiteBySubdomain as jest.Mock).mockResolvedValue({
+      id: 'website-1',
+      account_id: 'account-1',
+      subdomain: 'colombiatours',
+      custom_domain: 'colombiatours.travel',
+      status: 'published',
+      default_locale: 'es-CO',
+      supported_locales: ['es-CO', 'fr-FR'],
+      content: {
+        siteName: 'ColombiaTours.Travel',
+        account: { name: 'ColombiaTours.Travel' },
+      },
+    });
+    (getProductPage as jest.Mock).mockResolvedValue(null);
+    (getPageBySlugForLocale as jest.Mock).mockResolvedValue(null);
+  });
+
+  it('throws notFound for absent localized forfaits instead of emitting a Spanish soft-404 metadata document', async () => {
+    const { generateMetadata } = await import(
+      '@/app/site/[subdomain]/paquetes/[slug]/page'
+    );
+
+    await expect(
+      generateMetadata({
+        params: Promise.resolve({
+          subdomain: 'colombiatours',
+          slug: 'bogota-medellin-carthagene',
+        }),
+      }),
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+
+    expect(notFound).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/app/site/terms-metadata-route.test.ts
+++ b/__tests__/app/site/terms-metadata-route.test.ts
@@ -1,0 +1,93 @@
+import { getPageBySlugForLocale } from '@/lib/supabase/get-pages';
+import { getWebsiteBySubdomain } from '@/lib/supabase/get-website';
+
+jest.mock('next/navigation', () => ({
+  notFound: jest.fn(),
+  redirect: jest.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+jest.mock('next/link', () => 'a');
+jest.mock('@/components/pages/static-page', () => ({
+  StaticPage: () => null,
+}));
+jest.mock('@/lib/sanitize', () => ({
+  SafeHtml: () => null,
+}));
+jest.mock('@/lib/supabase/get-pages', () => ({
+  getDestinations: jest.fn(),
+  getPageBySlugForLocale: jest.fn(),
+}));
+jest.mock('@/lib/supabase/get-website', () => ({
+  getWebsiteBySubdomain: jest.fn(),
+}));
+jest.mock('@/lib/seo/public-metadata', () => ({
+  buildLocaleAwareAlternateLanguages: jest.fn(() => ({
+    'fr-FR': 'https://colombiatours.travel/fr/conditions-generales',
+    'x-default': 'https://colombiatours.travel/terminos-y-condiciones',
+  })),
+  resolvePublicMetadataLocale: jest.fn(async () => ({
+    defaultLocale: 'es-CO',
+    supportedLocales: ['es-CO', 'fr-FR'],
+    resolvedLocale: 'fr-FR',
+    resolvedLanguage: 'fr',
+    languageSegment: 'fr',
+    localizedPathname: '/fr/conditions-generales',
+  })),
+}));
+
+describe('terms metadata route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getWebsiteBySubdomain as jest.Mock).mockResolvedValue({
+      id: 'website-1',
+      subdomain: 'colombiatours',
+      custom_domain: 'colombiatours.travel',
+      status: 'published',
+      default_locale: 'es-CO',
+      supported_locales: ['es-CO', 'fr-FR'],
+      content: {
+        siteName: 'ColombiaTours.Travel',
+        account: { name: 'ColombiaTours.Travel' },
+      },
+    });
+    (getPageBySlugForLocale as jest.Mock).mockResolvedValue({
+      id: 'page-fr-terms',
+      slug: 'conditions-generales',
+      locale: 'fr-FR',
+      title: 'Conditions générales',
+      seo_title: 'Conditions générales | ColombiaTours.Travel',
+      seo_description: 'Conditions générales de ColombiaTours.Travel en français.',
+      is_published: true,
+      robots_noindex: false,
+    });
+  });
+
+  it('looks up the published fr-FR terms CMS row and emits indexable hreflang metadata', async () => {
+    const { generateMetadata } = await import(
+      '@/app/site/[subdomain]/terms/page'
+    );
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ subdomain: 'colombiatours' }),
+    });
+
+    expect(getPageBySlugForLocale).toHaveBeenCalledWith(
+      'colombiatours',
+      'conditions-generales',
+      'fr-FR',
+    );
+    expect(metadata.title).toBe('Conditions générales | ColombiaTours.Travel');
+    expect(metadata.description).toBe(
+      'Conditions générales de ColombiaTours.Travel en français.',
+    );
+    expect(metadata.robots).toBeUndefined();
+    expect(metadata.alternates).toEqual({
+      canonical: 'https://colombiatours.travel/fr/conditions-generales',
+      languages: {
+        'fr-FR': 'https://colombiatours.travel/fr/conditions-generales',
+        'x-default': 'https://colombiatours.travel/terminos-y-condiciones',
+      },
+    });
+  });
+});

--- a/__tests__/lib/site/public-route-seo.test.ts
+++ b/__tests__/lib/site/public-route-seo.test.ts
@@ -1,0 +1,21 @@
+import { getLocalizedLegalLookupSlug } from '@/lib/site/legal-route-seo';
+
+describe('localized legal route SEO helpers', () => {
+  it('strips the public locale segment before looking up localized legal CMS rows', () => {
+    expect(
+      getLocalizedLegalLookupSlug({
+        localizedPathname: '/fr/conditions-generales',
+        languageSegment: 'fr',
+      }),
+    ).toBe('conditions-generales');
+  });
+
+  it('keeps unprefixed/default legal paths lookupable', () => {
+    expect(
+      getLocalizedLegalLookupSlug({
+        localizedPathname: '/terminos-y-condiciones',
+        languageSegment: null,
+      }),
+    ).toBe('terminos-y-condiciones');
+  });
+});

--- a/app/site/[subdomain]/paquetes/[slug]/page.tsx
+++ b/app/site/[subdomain]/paquetes/[slug]/page.tsx
@@ -154,11 +154,7 @@ export async function generateMetadata({
       }
       return metadata;
     }
-    return {
-      title: "Paquete no encontrado",
-      description: fallbackDescription,
-      robots: { index: false, follow: true },
-    };
+    notFound();
   }
 
   const canonicalPathname = `/paquetes/${productPage.product.slug || slug}`;

--- a/app/site/[subdomain]/terms/page.tsx
+++ b/app/site/[subdomain]/terms/page.tsx
@@ -8,6 +8,7 @@ import { StaticPage } from '@/components/pages/static-page';
 import { getBasePath } from '@/lib/utils/base-path';
 import { getDefaultLegalContent } from '@/lib/legal-defaults';
 import { getPublicUiMessages } from '@/lib/site/public-ui-messages';
+import { getLocalizedLegalLookupSlug } from '@/lib/site/legal-route-seo';
 import { buildLocaleAwareAlternateLanguages, resolvePublicMetadataLocale } from '@/lib/seo/public-metadata';
 
 interface TermsPageProps {
@@ -29,7 +30,7 @@ export async function generateMetadata({ params }: TermsPageProps): Promise<Meta
     ? `https://${website.custom_domain}`
     : `https://${subdomain}.bukeer.com`;
   const canonical = `${baseUrl}${localeContext.localizedPathname}`;
-  const localizedSlug = localeContext.localizedPathname.replace(/^\/+|\/+$/g, '');
+  const localizedSlug = getLocalizedLegalLookupSlug(localeContext);
   const publishedPage = localizedSlug
     ? await getPageBySlugForLocale(
         subdomain,
@@ -78,7 +79,7 @@ export default async function TermsPage({ params }: TermsPageProps) {
   const siteName = website.content.account?.name || website.content.siteName;
   const localeContext = await resolvePublicMetadataLocale(website, '/terms');
   const messages = getPublicUiMessages(localeContext.resolvedLocale);
-  const localizedSlug = localeContext.localizedPathname.replace(/^\/+|\/+$/g, '');
+  const localizedSlug = getLocalizedLegalLookupSlug(localeContext);
   const publishedPage = localizedSlug
     ? await getPageBySlugForLocale(subdomain, localizedSlug, localeContext.resolvedLocale)
     : null;

--- a/lib/site/legal-route-seo.ts
+++ b/lib/site/legal-route-seo.ts
@@ -1,0 +1,29 @@
+export interface LocalizedLegalLookupContext {
+  localizedPathname: string;
+  languageSegment: string | null;
+}
+
+/**
+ * Convert the public localized legal pathname produced for canonicals
+ * (`/fr/conditions-generales`) back to the CMS slug stored in website_pages
+ * (`conditions-generales`). The CMS slug never includes the public locale
+ * prefix; using the whole localized pathname causes localized legal rows to be
+ * missed and falls back to noindex metadata.
+ */
+export function getLocalizedLegalLookupSlug(
+  context: LocalizedLegalLookupContext,
+): string {
+  const parts = context.localizedPathname
+    .replace(/^\/+|\/+$/g, '')
+    .split('/')
+    .filter(Boolean);
+
+  if (
+    context.languageSegment &&
+    parts[0]?.toLowerCase() === context.languageSegment.toLowerCase()
+  ) {
+    parts.shift();
+  }
+
+  return parts.join('/');
+}


### PR DESCRIPTION
## Summary
- Strip public locale segments before localized legal CMS lookup so `/fr/conditions-generales` uses the published `conditions-generales` fr-FR row.
- Throw `notFound()` from package metadata when neither product nor published static page exists, avoiding Spanish soft-404 metadata for absent `/fr/forfaits/*` URLs.
- Add targeted route/helper tests covering FR terms metadata and absent localized forfait metadata semantics.

## Validation
- `npx jest __tests__/lib/site/public-route-seo.test.ts __tests__/app/site/package-metadata-route.test.ts __tests__/app/site/terms-metadata-route.test.ts --runInBand`
- `npx jest __tests__/lib/seo/public-metadata-locale.test.ts __tests__/middleware/locale-site-route.test.ts __tests__/lib/site/public-page-resolution.test.ts __tests__/app/site/package-metadata-route.test.ts __tests__/app/site/terms-metadata-route.test.ts __tests__/lib/site/public-route-seo.test.ts --runInBand`
- `npm run typecheck`
- `npm run tech-validator:code:quick`

Kanban: t_cc68c872