### PR TITLE
fix(seo): use website id for localized page lookups

### DIFF
--- a/__tests__/app/site/terms-metadata-route.test.ts
+++ b/__tests__/app/site/terms-metadata-route.test.ts
@@ -73,7 +73,7 @@ describe('terms metadata route', () => {
     });
 
     expect(getPageBySlugForLocale).toHaveBeenCalledWith(
-      'colombiatours',
+      'website-1',
       'conditions-generales',
       'fr-FR',
     );

--- a/app/site/[subdomain]/paquetes/[slug]/page.tsx
+++ b/app/site/[subdomain]/paquetes/[slug]/page.tsx
@@ -120,7 +120,7 @@ export async function generateMetadata({
     );
     const staticPage = staticSlug
       ? await getPageBySlugForLocale(
-          subdomain,
+          String(website.id),
           staticSlug,
           localeContext.resolvedLocale,
         )
@@ -302,7 +302,7 @@ export default async function PackageSlugPage({ params }: PackagePageProps) {
       localeContext.localizedPathname,
     );
     const staticPage = staticSlug
-      ? await getPageBySlugForLocale(subdomain, staticSlug, resolvedLocale)
+      ? await getPageBySlugForLocale(String(website.id), staticSlug, resolvedLocale)
       : null;
     if (staticPage?.is_published) {
       const dynamicDestinations = await getDestinations(subdomain);

--- a/app/site/[subdomain]/terms/page.tsx
+++ b/app/site/[subdomain]/terms/page.tsx
@@ -33,7 +33,7 @@ export async function generateMetadata({ params }: TermsPageProps): Promise<Meta
   const localizedSlug = getLocalizedLegalLookupSlug(localeContext);
   const publishedPage = localizedSlug
     ? await getPageBySlugForLocale(
-        subdomain,
+        String(website.id),
         localizedSlug,
         localeContext.resolvedLocale,
       )
@@ -81,7 +81,7 @@ export default async function TermsPage({ params }: TermsPageProps) {
   const messages = getPublicUiMessages(localeContext.resolvedLocale);
   const localizedSlug = getLocalizedLegalLookupSlug(localeContext);
   const publishedPage = localizedSlug
-    ? await getPageBySlugForLocale(subdomain, localizedSlug, localeContext.resolvedLocale)
+    ? await getPageBySlugForLocale(String(website.id), localizedSlug, localeContext.resolvedLocale)
     : null;
   if (publishedPage?.is_published) {
     const dynamicDestinations = await getDestinations(subdomain);


### PR DESCRIPTION
## Summary
- Pass `website.id` (not subdomain) to `getPageBySlugForLocale` for legal and package static-page lookups.
- Updates FR terms metadata regression expectation to prevent another localized CMS miss.

## Validation
- `npx jest __tests__/app/site/terms-metadata-route.test.ts __tests__/app/site/package-metadata-route.test.ts __tests__/lib/site/public-route-seo.test.ts --runInBand`
- `npm run typecheck`
- `npm run tech-validator:code:quick`

Follow-up to #590/#591 / Kanban t_cc68c872.