### PR TITLE
fix: add static page JSON-LD for custom domains

### DIFF
--- a/__tests__/lib/schema/static-page-jsonld.test.ts
+++ b/__tests__/lib/schema/static-page-jsonld.test.ts
@@ -1,0 +1,83 @@
+import { generateStaticPageSchemas } from '@/lib/schema';
+import type { WebsiteData } from '@/lib/supabase/get-website';
+
+describe('generateStaticPageSchemas', () => {
+  const website = {
+    id: 'website-1',
+    account_id: 'account-1',
+    subdomain: 'colombiatours',
+    custom_domain: 'colombiatours.travel',
+    default_locale: 'es-CO',
+    supported_locales: ['es-CO', 'fr-FR'],
+    content: {
+      siteName: 'ColombiaTours.Travel',
+      tagline: 'Viajes a Colombia con expertos locales',
+      seo: { description: 'Tours privados por Colombia.' },
+      account: {
+        name: 'ColombiaTours',
+        logo: 'https://cdn.example.com/logo.png',
+        phone: '+57 300 000 0000',
+        email: 'hola@colombiatours.travel',
+      },
+      contact: {},
+      social: {},
+    },
+  } as unknown as WebsiteData;
+
+  it('emits valid WebPage and TravelAgency schemas on the custom-domain URL', () => {
+    const schemas = generateStaticPageSchemas(
+      website,
+      {
+        title: 'Hôtels en Colombie',
+        seo_title: 'Hôtels en Colombie | ColombiaTours.Travel',
+        seo_description: 'Sélection d’hôtels en Colombie par ColombiaTours.',
+        intro_content: { text: 'Intro fallback should not win over SEO description.' },
+      },
+      'https://colombiatours.travel/fr/h%C3%B4tels',
+      { publicBaseUrl: 'https://colombiatours.travel', inLanguage: 'fr-FR' },
+    );
+
+    expect(schemas).toHaveLength(2);
+    expect(schemas[0]).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'WebPage',
+      name: 'Hôtels en Colombie | ColombiaTours.Travel',
+      description: 'Sélection d’hôtels en Colombie par ColombiaTours.',
+      url: 'https://colombiatours.travel/fr/h%C3%B4tels',
+      inLanguage: 'fr-FR',
+      isPartOf: {
+        '@type': 'WebSite',
+        name: 'ColombiaTours',
+        url: 'https://colombiatours.travel',
+      },
+    });
+    expect(schemas[1]).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'TravelAgency',
+      name: 'ColombiaTours',
+      url: 'https://colombiatours.travel',
+      logo: 'https://cdn.example.com/logo.png',
+      telephone: '+57 300 000 0000',
+      email: 'hola@colombiatours.travel',
+    });
+  });
+
+  it('falls back to intro text/site copy when page SEO description is absent', () => {
+    const [webPage] = generateStaticPageSchemas(
+      website,
+      {
+        title: 'À propos',
+        intro_content: { text: 'Notre équipe locale en Colombie.' },
+      },
+      'https://colombiatours.travel/fr/a-propos',
+      { publicBaseUrl: 'https://colombiatours.travel', inLanguage: 'fr-FR' },
+    );
+
+    expect(webPage).toMatchObject({
+      '@type': 'WebPage',
+      name: 'À propos',
+      description: 'Notre équipe locale en Colombie.',
+      inLanguage: 'fr-FR',
+    });
+  });
+});

--- a/app/domain/[host]/[[...slug]]/page.tsx
+++ b/app/domain/[host]/[[...slug]]/page.tsx
@@ -15,9 +15,10 @@ import {
 } from '@/lib/supabase/get-pages';
 import { resolvePublicPageForRoute } from '@/lib/site/public-page-resolution';
 import { getBlogPosts, getBlogPostBySlug, getBlogCategories } from '@/lib/supabase/get-website';
-import { JsonLd, generateBlogListingSchemas, generateBlogPostSchemas } from '@/lib/schema';
+import { JsonLd, generateBlogListingSchemas, generateBlogPostSchemas, generateStaticPageSchemas } from '@/lib/schema';
 import { SafeHtml } from '@/lib/sanitize';
 import { generateHreflangLinks } from '@/lib/seo/hreflang';
+import { buildPublicLocalizedPath } from '@/lib/seo/locale-routing';
 import { resolveSiteIcons } from '@/lib/seo/site-icons';
 import { normalizePublicMetadataTitle } from '@/lib/seo/metadata-title';
 import { getDefaultLegalContent } from '@/lib/legal-defaults';
@@ -44,6 +45,11 @@ function getAnalyticsContext(website: WebsiteData) {
     locale,
     market: locale.split('-')[1] ?? null,
   };
