### PR TITLE
fix(seo): use localized blog slugs in hreflang alternates

### DIFF
--- a/__tests__/lib/seo/blog-post-alternates.test.ts
+++ b/__tests__/lib/seo/blog-post-alternates.test.ts
@@ -1,0 +1,55 @@
+import { buildBlogPostAlternateLanguages } from "@/lib/seo/blog-post-alternates";
+
+describe("blog post alternate languages", () => {
+  it("uses locale-specific blog slugs for hreflang and x-default", () => {
+    expect(
+      buildBlogPostAlternateLanguages("https://colombiatours.travel", "es-CO", [
+        {
+          locale: "es-CO",
+          slug: "los-10-mejores-destinos-para-conocer-colombia",
+        },
+        {
+          locale: "en-US",
+          slug: "best-places-to-visit-in-colombia",
+        },
+        {
+          locale: "fr-FR",
+          slug: "meilleurs-endroits-a-visiter-en-colombie",
+        },
+        {
+          locale: "de-DE",
+          slug: "10-schoenste-reiseziele-kolumbiens",
+        },
+        {
+          locale: "pt-BR",
+          slug: "melhores-destinos-para-conhecer-na-colombia",
+        },
+      ]),
+    ).toEqual({
+      "es-CO":
+        "https://colombiatours.travel/blog/los-10-mejores-destinos-para-conocer-colombia",
+      "en-US":
+        "https://colombiatours.travel/en/blog/best-places-to-visit-in-colombia",
+      "fr-FR":
+        "https://colombiatours.travel/fr/blog/meilleurs-endroits-a-visiter-en-colombie",
+      "de-DE":
+        "https://colombiatours.travel/de/blog/10-schoenste-reiseziele-kolumbiens",
+      "pt-BR":
+        "https://colombiatours.travel/pt-br/blog/melhores-destinos-para-conhecer-na-colombia",
+      "x-default":
+        "https://colombiatours.travel/blog/los-10-mejores-destinos-para-conocer-colombia",
+    });
+  });
+
+  it("skips empty route rows and only emits x-default when the default route exists", () => {
+    expect(
+      buildBlogPostAlternateLanguages("https://colombiatours.travel", "es-CO", [
+        { locale: "pt-BR", slug: "melhores-destinos" },
+        { locale: "es-CO", slug: "" },
+        { locale: null, slug: "missing-locale" },
+      ]),
+    ).toEqual({
+      "pt-BR": "https://colombiatours.travel/pt-br/blog/melhores-destinos",
+    });
+  });
+});

--- a/app/site/[subdomain]/blog/[slug]/page.tsx
+++ b/app/site/[subdomain]/blog/[slug]/page.tsx
@@ -6,17 +6,14 @@ import {
   getBlogPostBySlug,
   getBlogPostAnyLocale,
   getBlogPostByTranslationGroup,
-  getBlogPostTranslationLocales,
+  getBlogPostTranslationRoutes,
   normalizeBlogPublicLocale,
 } from "@/lib/supabase/get-website";
 import { JsonLd, generateBlogPostSchemas } from "@/lib/schema";
 import { getPlannerByUserId } from "@/lib/supabase/get-planners";
 import { BlogDetail } from "@/components/site/blog/blog-detail";
 import { resolveOgImage } from "@/lib/seo/og-helpers";
