### PR TITLE
fix(seo): unblock ColombiaTours product indexability

### DIFF
--- a/__tests__/app/product-static-landing-fallback.test.tsx
+++ b/__tests__/app/product-static-landing-fallback.test.tsx
@@ -1,0 +1,216 @@
+import React from "react";
+
+const mockNotFound = jest.fn(() => {
+  throw new Error("NEXT_NOT_FOUND");
+});
+const mockPermanentRedirect = jest.fn((url: string) => {
+  throw new Error(`NEXT_PERMANENT_REDIRECT:${url}`);
+});
+const mockRedirect = jest.fn((url: string) => {
+  throw new Error(`NEXT_REDIRECT:${url}`);
+});
+
+const mockGetWebsiteBySubdomain = jest.fn();
+const mockGetProductPage = jest.fn();
+const mockGetPageBySlug = jest.fn();
+const mockGetProductSlugRedirect = jest.fn();
+const mockGetDestinations = jest.fn();
+const mockStaticPage = jest.fn((props: unknown) =>
+  React.createElement("div", { "data-testid": "static-page", props }),
+);
+
+jest.mock("next/navigation", () => ({
+  notFound: () => mockNotFound(),
+  permanentRedirect: (url: string) => mockPermanentRedirect(url),
+  redirect: (url: string) => mockRedirect(url),
+}));
+
+jest.mock("@/components/pages/product-landing-page", () => ({
+  ProductLandingPage: () =>
+    React.createElement("div", { "data-testid": "product-page" }),
+}));
+
+jest.mock("@/components/pages/static-page", () => ({
+  StaticPage: (props: unknown) => mockStaticPage(props),
+}));
+
+jest.mock("@/components/site/themes/editorial-v1/template-slot", () => ({
+  TemplateSlot: () =>
+    React.createElement("div", { "data-testid": "template-slot" }),
+}));
+
+jest.mock("@/lib/supabase/get-website", () => ({
+  getWebsiteBySubdomain: (...args: unknown[]) =>
+    mockGetWebsiteBySubdomain(...args),
+}));
+
+jest.mock("@/lib/supabase/get-pages", () => ({
+  getCategoryProducts: jest.fn(async () => ({ items: [], total: 0 })),
+  getDestinations: (...args: unknown[]) => mockGetDestinations(...args),
+  getLocalizedProductOverlay: jest.fn(),
+  getPageBySlug: (...args: unknown[]) => mockGetPageBySlug(...args),
+  getPageBySlugForLocale: (...args: unknown[]) => mockGetPageBySlug(...args),
+  getProductPage: (...args: unknown[]) => mockGetProductPage(...args),
+  getProductSlugRedirect: (...args: unknown[]) =>
+    mockGetProductSlugRedirect(...args),
+}));
+
+jest.mock("@/lib/supabase/get-reviews", () => ({
+  getReviewsForContext: jest.fn(async () => []),
+}));
+
+jest.mock("@/lib/supabase/get-planners", () => ({
+  getPlanners: jest.fn(async () => []),
+}));
+
+jest.mock("@/lib/seo/public-metadata", () => ({
+  buildLocaleAwareAlternateLanguages: (baseUrl: string, pathname: string) => ({
+    "es-CO": `${baseUrl}${pathname}`,
+  }),
+  resolvePublicMetadataLocale: jest.fn(async () => ({
+    resolvedLocale: "es-CO",
+    defaultLocale: "es-CO",
+    resolvedLanguage: "es",
+  })),
+}));
+
+jest.mock("@/lib/seo/locale-routing", () => ({
+  buildPublicLocalizedPath: (pathname: string) => pathname,
+  localeToOgLocale: () => "es_CO",
+  translateCategoryPathname: (pathname: string) => pathname,
+}));
+
+jest.mock("@/lib/seo/og-helpers", () => ({
+  resolveOgImage: (_website: unknown, image: string | null) => image,
+}));
+
+import PackageSlugPage, {
+  generateMetadata as generatePackageMetadata,
+} from "@/app/site/[subdomain]/paquetes/[slug]/page";
+import ActivitySlugPage, {
+  generateMetadata as generateActivityMetadata,
+} from "@/app/site/[subdomain]/actividades/[slug]/page";
+
+const website = {
+  id: "web-colombiatours",
+  account_id: "acct-colombiatours",
+  subdomain: "colombiatours",
+  custom_domain: "colombiatours.travel",
+  status: "published",
+  content: {
+    siteName: "Colombia Tours Travel",
+    account: { name: "Colombia Tours Travel" },
+  },
+  featured_products: {
+    destinations: [],
+    hotels: [],
+    activities: [],
+    transfers: [],
+    packages: [],
+  },
+  sections: [],
+};
+
+function makePublishedLanding(slug: string) {
+  return {
+    id: `page-${slug}`,
+    slug,
+    title: "Cartagena Medellin",
+    seo_title: "Cartagena Medellin | Colombia Tours Travel",
+    seo_description:
+      "Itinerario personalizado para viajar por Colombia con soporte local, asesoría experta y acompañamiento durante la reserva.",
+    is_published: true,
+    robots_noindex: false,
+    hero_config: { backgroundImage: "https://cdn.example/hero.jpg" },
+    custom_sections: [],
+    sections_order: [],
+    hidden_sections: [],
+  };
+}
+
+describe("product static landing fallback", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetWebsiteBySubdomain.mockResolvedValue(website);
+    mockGetProductPage.mockResolvedValue(null);
+    mockGetProductSlugRedirect.mockResolvedValue(null);
+    mockGetDestinations.mockResolvedValue([]);
+  });
+
+  it("serves a published package landing as indexable metadata when the product RPC misses", async () => {
+    mockGetPageBySlug.mockResolvedValue(
+      makePublishedLanding("paquetes/cartagena-medellin"),
+    );
+
+    const metadata = await generatePackageMetadata({
+      params: Promise.resolve({
+        subdomain: "colombiatours",
+        slug: "cartagena-medellin",
+      }),
+    });
+    const element = await PackageSlugPage({
+      params: Promise.resolve({
+        subdomain: "colombiatours",
+        slug: "cartagena-medellin",
+      }),
+    });
+
+    expect(metadata.robots).toBeUndefined();
+    expect(metadata.alternates?.canonical).toBe(
+      "https://colombiatours.travel/paquetes/cartagena-medellin",
+    );
+    expect(mockGetPageBySlug).toHaveBeenCalledWith(
+      "web-colombiatours",
+      "paquetes/cartagena-medellin",
+      "es-CO",
+    );
+    expect(mockNotFound).not.toHaveBeenCalled();
+    expect(React.isValidElement(element)).toBe(true);
+    expect(element.props).toEqual(
+      expect.objectContaining({
+        page: expect.objectContaining({
+          slug: "paquetes/cartagena-medellin",
+          is_published: true,
+        }),
+      }),
+    );
+  });
+
+  it("serves a published activity landing as indexable metadata when the product RPC misses", async () => {
+    mockGetPageBySlug.mockResolvedValue(
+      makePublishedLanding("actividades/city-tour-cartagena"),
+    );
+
+    const metadata = await generateActivityMetadata({
+      params: Promise.resolve({
+        subdomain: "colombiatours",
+        slug: "city-tour-cartagena",
+      }),
+    });
+    const element = await ActivitySlugPage({
+      params: Promise.resolve({
+        subdomain: "colombiatours",
+        slug: "city-tour-cartagena",
+      }),
+    });
+
+    expect(metadata.robots).toBeUndefined();
+    expect(metadata.alternates?.canonical).toBe(
+      "https://colombiatours.travel/actividades/city-tour-cartagena",
+    );
+    expect(mockGetPageBySlug).toHaveBeenCalledWith(
+      "colombiatours",
+      "actividades/city-tour-cartagena",
+    );
+    expect(mockNotFound).not.toHaveBeenCalled();
+    expect(React.isValidElement(element)).toBe(true);
+    expect(element.props).toEqual(
+      expect.objectContaining({
+        page: expect.objectContaining({
+          slug: "actividades/city-tour-cartagena",
+          is_published: true,
+        }),
+      }),
+    );
+  });
+});

