### PR TITLE
fix: localize French header and footer chrome

### DIFF
--- a/__tests__/components/site/themes/editorial-v1/layout/site-footer.test.tsx
+++ b/__tests__/components/site/themes/editorial-v1/layout/site-footer.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * editorial-v1 <EditorialSiteFooter> — SSR localization checks.
+ */
+
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { EditorialSiteFooter } from '@/components/site/themes/editorial-v1/layout/site-footer';
+import type { WebsiteData } from '@/lib/supabase/get-website';
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/fr',
+  useRouter: () => ({ replace: jest.fn(), push: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(''),
+}));
+
+function makeWebsite(overrides: Partial<WebsiteData> = {}): WebsiteData {
+  return {
+    id: 'colombiatours',
+    account_id: 'a1',
+    subdomain: 'colombiatours',
+    custom_domain: 'colombiatours.travel',
+    status: 'published',
+    template_id: 'editorial-v1',
+    default_locale: 'es-CO',
+    supported_locales: ['es-CO', 'fr-FR'],
+    theme: { tokens: {}, profile: { metadata: {} } },
+    content: {
+      siteName: 'ColombiaTours',
+      locale: 'es-CO',
+      tagline: 'Descubre Colombia con expertos locales',
+      seo: {
+        title: 'ColombiaTours',
+        description: 'Descubre Colombia con expertos locales.',
+        keywords: '',
+      },
+      contact: { email: 'hola@example.com', phone: '', address: '' },
+      social: {},
+      account: {
+        name: 'ColombiaTours',
+        primary_currency: 'COP',
+        enabled_currencies: ['COP', 'USD'],
+        currency: [
+          { name: 'COP', rate: 1, type: 'base' },
+          { name: 'USD', rate: 0.00025 },
+        ],
+      },
+      market_experience: {
+        show_in_header: true,
+        show_in_footer: true,
+        show_language: true,
+        show_currency: true,
+        switcher_style: 'compact',
+      },
+    },
+    featured_products: {
+      destinations: [],
+      hotels: [],
+      activities: [],
+      transfers: [],
+      packages: [],
+    },
+    sections: [],
+    ...overrides,
+  } as unknown as WebsiteData;
+}
+
+describe('editorial-v1 <EditorialSiteFooter>', () => {
+  it('uses French copy and localized category paths for /fr shared footer chrome', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(EditorialSiteFooter, {
+        website: makeWebsite({ resolvedLocale: 'fr-FR' } as unknown as Partial<WebsiteData>),
+        isCustomDomain: true,
+      }),
+    );
+
+    expect(html).toContain('Découvrez la Colombie avec des experts locaux');
+    expect(html).toContain('Forfaits');
+    expect(html).toContain('Hôtels boutique');
+    expect(html).toContain('Voyages de noces');
+    expect(html).toContain('Groupes et entreprises');
+    expect(html).toContain('À propos');
+    expect(html).toContain('Nos planners');
+    expect(html).toContain('Presse');
+    expect(html).toContain('href="/fr/destinations/cartagena"');
+    expect(html).toContain('href="/fr/forfaits"');
+
+    expect(html).not.toContain('Descubre Colombia con expertos locales');
+    expect(html).not.toContain('Paquetes');
+    expect(html).not.toContain('Hoteles boutique');
+    expect(html).not.toContain('Luna de miel');
+    expect(html).not.toContain('Grupos y corporativo');
+    expect(html).not.toContain('Sobre nosotros');
+    expect(html).not.toContain('Nuestros planners');
+    expect(html).not.toContain('Contacto');
+    expect(html).not.toContain('/fr/destinos/');
+    expect(html).not.toContain('/fr/paquetes');
+  });
+});

