### PR TITLE
fix(seo): derive legal locale prefix for metadata lookup

### DIFF
--- a/__tests__/app/site/terms-metadata-route.test.ts
+++ b/__tests__/app/site/terms-metadata-route.test.ts
@@ -31,7 +31,7 @@ jest.mock('@/lib/seo/public-metadata', () => ({
     supportedLocales: ['es-CO', 'fr-FR'],
     resolvedLocale: 'fr-FR',
     resolvedLanguage: 'fr',
-    languageSegment: 'fr',
+    languageSegment: null,
     localizedPathname: '/fr/conditions-generales',
   })),
 }));

--- a/__tests__/lib/site/public-route-seo.test.ts
+++ b/__tests__/lib/site/public-route-seo.test.ts
@@ -10,6 +10,17 @@ describe('localized legal route SEO helpers', () => {
     ).toBe('conditions-generales');
   });
 
+  it('strips a locale-derived segment when middleware does not thread x-public-locale-segment into metadata', () => {
+    expect(
+      getLocalizedLegalLookupSlug({
+        localizedPathname: '/fr/conditions-generales',
+        languageSegment: null,
+        resolvedLocale: 'fr-FR',
+        defaultLocale: 'es-CO',
+      }),
+    ).toBe('conditions-generales');
+  });
+
   it('keeps unprefixed/default legal paths lookupable', () => {
     expect(
       getLocalizedLegalLookupSlug({

--- a/lib/site/legal-route-seo.ts
+++ b/lib/site/legal-route-seo.ts
@@ -1,6 +1,10 @@
+import { localeToPublicSegment } from '@/lib/seo/locale-routing';
+
 export interface LocalizedLegalLookupContext {
   localizedPathname: string;
   languageSegment: string | null;
+  resolvedLocale?: string;
+  defaultLocale?: string;
 }
 
 /**
@@ -18,9 +22,14 @@ export function getLocalizedLegalLookupSlug(
     .split('/')
     .filter(Boolean);
 
+  const segmentFromLocale = context.resolvedLocale
+    ? localeToPublicSegment(context.resolvedLocale, context.defaultLocale)
+    : null;
+  const publicLocaleSegment = context.languageSegment || segmentFromLocale;
+
   if (
-    context.languageSegment &&
-    parts[0]?.toLowerCase() === context.languageSegment.toLowerCase()
+    publicLocaleSegment &&
+    parts[0]?.toLowerCase() === publicLocaleSegment.toLowerCase()
   ) {
     parts.shift();
   }


### PR DESCRIPTION
## Summary
- Make localized legal CMS slug lookup strip locale prefixes derived from `resolvedLocale` when `languageSegment` is absent in metadata execution.
- Update FR terms metadata regression test to cover segmentless metadata context.

## Validation
- `npx jest __tests__/lib/site/public-route-seo.test.ts __tests__/app/site/terms-metadata-route.test.ts --runInBand`
- `npm run typecheck`
- `npm run tech-validator:code:quick`

Follow-up to #590 / Kanban t_cc68c872.