--- a/__tests__/lib/seo/sitemap.test.ts
+++ b/__tests__/lib/seo/sitemap.test.ts
@@ -13,12 +13,43 @@ jest.mock("@/lib/supabase/get-pages", () => ({
 
 import { groupBlogRowsForSitemap } from "@/lib/seo/blog-sitemap-groups";
 import {
+  buildSitemapUrls,
   generateSitemapXml,
   localizeSitemapUrlsForLocale,
   type SitemapUrl,
 } from "@/lib/seo/sitemap";
+import {
+  getAllPageSlugs,
+  getCategoryProducts,
+  getDestinations,
+  getIndexablePageSlugs,
+  getNoindexDestinationSlugs,
+  getNoindexProductSlugs,
+} from "@/lib/supabase/get-pages";
+import { getPublishedBlogPostSitemapRows } from "@/lib/supabase/get-website";
+
+const mockedGetAllPageSlugs = jest.mocked(getAllPageSlugs);
+const mockedGetCategoryProducts = jest.mocked(getCategoryProducts);
+const mockedGetDestinations = jest.mocked(getDestinations);
+const mockedGetIndexablePageSlugs = jest.mocked(getIndexablePageSlugs);
+const mockedGetNoindexDestinationSlugs = jest.mocked(getNoindexDestinationSlugs);
+const mockedGetNoindexProductSlugs = jest.mocked(getNoindexProductSlugs);
+const mockedGetPublishedBlogPostSitemapRows = jest.mocked(
+  getPublishedBlogPostSitemapRows,
+);
 
 describe("sitemap blog quality gates", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetPublishedBlogPostSitemapRows.mockResolvedValue([]);
+    mockedGetAllPageSlugs.mockResolvedValue([]);
+    mockedGetIndexablePageSlugs.mockResolvedValue([]);
+    mockedGetNoindexProductSlugs.mockResolvedValue(new Set());
+    mockedGetNoindexDestinationSlugs.mockResolvedValue(new Set());
+    mockedGetDestinations.mockResolvedValue([]);
+    mockedGetCategoryProducts.mockResolvedValue({ items: [], total: 0 });
+  });
+
   it("removes EN quality-blocked blog rows from translated sitemap alternates", () => {
     const groups = groupBlogRowsForSitemap([
       {
@@ -184,5 +215,63 @@ describe("sitemap blog quality gates", () => {
     });
 
     expect(localized).toEqual([]);
+  });
+});
+
+describe("sitemap product indexability gates", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetPublishedBlogPostSitemapRows.mockResolvedValue([]);
+    mockedGetNoindexProductSlugs.mockResolvedValue(new Set());
+    mockedGetNoindexDestinationSlugs.mockResolvedValue(new Set());
+    mockedGetDestinations.mockResolvedValue([]);
+    mockedGetCategoryProducts.mockResolvedValue({ items: [], total: 0 });
+  });
+
+  it("does not emit shadowed default-locale aliases like /packages/* when /paquetes/* exists", async () => {
+    mockedGetAllPageSlugs.mockResolvedValue([
+      "paquetes",
+      "packages",
+      "paquetes/cartagena-medellin",
+      "packages/cartagena-medellin",
+      "actividades",
+      "activities",
+      "actividades/city-tour-full-day",
+      "activities/city-tour-full-day",
+    ]);
+    mockedGetIndexablePageSlugs.mockResolvedValue([
+      "paquetes",
+      "packages",
+      "paquetes/cartagena-medellin",
+      "packages/cartagena-medellin",
+      "actividades",
+      "activities",
+      "actividades/city-tour-full-day",
+      "activities/city-tour-full-day",
+    ]);
+
+    const urls = await buildSitemapUrls(
+      "colombiatours",
+      "website-colombiatours",
+      "https://colombiatours.travel",
+    );
+    const locs = urls.map((url) => url.loc);
+
+    expect(locs).toContain("https://colombiatours.travel/paquetes");
+    expect(locs).toContain(
+      "https://colombiatours.travel/paquetes/cartagena-medellin",
+    );
+    expect(locs).toContain("https://colombiatours.travel/actividades");
+    expect(locs).toContain(
+      "https://colombiatours.travel/actividades/city-tour-full-day",
+    );
+    expect(locs).not.toContain("https://colombiatours.travel/packages");
+    expect(locs).not.toContain(
+      "https://colombiatours.travel/packages/cartagena-medellin",
+    );
+    expect(locs).not.toContain("https://colombiatours.travel/activities");
+    expect(locs).not.toContain(
+      "https://colombiatours.travel/activities/city-tour-full-day",
+    );
   });
 });