--- a/__tests__/components/site/themes/editorial-v1/layout/site-header.test.tsx
+++ b/__tests__/components/site/themes/editorial-v1/layout/site-header.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * editorial-v1 <EditorialSiteHeader> — SSR localization checks.
+ */
+
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { EditorialSiteHeader } from '@/components/site/themes/editorial-v1/layout/site-header';
+import type { WebsiteData } from '@/lib/supabase/get-website';
+import type { NavigationItem } from '@bukeer/website-contract';
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/fr',
+  useRouter: () => ({ replace: jest.fn(), push: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(''),
+}));
+
+jest.mock('@/components/site/themes/editorial-v1/layout/market-switcher', () => ({
+  MarketSwitcher: () => null,
+}));
+
+function makeWebsite(overrides: Partial<WebsiteData> = {}): WebsiteData {
+  return {
+    id: 'colombiatours',
+    account_id: 'a1',
+    subdomain: 'colombiatours',
+    custom_domain: 'colombiatours.travel',
+    status: 'published',
+    template_id: 'editorial-v1',
+    default_locale: 'es-CO',
+    supported_locales: ['es-CO', 'fr-FR'],
+    theme: { tokens: {}, profile: { metadata: {} } },
+    content: {
+      siteName: 'ColombiaTours',
+      locale: 'es-CO',
+      seo: { title: 'ColombiaTours', description: '', keywords: '' },
+      contact: { email: 'hola@example.com', phone: '', address: '' },
+      social: {},
+      account: {
+        name: 'ColombiaTours',
+        primary_currency: 'COP',
+        enabled_currencies: ['COP', 'USD'],
+        currency: [
+          { name: 'COP', rate: 1, type: 'base' },
+          { name: 'USD', rate: 0.00025 },
+        ],
+      },
+      market_experience: {
+        show_in_header: true,
+        show_in_footer: true,
+        show_language: true,
+        show_currency: true,
+        switcher_style: 'compact',
+      },
+    },
+    featured_products: {
+      destinations: [],
+      hotels: [],
+      activities: [],
+      transfers: [],
+      packages: [],
+    },
+    sections: [],
+    ...overrides,
+  } as unknown as WebsiteData;
+}
+
+const mixedLocaleNav: NavigationItem[] = [
+  { slug: 'destinations', label: 'Destinations', page_type: 'anchor', href: '#destinations', target: '_self' },
+  { slug: 'packages', label: 'Paquetes', page_type: 'anchor', href: '#packages', target: '_self' },
+  { slug: 'activities', label: 'Activities', page_type: 'anchor', href: '#activities', target: '_self' },
+  { slug: 'blog', label: 'Blog', page_type: 'custom', href: '/blog', target: '_self' },
+];
+
+describe('editorial-v1 <EditorialSiteHeader>', () => {
+  it('localizes mixed CMS nav labels on French pages', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(EditorialSiteHeader, {
+        website: makeWebsite({ resolvedLocale: 'fr-FR' } as unknown as Partial<WebsiteData>),
+        navigation: mixedLocaleNav,
+        isCustomDomain: true,
+      }),
+    );
+
+    expect(html).toContain('Destinations');
+    expect(html).toContain('Forfaits');
+    expect(html).toContain('Expériences');
+    expect(html).toContain('Blog');
+
+    expect(html).not.toContain('Paquetes');
+    expect(html).not.toContain('Activities');
+  });
+});

--- a/components/site/themes/editorial-v1/layout/site-footer.tsx
+++ b/components/site/themes/editorial-v1/layout/site-footer.tsx
@@ -23,7 +23,13 @@ import Link from 'next/link';
 import type { WebsiteData } from '@/lib/supabase/get-website';
 import type { NavigationItem } from '@bukeer/website-contract';
 import { getBasePath } from '@/lib/utils/base-path';
-import { buildLegalPagePath, type LegalPageType } from '@/lib/seo/locale-routing';
+import {
+  CATEGORY_CANONICAL_SEGMENT,
+  buildLegalPagePath,
+  localeToLanguage,
+  type CategoryLanguage,
+  type LegalPageType,
+} from '@/lib/seo/locale-routing';
 import { Icons } from '../primitives/icons';
 import { FooterSwitcher } from './footer-switcher';
 import { FooterNewsletterForm } from './footer-newsletter-form';
@@ -58,6 +64,42 @@ function isColombiaToursWebsite(website: WebsiteData): boolean {
   );
 }
 