+}
+
+function joinPublicUrl(baseUrl: string, pathname: string): string {
+  const normalizedPathname = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  return normalizedPathname === '/' ? baseUrl : `${baseUrl}${normalizedPathname}`;
 }
 
 async function getWebsiteByCustomDomain(customDomain: string): Promise<WebsiteData | null> {
@@ -543,6 +549,25 @@ export default async function CustomDomainPage({ params, searchParams }: CustomD
     notFound();
   }
 
+  const pageJsonLdSchemas = page
+    ? generateStaticPageSchemas(
+        website,
+        page,
+        joinPublicUrl(
+          baseUrl,
+          buildPublicLocalizedPath(
+            resolvedPageRoute.locale.canonicalPathname,
+            resolvedPageRoute.locale.resolvedLocale,
+            resolvedPageRoute.locale.defaultLocale,
+          ),
+        ),
+        {
+          publicBaseUrl: baseUrl,
+          inLanguage: resolvedPageRoute.locale.resolvedLocale,
+        },
+      )
+    : null;
+
   return (
     <M3ThemeProvider initialTheme={getInitialTheme(website.theme)}>
       {/* Google Tag Manager and Analytics Scripts */}
@@ -554,6 +579,7 @@ export default async function CustomDomainPage({ params, searchParams }: CustomD
 
         <SiteHeader website={website} isCustomDomain={true} />
         <main className="flex-1">
+          {pageJsonLdSchemas && <JsonLd data={pageJsonLdSchemas} />}
           {page && <StaticPage website={website} page={page} dynamicDestinations={dynamicDestinations} />}
         </main>
         <SiteFooter website={website} isCustomDomain={true} />

--- a/lib/schema/index.ts
+++ b/lib/schema/index.ts
@@ -45,8 +45,8 @@
  * ```
  */
 
-// Components
-export { JsonLd, safeStringifySchema } from './json-ld';
+// Components and legacy static-page helpers
+export { JsonLd, safeStringifySchema, generateStaticPageSchemas } from './json-ld';
 
 // Generators
 export {

--- a/lib/schema/json-ld.tsx
+++ b/lib/schema/json-ld.tsx
@@ -30,6 +30,7 @@ export interface JsonLdWebPage {
   name: string;
   description?: string;
   url: string;
+  inLanguage?: string;
   isPartOf: {
     '@type': 'WebSite';
     name: string;
@@ -94,11 +95,14 @@ export interface JsonLdFAQ {
 /**
  * Generate Organization JSON-LD for the travel agency
  */
-export function generateOrganizationSchema(website: WebsiteData): JsonLdOrganization {
+export function generateOrganizationSchema(
+  website: WebsiteData,
+  publicBaseUrl?: string,
+): JsonLdOrganization {
   const content = website.content || {};
   const contact = content.contact || {};
   const social = content.social || {};
-  const baseUrl = `https://${website.subdomain}.bukeer.com`;
+  const baseUrl = publicBaseUrl || `https://${website.subdomain}.bukeer.com`;
 
   // Prefer account data over content data
   const orgName = content.account?.name || content.siteName || website.subdomain;
@@ -140,10 +144,11 @@ export function generateWebPageSchema(
   website: WebsiteData,
   pageTitle: string,
   pageDescription: string | undefined,
-  pageUrl: string
+  pageUrl: string,
+  options: { publicBaseUrl?: string; inLanguage?: string } = {},
 ): JsonLdWebPage {
   const content = website.content || {};
-  const baseUrl = `https://${website.subdomain}.bukeer.com`;
+  const baseUrl = options.publicBaseUrl || `https://${website.subdomain}.bukeer.com`;
 
   const webSiteName = content.account?.name || content.siteName || website.subdomain;
 
@@ -153,6 +158,7 @@ export function generateWebPageSchema(
     name: pageTitle,
     description: pageDescription,
     url: pageUrl,
+    inLanguage: options.inLanguage,
     isPartOf: {
       '@type': 'WebSite',
       name: webSiteName,
@@ -267,6 +273,36 @@ export function generateFAQSchema(
       },
     })),
   };
+}
+
+/**
+ * Generate WebPage + Organization JSON-LD for custom/static public pages.
+ *
+ * These pages are resolved from `website_pages`, not product/blog routes, so
+ * they need a generic governed schema instead of product-specific markup.
+ */
+export function generateStaticPageSchemas(
+  website: WebsiteData,
+  page: {
+    title: string;
+    seo_title?: string | null;
+    seo_description?: string | null;
+    intro_content?: { text?: string | null } | null;
+  },
+  pageUrl: string,
+  options: { publicBaseUrl?: string; inLanguage?: string } = {},
+): [JsonLdWebPage, JsonLdOrganization] {
+  const pageTitle = page.seo_title || page.title;
+  const pageDescription =
+    page.seo_description ||
+    (typeof page.intro_content?.text === 'string' ? page.intro_content.text : undefined) ||
+    website.content?.seo?.description ||
+    website.content?.tagline;
+
+  return [
+    generateWebPageSchema(website, pageTitle, pageDescription, pageUrl, options),
+    generateOrganizationSchema(website, options.publicBaseUrl),
+  ];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds governed WebPage + Organization/TravelAgency JSON-LD for custom-domain static pages resolved from `website_pages`.
- Uses the live custom-domain base URL and locale-aware canonical path for WebPage/isPartOf URLs.
- Adds `inLanguage` support for WebPage JSON-LD and regression tests for FR custom-domain static pages.

## Validation
- PASS: `npm test -- --runTestsByPath __tests__/lib/schema/static-page-jsonld.test.ts`
- PASS: `npm run typecheck`
- PASS: `npx next lint --file app/domain/[host]/[[...slug]]/page.tsx --file lib/schema/json-ld.tsx --file lib/schema/index.ts --file __tests__/lib/schema/static-page-jsonld.test.ts`
- PASS: `npm run build:worker` with non-secret placeholder build env; OpenNext worker generated successfully.
- NOTE: full `npm run lint` still fails on pre-existing unrelated files: `components/site/themes/editorial-v1/pages/paquetes-list-grid.client.tsx` and `lib/admin-next/whatsapp-handoff.test.ts`.

## Rollback
Revert commit `f1aa4632` or remove the static-page schema generation/rendering added to `app/domain/[host]/[[...slug]]/page.tsx` and `lib/schema/json-ld.tsx`.

Kanban task: t_5cb8e7d6