-import {
-  buildLocaleAwareAlternateLanguages,
-  resolvePublicMetadataLocale,
-} from "@/lib/seo/public-metadata";
+import { resolvePublicMetadataLocale } from "@/lib/seo/public-metadata";
 import {
   buildPublicLocalizedPath,
   localeToOgLocale,
@@ -25,6 +22,7 @@ import { isEnBlogQualityBlocked } from "@/lib/seo/en-quality-gate";
 import { normalizePublicMetadataTitle } from "@/lib/seo/metadata-title";
 import { getPublicUiMessages } from "@/lib/site/public-ui-messages";
 import { inferIsCustomDomainWebsite } from "@/lib/utils/base-path";
+import { buildBlogPostAlternateLanguages } from "@/lib/seo/blog-post-alternates";
 
 interface BlogPostPageProps {
   params: Promise<{ subdomain: string; slug: string }>;
@@ -73,18 +71,15 @@ export async function generateMetadata({
   );
   const localizedBlogPath = localizedLocaleContext.localizedPathname;
   const canonical = `${baseUrl}${localizedBlogPath}`;
-  const translatedLocales = await getBlogPostTranslationLocales(
+  const translatedRoutes = await getBlogPostTranslationRoutes(
     website.id,
     post.translation_group_id ?? post.id,
-    normalizeBlogPublicLocale(post.locale),
+    { locale: normalizeBlogPublicLocale(post.locale), slug: post.slug },
   );
-  const languages = buildLocaleAwareAlternateLanguages(
+  const languages = buildBlogPostAlternateLanguages(
     baseUrl,
-    blogPath,
-    localizedLocaleContext,
-    {
-      translatedLocales,
-    },
+    localizedLocaleContext.defaultLocale,
+    translatedRoutes,
   );
   const siteName =
     website.content?.account?.name || website.content?.siteName || subdomain;

--- a/lib/seo/blog-post-alternates.ts
+++ b/lib/seo/blog-post-alternates.ts
@@ -1,0 +1,34 @@
+import { buildPublicLocalizedPath } from "@/lib/seo/locale-routing";
+
+export interface BlogPostAlternateRoute {
+  locale: string | null | undefined;
+  slug: string | null | undefined;
+}
+
+export function buildBlogPostAlternateLanguages(
+  baseUrl: string,
+  defaultLocale: string,
+  routes: BlogPostAlternateRoute[],
+): Record<string, string> {
+  const languages: Record<string, string> = {};
+  const normalizedDefaultLocale = defaultLocale || "es-CO";
+
+  for (const route of routes) {
+    const locale = route.locale?.trim();
+    const slug = route.slug?.trim();
+    if (!locale || !slug) continue;
+
+    languages[locale] = `${baseUrl}${buildPublicLocalizedPath(
+      `/blog/${slug}`,
+      locale,
+      normalizedDefaultLocale,
+    )}`;
+  }
+
+  const defaultHref = languages[normalizedDefaultLocale];
+  if (defaultHref) {
+    languages["x-default"] = defaultHref;
+  }
+
+  return languages;
+}

--- a/lib/supabase/get-website.ts
+++ b/lib/supabase/get-website.ts
@@ -804,6 +804,46 @@ export async function getBlogPostTranslationLocales(
   }
 }
 
+export async function getBlogPostTranslationRoutes(
+  websiteId: string,
+  translationGroupId: string | null | undefined,
+  fallback?: { locale?: string | null; slug?: string | null },
+): Promise<Array<{ locale: string; slug: string }>> {
+  const fallbackRoutes = (() => {
+    const locale = normalizeBlogPublicLocale(fallback?.locale);
+    const slug = fallback?.slug?.trim();
+    return locale && slug ? [{ locale, slug }] : [];
+  })();
+  if (!translationGroupId) return fallbackRoutes;
+
+  try {
+    const { data, error } = await supabase
+      .from("website_blog_posts")
+      .select("locale, slug")
+      .eq("website_id", websiteId)
+      .eq("translation_group_id", translationGroupId)
+      .eq("status", "published")
+      .is("deleted_at", null);
+
+    if (error) return fallbackRoutes;
+
+    const routes = new Map<string, string>();
+    for (const row of data ?? []) {
+      const locale = normalizeBlogPublicLocale(
+        (row as { locale?: string | null }).locale,
+      );
+      const slug = (row as { slug?: string | null }).slug?.trim();
+      if (locale && slug && !routes.has(locale)) routes.set(locale, slug);
+    }
+
+    return routes.size > 0
+      ? Array.from(routes.entries()).map(([locale, slug]) => ({ locale, slug }))
+      : fallbackRoutes;
+  } catch {
+    return fallbackRoutes;
+  }
+}
+
 export function normalizeBlogPublicLocale(
   locale: string | null | undefined,
 ): string | null {


### PR DESCRIPTION
## Summary
- Query published blog translation-group routes with locale-specific slugs for blog post metadata.
- Build blog post hreflang alternates from those route rows so es-CO/x-default use the default-locale slug instead of the current pt-BR slug.
- Add regression coverage for the pt-BR post2 translation group slug matrix.

## Test Plan
- npm test -- __tests__/lib/seo/blog-post-alternates.test.ts --runInBand
- npm run typecheck

## Rollback
- Revert this PR/commit to restore previous buildLocaleAwareAlternateLanguages-based blog post metadata generation.

Follow-up after deploy: trigger growth-monitor-agent for origin task t_2e0b39c1 / pt-BR post2 (post id 712289ce-17f0-49b6-b191-41060b1c80f4) so traffic readiness can be reconsidered after live hreflang verification.