--- a/__tests__/middleware/product-fallback-routing.test.ts
+++ b/__tests__/middleware/product-fallback-routing.test.ts
@@ -1,0 +1,153 @@
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("middleware product fallback routing", () => {
+  const originalFetch = global.fetch;
+  const originalSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const originalSupabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const originalMainDomain = process.env.NEXT_PUBLIC_MAIN_DOMAIN;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.NEXT_PUBLIC_SUPABASE_URL = originalSupabaseUrl;
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = originalSupabaseAnonKey;
+    process.env.NEXT_PUBLIC_MAIN_DOMAIN = originalMainDomain;
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("does not apply slug redirects when a published static product landing exists", async () => {
+    jest.resetModules();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://supabase.test";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-test";
+    process.env.NEXT_PUBLIC_MAIN_DOMAIN = "bukeer.com";
+
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.includes("/rest/v1/websites?")) {
+        return jsonResponse([
+          {
+            id: "website-colombiatours",
+            subdomain: "colombiatours",
+            account_id: "account-colombiatours",
+            default_locale: "es-CO",
+            supported_locales: ["es-CO", "en-US"],
+          },
+        ]);
+      }
+
+      if (url.includes("/rest/v1/rpc/get_website_product_page")) {
+        return jsonResponse({ product: null });
+      }
+
+      if (
+        url.includes("/rest/v1/website_pages?") &&
+        url.includes("slug=eq.paquetes%2Fcartagena-medellin")
+      ) {
+        return jsonResponse([{ id: "page-cartagena-medellin" }]);
+      }
+
+      if (url.includes("/rest/v1/slug_redirects?")) {
+        return jsonResponse([{ new_slug: "cartagena" }]);
+      }
+
+      return jsonResponse([]);
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const { NextRequest } = await import("next/server");
+    const { middleware } = await import("@/middleware");
+
+    const response = await middleware(
+      new NextRequest("https://colombiatours.travel/paquetes/cartagena-medellin", {
+        headers: { host: "colombiatours.travel" },
+      }),
+    );
+
+    expect(response.status).not.toBe(301);
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("x-middleware-rewrite")).toContain(
+      "/site/colombiatours/paquetes/cartagena-medellin",
+    );
+    expect(
+      fetchMock.mock.calls.some(([input]) =>
+        String(input).includes("/rest/v1/slug_redirects?"),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not apply legacy redirects when the product route exists", async () => {
+    jest.resetModules();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://supabase.test";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-test";
+    process.env.NEXT_PUBLIC_MAIN_DOMAIN = "bukeer.com";
+
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.includes("/rest/v1/websites?")) {
+        return jsonResponse([
+          {
+            id: "website-colombiatours",
+            subdomain: "colombiatours",
+            account_id: "account-colombiatours",
+            default_locale: "es-CO",
+            supported_locales: ["es-CO", "en-US"],
+          },
+        ]);
+      }
+
+      if (url.includes("/rest/v1/rpc/get_website_product_page")) {
+        return jsonResponse({
+          product: {
+            id: "pkg-cartagena-premium",
+            slug: "cartagena-premium-ciudad-amurallada-y-caribe-5-dias",
+            type: "package",
+          },
+        });
+      }
+
+      if (url.includes("/rest/v1/website_legacy_redirects?")) {
+        return jsonResponse([
+          {
+            old_path:
+              "/paquetes/cartagena-premium-ciudad-amurallada-y-caribe-5-dias",
+            new_path: "/cartagena",
+            status_code: 301,
+          },
+        ]);
+      }
+
+      return jsonResponse([]);
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const { NextRequest } = await import("next/server");
+    const { middleware } = await import("@/middleware");
+
+    const response = await middleware(
+      new NextRequest(
+        "https://colombiatours.travel/paquetes/cartagena-premium-ciudad-amurallada-y-caribe-5-dias",
+        {
+          headers: { host: "colombiatours.travel" },
+        },
+      ),
+    );
+
+    expect(response.status).not.toBe(301);
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("x-middleware-rewrite")).toContain(
+      "/site/colombiatours/paquetes/cartagena-premium-ciudad-amurallada-y-caribe-5-dias",
+    );
+    expect(
+      fetchMock.mock.calls.some(([input]) =>
+        String(input).includes("/rest/v1/website_legacy_redirects?"),
+      ),
+    ).toBe(false);
+  });
+});