+function stripDiacritics(value: string): string {
+  return value.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+
+function normalizeCopy(value: string | null | undefined): string {
+  return stripDiacritics(value ?? '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .replace(/[.。]+$/g, '')
+    .trim();
+}
+
+function localizeKnownEditorialFooterCopy(
+  value: string | null | undefined,
+  fallback: string,
+  language: string,
+): string {
+  if (!value) return fallback;
+
+  const normalized = normalizeCopy(value);
+  if (language === 'fr' && normalized === 'descubre colombia con expertos locales') {
+    const suffix = value.trim().endsWith('.') ? '.' : '';
+    return `Découvrez la Colombie avec des experts locaux${suffix}`;
+  }
+
+  return value;
+}
+
+function localizedCategorySegment(
+  productType: keyof typeof CATEGORY_CANONICAL_SEGMENT,
+  language: string,
+): string {
+  const segments = CATEGORY_CANONICAL_SEGMENT[productType];
+  return segments[language as CategoryLanguage] ?? segments.es;
+}
+
 export function EditorialSiteFooter({
   website,
   isCustomDomain = false,
@@ -65,36 +107,63 @@ export function EditorialSiteFooter({
 }: EditorialSiteFooterProps) {
   const editorialText = getEditorialTextGetter(website);
   const { content, subdomain } = website;
-  const basePath = getBasePath(subdomain, isCustomDomain, (website as WebsiteData & { resolvedLocale?: string | null }).resolvedLocale || undefined);
+  const resolvedLocale =
+    (website as WebsiteData & { resolvedLocale?: string | null }).resolvedLocale
+    ?? content.locale
+    ?? website.default_locale
+    ?? 'es-CO';
+  const defaultLocale = website.default_locale ?? content.locale ?? 'es-CO';
+  const language = localeToLanguage(resolvedLocale);
+  const basePath = getBasePath(subdomain, isCustomDomain, resolvedLocale || undefined);
   const currentYear = new Date().getFullYear();
   const siteName = content.account?.name || content.siteName;
   const social = content.social || {};
   const legal = content.account?.legal;
 
   const logoUrl = content.account?.logo || content.logo || null;
-  const tagline = content.tagline || editorialText('editorialFooterTaglineFallback');
+  const tagline = localizeKnownEditorialFooterCopy(
+    content.tagline,
+    editorialText('editorialFooterTaglineFallback'),
+    language,
+  );
   // WebsiteContent exposes `tagline` + account.* but no top-level
   // `description`. Pull from SEO description as a soft fallback.
-  const aboutBlurb =
-    content.seo?.description ||
-    editorialText('editorialFooterAboutFallback');
+  const aboutBlurb = localizeKnownEditorialFooterCopy(
+    content.seo?.description,
+    editorialText('editorialFooterAboutFallback'),
+    language,
+  );
+  const destinationSegment = localizedCategorySegment('destination', language);
+  const packageSegment = localizedCategorySegment('package', language);
 
   const destinosLinks = [
-    { label: 'Cartagena', href: `${basePath}/destinos/cartagena` },
-    { label: 'Eje Cafetero', href: `${basePath}/destinos/eje-cafetero` },
-    { label: 'Tayrona', href: `${basePath}/destinos/tayrona` },
-    { label: 'San Andrés', href: `${basePath}/destinos/san-andres` },
-    { label: 'Amazonas', href: `${basePath}/destinos/amazonas` },
+    { label: 'Cartagena', href: `${basePath}/${destinationSegment}/cartagena` },
+    { label: 'Eje Cafetero', href: `${basePath}/${destinationSegment}/eje-cafetero` },
+    { label: 'Tayrona', href: `${basePath}/${destinationSegment}/tayrona` },
+    { label: 'San Andrés', href: `${basePath}/${destinationSegment}/san-andres` },
+    { label: 'Amazonas', href: `${basePath}/${destinationSegment}/amazonas` },
     { label: editorialText('editorialFooterViewAll'), href: `${basePath}/#destinations` },
   ];
-  const viajarLinks = [
-    { label: 'Paquetes', href: `${basePath}/paquetes` },
+  const viajarLinks = language === 'fr' ? [
+    { label: 'Forfaits', href: `${basePath}/${packageSegment}` },
+    { label: editorialText('editorialFooterSearch'), href: `${basePath}/buscar` },
+    { label: 'Hôtels boutique', href: `${basePath}/#hotels` },
+    { label: 'Voyages de noces', href: `${basePath}/${packageSegment}?tipo=luna-de-miel` },
+    { label: 'Groupes et entreprises', href: `${basePath}/#cta` },
+  ] : [
+    { label: 'Paquetes', href: `${basePath}/${packageSegment}` },
     { label: editorialText('editorialFooterSearch'), href: `${basePath}/buscar` },
     { label: 'Hoteles boutique', href: `${basePath}/#hotels` },
-    { label: 'Luna de miel', href: `${basePath}/paquetes?tipo=luna-de-miel` },
+    { label: 'Luna de miel', href: `${basePath}/${packageSegment}?tipo=luna-de-miel` },
     { label: 'Grupos y corporativo', href: `${basePath}/#cta` },
   ];
-  const agenciaLinks = [
+  const agenciaLinks = language === 'fr' ? [
+    { label: 'À propos', href: `${basePath}/#about` },
+    { label: 'Nos planners', href: `${basePath}/planners` },
+    { label: 'Blog', href: `${basePath}/blog` },
+    { label: 'Presse', href: `${basePath}/presse` },
+    { label: 'Contact', href: `${basePath}/#cta` },
+  ] : [
     { label: 'Sobre nosotros', href: `${basePath}/#about` },
     { label: 'Nuestros planners', href: `${basePath}/planners` },
     { label: 'Blog', href: `${basePath}/blog` },
@@ -144,12 +213,6 @@ export function EditorialSiteFooter({
   const legalPrivacy = editorialText('editorialFooterLegalPrivacy');
   const legalTerms = editorialText('editorialFooterLegalTerms');
   const legalCancellation = editorialText('editorialFooterLegalCancellation');
-  const resolvedLocale =
-    (website as WebsiteData & { resolvedLocale?: string | null }).resolvedLocale
-    ?? content.locale
-    ?? website.default_locale
-    ?? 'es-CO';
-  const defaultLocale = website.default_locale ?? content.locale ?? 'es-CO';
   const legalLinks: Array<{ label: string; href: string }> = [
     { label: legalPrivacy, href: legalHref(basePath, 'privacy', resolvedLocale, defaultLocale) },
     { label: legalTerms, href: legalHref(basePath, 'terms', resolvedLocale, defaultLocale) },

--- a/components/site/themes/editorial-v1/layout/site-header.tsx
+++ b/components/site/themes/editorial-v1/layout/site-header.tsx
@@ -23,7 +23,7 @@ import type { WebsiteData } from '@/lib/supabase/get-website';
 import type { NavigationItem } from '@bukeer/website-contract';
 import { getBasePath } from '@/lib/utils/base-path';
 import { resolveNavHref } from '@/lib/utils/navigation';
-import { extractWebsiteLocaleSettings } from '@/lib/seo/locale-routing';
+import { extractWebsiteLocaleSettings, localeToLanguage } from '@/lib/seo/locale-routing';
 import { Logo } from '../primitives/logo';
 import { Icons } from '../primitives/icons';
 import { HeaderScrollState, MobileNavToggle } from './site-header.client';
@@ -50,7 +50,9 @@ export function EditorialSiteHeader({
     (website as WebsiteData & { resolvedLocale?: string | null }).resolvedLocale
     ?? localeSettings.defaultLocale
   );
-  const isEnglish = resolvedLocale.startsWith('en');
+  const language = localeToLanguage(resolvedLocale);
+  const isEnglish = language === 'en';
+  const isFrench = language === 'fr';
   const { content, subdomain } = website;
   const basePath = getBasePath(subdomain, isCustomDomain, resolvedLocale);
   const siteName = content.account?.name || content.siteName;
@@ -58,9 +60,9 @@ export function EditorialSiteHeader({
 
   // Fallback to designer canonical nav labels if no navigation prop is passed.
   const fallbackNav: NavigationItem[] = [
-    { slug: 'destinations', label: isEnglish ? 'Destinations' : 'Destinos', page_type: 'anchor', href: `${basePath}/#destinations`, target: '_self' },
-    { slug: 'packages', label: isEnglish ? 'Packages' : 'Paquetes', page_type: 'anchor', href: `${basePath}/#packages`, target: '_self' },
-    { slug: 'experiences', label: isEnglish ? 'Experiences' : 'Experiencias', page_type: 'anchor', href: `${basePath}/#activities`, target: '_self' },
+    { slug: 'destinations', label: isEnglish || isFrench ? 'Destinations' : 'Destinos', page_type: 'anchor', href: `${basePath}/#destinations`, target: '_self' },
+    { slug: 'packages', label: isEnglish ? 'Packages' : isFrench ? 'Forfaits' : 'Paquetes', page_type: 'anchor', href: `${basePath}/#packages`, target: '_self' },
+    { slug: 'experiences', label: isEnglish ? 'Experiences' : isFrench ? 'Expériences' : 'Experiencias', page_type: 'anchor', href: `${basePath}/#activities`, target: '_self' },
     { slug: 'blog', label: 'Blog', page_type: 'custom', href: `${basePath}/blog`, target: '_self' },
   ];
   const rawNavItems = navigation && navigation.length > 0 ? navigation : fallbackNav;
@@ -92,8 +94,22 @@ export function EditorialSiteHeader({
     .map((key) => navByKey.get(key))
     .filter((item): item is NavigationItem => Boolean(item));
   const navLabelForLocale = (label: string): string => {
-    if (!isEnglish) return label;
     const normalized = label.trim().toLowerCase();
+
+    if (isFrench) {
+      if (normalized === 'destinos' || normalized === 'destinations') return 'Destinations';
+      if (normalized === 'paquetes' || normalized === 'packages') return 'Forfaits';
+      if (
+        normalized === 'experiencias'
+        || normalized === 'experiences'
+        || normalized === 'actividades'
+        || normalized === 'activities'
+      ) return 'Expériences';
+      if (normalized === 'nosotros' || normalized === 'sobre nosotros' || normalized === 'about') return 'À propos';
+      return label;
+    }
+
+    if (!isEnglish) return label;
     if (normalized === 'destinos') return 'Destinations';
     if (normalized === 'paquetes') return 'Packages';
     if (normalized === 'experiencias') return 'Experiences';


### PR DESCRIPTION
Clean follow-up for FR shared chrome leaks after t_32fbe85c. Localizes French header/nav/footer labels and known ColombiaTours CMS tagline/about copy; fixes French destination/package paths; adds SSR regression tests for header/footer leak cases.

Worker validation: targeted Jest 4 suites/8 tests PASS, typecheck PASS, lint:hardcoded-ui PASS.