--- a/app/site/[subdomain]/actividades/[slug]/page.tsx
+++ b/app/site/[subdomain]/actividades/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { notFound, permanentRedirect, redirect } from "next/navigation";
 
 import { ProductLandingPage } from "@/components/pages/product-landing-page";
+import { StaticPage } from "@/components/pages/static-page";
 import { TemplateSlot } from "@/components/site/themes/editorial-v1/template-slot";
 import type { EditorialActivityDetailPayload } from "@/components/site/themes/editorial-v1/pages/activity-detail";
 import { ACTIVITY_FAQS_DEFAULT } from "@/lib/products/activity-faqs-default";
@@ -13,7 +14,9 @@ import { sanitizeProductCopy } from "@/lib/products/normalize-product";
 import { resolveTemplateSet } from "@/lib/sections/template-set";
 import {
   getCategoryProducts,
+  getDestinations,
   getLocalizedProductOverlay,
+  getPageBySlug,
   getProductPage,
   getProductSlugRedirect,
 } from "@/lib/supabase/get-pages";
@@ -75,6 +78,54 @@ export async function generateMetadata({
   });
 
   if (!productPage?.product) {
+    const fallbackLanding = await getPageBySlug(subdomain, `actividades/${slug}`);
+    if (fallbackLanding?.is_published) {
+      const title = normalizePublicMetadataTitle(
+        fallbackLanding.seo_title || fallbackLanding.title,
+        siteName,
+      );
+      const description =
+        fallbackLanding.seo_description ||
+        `${siteName} - Actividades y experiencias en Colombia con información clara, soporte local y opciones de reserva.`;
+      const ogImage = resolveOgImage(
+        website,
+        fallbackLanding.hero_config?.backgroundImage || null,
+      );
+      const metadata: Metadata = {
+        title,
+        description,
+        alternates: {
+          canonical: `${baseUrl}/actividades/${slug}`,
+          languages: buildLocaleAwareAlternateLanguages(
+            baseUrl,
+            `/actividades/${slug}`,
+            localeContext,
+          ),
+        },
+        openGraph: {
+          title,
+          description,
+          type: "website",
+          url: `${baseUrl}/actividades/${slug}`,
+          siteName,
+          locale: localeToOgLocale(localeContext.resolvedLocale),
+          ...(ogImage && { images: [{ url: ogImage }] }),
+        },
+        twitter: {
+          card: "summary_large_image",
+          title,
+          description,
+          ...(ogImage && { images: [ogImage] }),
+        },
+      };
+
+      if (fallbackLanding.robots_noindex) {
+        metadata.robots = { index: false, follow: true };
+      }
+
+      return metadata;
+    }
+
     return {
       title: "Actividad no encontrada",
       description: fallbackDescription,
@@ -210,6 +261,30 @@ export default async function ActivitySlugPage({ params }: ActivityPageProps) {
     if (redirectedSlug) {
       permanentRedirect(`/site/${subdomain}/actividades/${redirectedSlug}`);
     }
+
+    const fallbackLanding = await getPageBySlug(
+      subdomain,
+      `actividades/${slug}`,
+    );
+    if (fallbackLanding?.is_published) {
+      const isCustomDomain = inferIsCustomDomainWebsite(website);
+      const websiteForRender = {
+        ...website,
+        resolvedLocale,
+        defaultLocale: localeContext.defaultLocale ?? "es-CO",
+        isCustomDomain,
+      };
+      const dynamicDestinations = await getDestinations(subdomain);
+
+      return (
+        <StaticPage
+          website={websiteForRender}
+          page={fallbackLanding}
+          dynamicDestinations={dynamicDestinations}
+        />
+      );
+    }
+
     notFound();
   }
 

--- a/app/site/[subdomain]/paquetes/[slug]/page.tsx
+++ b/app/site/[subdomain]/paquetes/[slug]/page.tsx
@@ -59,9 +59,13 @@ function looksLikeLegacyId(value: string): boolean {
   );
 }
 
-function localizedStaticPackageSlug(slug: string, localizedPathname: string): string | null {
+function localizedStaticPackageSlug(
+  slug: string,
+  localizedPathname?: string | null,
+): string | null {
+  if (!localizedPathname) return `paquetes/${slug}`;
   const path = localizedPathname.replace(/^\/+|\/+$/g, "");
-  if (!path || path === `paquetes/${slug}`) return null;
+  if (!path || path === `paquetes/${slug}`) return `paquetes/${slug}`;
   const parts = path.split("/");
   if (parts.length < 2 || parts[parts.length - 1] !== slug) return null;
   return path;
@@ -126,6 +130,8 @@ export async function generateMetadata({
         )
       : null;
     if (staticPage?.is_published) {
+      const canonicalPathname =
+        localeContext.localizedPathname || `/${staticSlug}`;
       const pageTitle = normalizePublicMetadataTitle(
         staticPage.seo_title || staticPage.title,
         siteName,
@@ -135,7 +141,7 @@ export async function generateMetadata({
         title: pageTitle,
         description,
         alternates: {
-          canonical: `${baseUrl}${localeContext.localizedPathname}`,
+          canonical: `${baseUrl}${canonicalPathname}`,
           languages: buildLocaleAwareAlternateLanguages(
             baseUrl,
             `/paquetes/${slug}`,

--- a/lib/seo/sitemap.ts
+++ b/lib/seo/sitemap.ts
@@ -65,6 +65,11 @@ const CATEGORY_SLUG_MAP: Record<string, string> = {
   packages: "paquetes",
 };
 
+const DEFAULT_CATEGORY_ALIAS_MAP: Record<string, string> = {
+  ...CATEGORY_SLUG_MAP,
+  destinations: "destinos",
+};
+
 /**
  * Build all sitemap URLs for a tenant website.
  *
@@ -98,6 +103,10 @@ export async function buildSitemapUrls(
   const allPageSlugSet = new Set(allPageSlugs);
 
   for (const slug of pageSlugs) {
+    if (isShadowedDefaultLocaleAlias(slug, allPageSlugSet)) {
+      continue;
+    }
+
     urls.push({
       loc: `${baseUrl}/${slug}`,
       changefreq: "weekly",
@@ -205,6 +214,21 @@ export async function buildSitemapUrls(
   }
 
   return urls;
+}
+
+function isShadowedDefaultLocaleAlias(
+  slug: string,
+  allPageSlugSet: Set<string>,
+): boolean {
+  const [firstSegment, ...rest] = slug.split("/").filter(Boolean);
+  if (!firstSegment) return false;
+
+  const canonicalSegment = DEFAULT_CATEGORY_ALIAS_MAP[firstSegment];
+  if (!canonicalSegment || canonicalSegment === firstSegment) return false;
+  if (!allPageSlugSet.has(canonicalSegment)) return false;
+
+  const canonicalSlug = [canonicalSegment, ...rest].join("/");
+  return allPageSlugSet.has(canonicalSlug) || rest.length === 0;
 }
 
 /**

--- a/middleware.ts
+++ b/middleware.ts
@@ -65,6 +65,27 @@ function isLocalizedSystemPageAliasPath(
   );
 }
 
+async function shouldBypassLegacyRedirectForProductRoute(
+  website: WebsiteLookup | null,
+  route: { categorySlug: string; productType: string; productSlug: string } | null,
+): Promise<boolean> {
+  if (!website?.id || !website.subdomain || !route) {
+    return false;
+  }
+
+  const exists = await productExists(
+    website.subdomain,
+    route.productType,
+    route.productSlug,
+  );
+  if (exists) return true;
+
+  return publishedWebsitePageExistsBySlug(
+    website.id,
+    `${route.categorySlug}/${route.productSlug}`,
+  );
+}
+
 const CATEGORY_TO_PRODUCT_TYPE: Record<string, string> = {
   destinos: "destination",
   destinations: "destination",
@@ -424,6 +445,28 @@ async function productExists(
   return product === undefined || Boolean(product);
 }
 
+async function publishedWebsitePageExistsBySlug(
+  websiteId: string,
+  slug: string,
+): Promise<boolean> {
+  const normalizedSlug = slug
+    .split("/")
+    .filter(Boolean)
+    .join("/");
+  if (!normalizedSlug) return false;
+
+  const cacheKey = `page-slug:${websiteId}:${normalizedSlug}`;
+  const cached = getCached<boolean>(cacheKey);
+  if (cached !== undefined) return cached;
+
+  const data = await supabaseFetch<Array<{ id: string }>>(
+    `/rest/v1/website_pages?select=id&website_id=eq.${encodeURIComponent(websiteId)}&slug=eq.${encodeURIComponent(normalizedSlug)}&is_published=eq.true&limit=1`,
+  );
+  const result = Boolean(data && data.length > 0);
+  setCached(cacheKey, result);
+  return result;
+}
+
 async function localizedProductOverlayExists(
   websiteId: string,
   productType: string,
@@ -748,6 +791,14 @@ async function trySlugRedirect(
     route.productSlug,
   );
   if (exists) {
+    return null;
+  }
+
+  const publishedFallbackPageExists = await publishedWebsitePageExistsBySlug(
+    website.id,
+    `${route.categorySlug}/${route.productSlug}`,
+  );
+  if (publishedFallbackPageExists) {
     return null;
   }
 
@@ -1409,7 +1460,13 @@ export async function middleware(request: NextRequest) {
         !isLegalPathname(localeResolution.pathnameWithoutLang) &&
         !isLocalizedSystemPageAliasPath(localeResolution);
 
-      if (allowLegacyRedirects) {
+      if (
+        allowLegacyRedirects &&
+        !(await shouldBypassLegacyRedirectForProductRoute(
+          website,
+          potentialProductRoute,
+        ))
+      ) {
         const legacyRedirectResponse = await tryLegacyRedirect(
           request,
           website,
@@ -1518,7 +1575,13 @@ export async function middleware(request: NextRequest) {
       !isLegalPathname(localeResolution.pathnameWithoutLang) &&
       !isLocalizedSystemPageAliasPath(localeResolution);
 
-    if (allowLegacyRedirects) {
+    if (
+      allowLegacyRedirects &&
+      !(await shouldBypassLegacyRedirectForProductRoute(
+        website,
+        potentialProductRoute,
+      ))
+    ) {
       const legacyRedirectResponse = await tryLegacyRedirect(
         request,
         website,
@@ -1614,7 +1677,13 @@ export async function middleware(request: NextRequest) {
       !isLegalPathname(localeResolution.pathnameWithoutLang) &&
       !isLocalizedSystemPageAliasPath(localeResolution);
 
-    if (allowLegacyRedirects) {
+    if (
+      allowLegacyRedirects &&
+      !(await shouldBypassLegacyRedirectForProductRoute(
+        website,
+        potentialProductRoute,
+      ))
+    ) {
       const legacyRedirectResponse = await tryLegacyRedirect(
         request,
         website,

--- a/scripts/seo/audit-product-indexing-gate.mjs
+++ b/scripts/seo/audit-product-indexing-gate.mjs
@@ -1,0 +1,483 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { createClient } from "@supabase/supabase-js";
+
+const DEFAULT_BASE_URL = "https://colombiatours.travel";
+const DEFAULT_OUT_DIR = "artifacts/seo/product-indexing-gate";
+const PRODUCT_PREFIXES = [
+  "/paquetes/",
+  "/actividades/",
+  "/packages/",
+  "/activities/",
+];
+
+const args = parseArgs(process.argv.slice(2));
+const baseUrl = normalizeBaseUrl(args.baseUrl ?? DEFAULT_BASE_URL);
+const outDir = args.outDir ?? DEFAULT_OUT_DIR;
+const limit = Number(args.limit ?? 0);
+const includeDb = args.db !== false;
+
+const startedAt = new Date().toISOString();
+
+if (isCliEntryPoint()) {
+  main().catch((error) => {
+    console.error("[product-indexing-gate] failed", redactError(error));
+    process.exit(1);
+  });
+}
+
+async function main() {
+  const urls = new Map();
+  const sitemapUrls = await readSitemapProductUrls(baseUrl);
+  for (const url of sitemapUrls) addSource(urls, url, "sitemap");
+
+  for (const listingPath of ["/paquetes", "/actividades", "/packages", "/activities"]) {
+    const listingUrls = await readListingProductUrls(`${baseUrl}${listingPath}`);
+    for (const url of listingUrls) addSource(urls, url, `listing:${listingPath}`);
+  }
+
+  if (includeDb) {
+    const dbUrls = await readDbProductLikeUrls(baseUrl);
+    for (const row of dbUrls) {
+      addSource(urls, row.url, row.source);
+      const current = urls.get(row.url);
+      current.db = row.db;
+    }
+  }
+
+  let candidates = [...urls.values()].sort((a, b) => a.url.localeCompare(b.url));
+  if (limit > 0) candidates = candidates.slice(0, limit);
+
+  const checks = [];
+  for (const candidate of candidates) {
+    checks.push(await auditUrl(candidate));
+  }
+
+  const summary = summarize(checks);
+  const report = {
+    contract: "product_indexing_gate_v1",
+    base_url: baseUrl,
+    started_at: startedAt,
+    completed_at: new Date().toISOString(),
+    summary,
+    checks,
+  };
+
+  await fs.mkdir(outDir, { recursive: true });
+  const stamp = startedAt.replace(/[:.]/g, "-");
+  const jsonPath = path.join(outDir, `${stamp}-product-indexing-gate.json`);
+  const mdPath = path.join(outDir, `${stamp}-product-indexing-gate.md`);
+  await fs.writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`);
+  await fs.writeFile(mdPath, renderMarkdown(report));
+
+  console.log(
+    JSON.stringify(
+      {
+        status: summary.p0 === 0 && summary.p1 === 0 ? "PASS" : "FAIL",
+        summary,
+        jsonPath,
+        mdPath,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (args.strict && (summary.p0 > 0 || summary.p1 > 0)) {
+    process.exit(2);
+  }
+}
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const arg = rawArgs[index];
+    if (arg === "--strict") {
+      parsed.strict = true;
+    } else if (arg === "--no-db") {
+      parsed.db = false;
+    } else if (arg.startsWith("--base-url=")) {
+      parsed.baseUrl = arg.slice("--base-url=".length);
+    } else if (arg === "--base-url") {
+      parsed.baseUrl = rawArgs[index + 1];
+      index += 1;
+    } else if (arg.startsWith("--out-dir=")) {
+      parsed.outDir = arg.slice("--out-dir=".length);
+    } else if (arg === "--out-dir") {
+      parsed.outDir = rawArgs[index + 1];
+      index += 1;
+    } else if (arg.startsWith("--limit=")) {
+      parsed.limit = arg.slice("--limit=".length);
+    } else if (arg === "--limit") {
+      parsed.limit = rawArgs[index + 1];
+      index += 1;
+    }
+  }
+  return parsed;
+}
+
+function normalizeBaseUrl(input) {
+  return String(input || DEFAULT_BASE_URL).replace(/\/+$/, "");
+}
+
+function addSource(map, url, source) {
+  if (!isProductLikeUrl(url)) return;
+  const normalized = normalizeUrl(url);
+  if (!normalized) return;
+  const row = map.get(normalized) ?? { url: normalized, sources: [] };
+  if (!row.sources.includes(source)) row.sources.push(source);
+  map.set(normalized, row);
+}
+
+async function readSitemapProductUrls(siteBaseUrl) {
+  const sitemapUrl = `${siteBaseUrl}/sitemap.xml`;
+  const response = await fetch(sitemapUrl, { redirect: "follow" });
+  if (!response.ok) return [];
+  const xml = await response.text();
+  return [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) => match[1].trim());
+}
+
+async function readListingProductUrls(listingUrl) {
+  try {
+    const response = await fetch(listingUrl, { redirect: "follow" });
+    if (!response.ok) return [];
+    const html = await response.text();
+    const origin = new URL(response.url).origin;
+    return [...html.matchAll(/\shref=["']([^"']+)["']/g)]
+      .map((match) => normalizeUrl(match[1], origin))
+      .filter(Boolean)
+      .filter(isProductLikeUrl);
+  } catch {
+    return [];
+  }
+}
+
+async function readDbProductLikeUrls(siteBaseUrl) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !anonKey) return [];
+
+  const client = createClient(supabaseUrl, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const host = new URL(siteBaseUrl).hostname;
+  const { data: website } = await client
+    .from("websites")
+    .select("id, subdomain, custom_domain")
+    .or(`custom_domain.eq.${host},subdomain.eq.${host.split(".")[0]}`)
+    .maybeSingle();
+
+  if (!website?.id) return [];
+
+  const { data: pages } = await client
+    .from("website_pages")
+    .select("id, slug, is_published, robots_noindex, page_type, category_type, updated_at")
+    .eq("website_id", website.id)
+    .eq("is_published", true)
+    .or(
+      "slug.like.paquetes/%,slug.like.actividades/%,slug.like.packages/%,slug.like.activities/%",
+    );
+
+  return (pages ?? [])
+    .filter((page) => typeof page.slug === "string" && page.slug.length > 0)
+    .map((page) => ({
+      url: `${siteBaseUrl}/${page.slug.replace(/^\/+/, "")}`,
+      source: "db:website_pages",
+      db: {
+        table: "website_pages",
+        id: page.id,
+        is_published: page.is_published,
+        robots_noindex: page.robots_noindex,
+        page_type: page.page_type,
+        category_type: page.category_type,
+        updated_at: page.updated_at,
+      },
+    }));
+}
+
+async function auditUrl(candidate) {
+  try {
+    const response = await fetch(candidate.url, { redirect: "follow" });
+    const html = await response.text();
+    const rendered = parseRenderedPage(response, html);
+    const issues = classifyIssues(candidate, rendered);
+    return {
+      ...candidate,
+      rendered,
+      issues,
+      verdict: issues.some((issue) => issue.severity === "P0")
+        ? "P0"
+        : issues.some((issue) => issue.severity === "P1")
+          ? "P1"
+          : issues.some((issue) => issue.severity === "P2")
+            ? "P2"
+            : "PASS",
+    };
+  } catch (error) {
+    return {
+      ...candidate,
+      rendered: null,
+      issues: [
+        {
+          severity: "P0",
+          code: "fetch_failed",
+          message: redactError(error),
+        },
+      ],
+      verdict: "P0",
+    };
+  }
+}
+
+function parseRenderedPage(response, html) {
+  const title = matchFirst(html, /<title[^>]*>([\s\S]*?)<\/title>/i);
+  const description =
+    matchFirst(html, /<meta[^>]+name=["']description["'][^>]+content=["']([^"']*)["']/i) ??
+    matchFirst(html, /<meta[^>]+content=["']([^"']*)["'][^>]+name=["']description["']/i);
+  const robots =
+    matchFirst(html, /<meta[^>]+name=["']robots["'][^>]+content=["']([^"']*)["']/i) ??
+    "";
+  const canonical = matchFirst(
+    html,
+    /<link[^>]+rel=["']canonical["'][^>]+href=["']([^"']+)["']/i,
+  );
+  const h1 = [...html.matchAll(/<h1[^>]*>([\s\S]*?)<\/h1>/gi)]
+    .map((match) => stripHtml(match[1]))
+    .filter(Boolean);
+  const schemaTypes = [];
+  for (const match of html.matchAll(
+    /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi,
+  )) {
+    try {
+      const json = JSON.parse(match[1]);
+      const rows = Array.isArray(json) ? json : [json];
+      for (const row of rows) {
+        if (Array.isArray(row?.["@graph"])) {
+          for (const graphRow of row["@graph"]) schemaTypes.push(graphRow?.["@type"]);
+        } else {
+          schemaTypes.push(row?.["@type"]);
+        }
+      }
+    } catch {
+      schemaTypes.push("parse_error");
+    }
+  }
+
+  return {
+    status: response.status,
+    final_url: response.url,
+    title: stripHtml(title ?? ""),
+    title_length: stripHtml(title ?? "").length,
+    description_length: description?.length ?? 0,
+    robots,
+    x_robots_tag: response.headers.get("x-robots-tag"),
+    canonical,
+    h1,
+    schema_types: schemaTypes.flat().filter(Boolean),
+    bytes: html.length,
+  };
+}
+
+function classifyIssues(candidate, rendered) {
+  const issues = [];
+  const inSitemapOrListing = candidate.sources.some(
+    (source) => source === "sitemap" || source.startsWith("listing:"),
+  );
+  const dbSaysIndexable =
+    candidate.db?.is_published === true && candidate.db?.robots_noindex !== true;
+  const shouldBeIndexable = inSitemapOrListing || dbSaysIndexable;
+  const renderedFinalUrl = rendered.final_url
+    ? normalizeUrl(rendered.final_url)
+    : null;
+  const renderedCanonical = rendered.canonical
+    ? normalizeUrl(rendered.canonical)
+    : null;
+
+  if (rendered.status !== 200) {
+    issues.push({
+      severity: "P0",
+      code: "non_200",
+      message: `Expected HTTP 200, got ${rendered.status}`,
+    });
+  }
+
+  if (shouldBeIndexable && renderedFinalUrl && renderedFinalUrl !== candidate.url) {
+    issues.push({
+      severity: "P0",
+      code: "public_url_redirects",
+      message: `Public product URL redirects to ${renderedFinalUrl}`,
+    });
+  }
+
+  if (shouldBeIndexable && /\bnoindex\b/i.test(rendered.robots || "")) {
+    issues.push({
+      severity: "P0",
+      code: "public_url_noindex",
+      message: "Public product URL is in sitemap/listing/DB but renders noindex",
+    });
+  }
+
+  if (shouldBeIndexable && !rendered.canonical) {
+    issues.push({
+      severity: "P0",
+      code: "missing_canonical",
+      message: "Public product URL has no canonical",
+    });
+  }
+
+  if (
+    shouldBeIndexable &&
+    renderedCanonical &&
+    renderedCanonical !== candidate.url
+  ) {
+    issues.push({
+      severity: "P0",
+      code: "canonical_mismatch",
+      message: `Public product URL canonical points to ${renderedCanonical}`,
+    });
+  }
+
+  if (shouldBeIndexable && rendered.h1.length === 0) {
+    issues.push({
+      severity: "P0",
+      code: "missing_h1",
+      message: "Public product URL has no H1",
+    });
+  } else if (rendered.h1.length > 1) {
+    issues.push({
+      severity: "P1",
+      code: "multiple_h1",
+      message: `Expected one H1, found ${rendered.h1.length}`,
+    });
+  }
+
+  const hasProductSchema = rendered.schema_types.some((type) =>
+    [
+      "Product",
+      "Offer",
+      "TouristTrip",
+      "TouristAttraction",
+      "FAQPage",
+      "BreadcrumbList",
+    ].includes(String(type)),
+  );
+  if (shouldBeIndexable && !hasProductSchema) {
+    issues.push({
+      severity: "P0",
+      code: "missing_product_schema",
+      message: "Public product URL has no product/travel structured data",
+    });
+  }
+
+  if (shouldBeIndexable && rendered.title_length > 0 && rendered.title_length < 50) {
+    issues.push({
+      severity: "P2",
+      code: "weak_title",
+      message: `Title is short or generic (${rendered.title_length} chars)`,
+    });
+  }
+
+  if (shouldBeIndexable && rendered.description_length > 0 && rendered.description_length < 80) {
+    issues.push({
+      severity: "P2",
+      code: "weak_description",
+      message: `Meta description is short (${rendered.description_length} chars)`,
+    });
+  }
+
+  return issues;
+}
+
+function summarize(checks) {
+  return checks.reduce(
+    (acc, check) => {
+      acc.total += 1;
+      if (check.verdict === "PASS") acc.pass += 1;
+      if (check.verdict === "P0") acc.p0 += 1;
+      if (check.verdict === "P1") acc.p1 += 1;
+      if (check.verdict === "P2") acc.p2 += 1;
+      return acc;
+    },
+    { total: 0, pass: 0, p0: 0, p1: 0, p2: 0 },
+  );
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    "# Product Indexing Gate",
+    "",
+    `- Base URL: ${report.base_url}`,
+    `- Started: ${report.started_at}`,
+    `- Completed: ${report.completed_at}`,
+    `- Total: ${report.summary.total}`,
+    `- PASS: ${report.summary.pass}`,
+    `- P0: ${report.summary.p0}`,
+    `- P1: ${report.summary.p1}`,
+    `- P2: ${report.summary.p2}`,
+    "",
+    "## Failures",
+    "",
+    "| Severity | URL | Sources | Issues |",
+    "|---|---|---|---|",
+  ];
+
+  for (const check of report.checks.filter((row) => row.verdict !== "PASS")) {
+    lines.push(
+      `| ${check.verdict} | ${check.url} | ${check.sources.join(", ")} | ${check.issues
+        .map((issue) => issue.code)
+        .join(", ")} |`,
+    );
+  }
+
+  lines.push("");
+  lines.push("## PASS Sample");
+  lines.push("");
+  for (const check of report.checks.filter((row) => row.verdict === "PASS").slice(0, 20)) {
+    lines.push(`- ${check.url}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function normalizeUrl(value, origin = baseUrl) {
+  try {
+    return new URL(value, origin).toString().replace(/\/$/, "");
+  } catch {
+    return null;
+  }
+}
+
+function isProductLikeUrl(value) {
+  try {
+    const pathname = new URL(value, baseUrl).pathname;
+    return PRODUCT_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+  } catch {
+    return false;
+  }
+}
+
+function matchFirst(value, pattern) {
+  return value.match(pattern)?.[1] ?? null;
+}
+
+function stripHtml(value) {
+  return String(value)
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function redactError(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isCliEntryPoint() {
+  return import.meta.url === `file://${process.argv[1]}`;
+}


### PR DESCRIPTION
## Summary

Hotfix directly against `main` to unblock ColombiaTours public product indexability without deploying the full accumulated `dev -> main` delta.

I also opened PR #603 against `dev` for the normal integration branch. This PR targets production because `origin/dev -> origin/main` currently spans 248 files and ~32k insertions, so merging all of `dev` would not be a controlled product-indexability release.

## Changes

- Serve published static package/activity landings as indexable fallbacks when product RPC lookup misses.
- Bypass slug redirects and legacy redirects when a public product route or published product landing exists.
- Prevent sitemap from emitting default-locale shadow aliases such as `/packages/*` and `/activities/*` when canonical Spanish paths exist.
- Add `scripts/seo/audit-product-indexing-gate.mjs` for live product indexability audits.
- Add focused tests for fallback rendering, middleware redirect precedence, and sitemap alias filtering.

## Validation

Run from clean `origin/main` worktree `/private/tmp/bukeer-indexing-main-hotfix`:

```bash
npm test -- --runTestsByPath __tests__/middleware/product-fallback-routing.test.ts __tests__/app/product-static-landing-fallback.test.tsx __tests__/lib/seo/sitemap.test.ts __tests__/middleware/locale-site-route.test.ts --runInBand
npm run typecheck -- --pretty false
DOTENV_CONFIG_PATH=/Users/yeisongomez/Documents/Proyectos/Bukeer/bukeer-studio/.env.local NODE_OPTIONS='-r dotenv/config' npm run build:worker
```

Results:

- focused Jest: PASS, 4 suites / 26 tests
- typecheck: PASS
- OpenNext worker build: PASS with local env loaded, no secrets printed

Live production before merge/deploy still fails:

- `status=FAIL`
- `total=66`
- `pass=37`
- `p0=9`
- `p1=0`
- `p2=20`

Evidence artifact:

`artifacts/seo/product-indexing-gate/2026-05-31T00-10-55-633Z-product-indexing-gate.md`

## Post-deploy gate

After merge/deploy, rerun:

```bash
DOTENV_CONFIG_PATH=.env.local node -r dotenv/config scripts/seo/audit-product-indexing-gate.mjs --base-url https://colombiatours.travel
```

The objective is not complete until the live gate returns `p0=0` for public package/activity URLs.