### PR TITLE
fix(seo): keep localized product aliases out of default sitemap

### DIFF
--- a/lib/supabase/get-pages.ts
+++ b/lib/supabase/get-pages.ts
@@ -1890,7 +1890,7 @@ export async function getAllPageSlugs(subdomain: string): Promise<string[]> {
     // Get website first
     const { data: websiteData, error: websiteError } = await supabase
       .from("websites")
-      .select("id")
+      .select("id, default_locale")
       .eq("subdomain", subdomain)
       .eq("status", "published")
       .is("deleted_at", null)
@@ -1903,7 +1903,7 @@ export async function getAllPageSlugs(subdomain: string): Promise<string[]> {
     // Get all published pages
     const { data, error } = await supabase
       .from("website_pages")
-      .select("slug")
+      .select("slug, locale")
       .eq("website_id", websiteData.id)
       .eq("is_published", true);
 
@@ -1912,7 +1912,10 @@ export async function getAllPageSlugs(subdomain: string): Promise<string[]> {
       return [];
     }
 
-    return data.map((p) => p.slug);
+    const defaultLocale = websiteData.default_locale || "es-CO";
+    return data
+      .filter((p) => isDefaultLocalePage(p.locale, defaultLocale))
+      .map((p) => p.slug);
   } catch (e) {
     console.error("[getAllPageSlugs] Exception:", e);
     return [];
@@ -1929,7 +1932,7 @@ export async function getIndexablePageSlugs(
   try {
     const { data: websiteData, error: websiteError } = await supabase
       .from("websites")
-      .select("id")
+      .select("id, default_locale")
       .eq("subdomain", subdomain)
       .eq("status", "published")
       .is("deleted_at", null)
@@ -1941,7 +1944,7 @@ export async function getIndexablePageSlugs(
 
     const { data, error } = await supabase
       .from("website_pages")
-      .select("slug, robots_noindex")
+      .select("slug, robots_noindex, locale")
       .eq("website_id", websiteData.id)
       .eq("is_published", true);
 
@@ -1950,11 +1953,24 @@ export async function getIndexablePageSlugs(
       return [];
     }
 
-    return data.filter((p) => !p.robots_noindex).map((p) => p.slug);
+    const defaultLocale = websiteData.default_locale || "es-CO";
+    return data
+      .filter((p) => !p.robots_noindex)
+      .filter((p) => isDefaultLocalePage(p.locale, defaultLocale))
+      .map((p) => p.slug);
   } catch (e) {
     console.error("[getIndexablePageSlugs] Exception:", e);
     return [];
   }
+}
+
+function isDefaultLocalePage(
+  locale: string | null | undefined,
+  defaultLocale: string,
+): boolean {
+  if (!locale) return true;
+  if (locale === defaultLocale) return true;
+  return locale.split("-")[0]?.toLowerCase() === defaultLocale.split("-")[0]?.toLowerCase();
 }
 
 /**

--- a/scripts/seo/audit-product-indexing-gate.mjs
+++ b/scripts/seo/audit-product-indexing-gate.mjs
@@ -167,7 +167,7 @@ async function readDbProductLikeUrls(siteBaseUrl) {
   const host = new URL(siteBaseUrl).hostname;
   const { data: website } = await client
     .from("websites")
-    .select("id, subdomain, custom_domain")
+    .select("id, subdomain, custom_domain, default_locale")
     .or(`custom_domain.eq.${host},subdomain.eq.${host.split(".")[0]}`)
     .maybeSingle();
 
@@ -175,7 +175,7 @@ async function readDbProductLikeUrls(siteBaseUrl) {
 
   const { data: pages } = await client
     .from("website_pages")
-    .select("id, slug, is_published, robots_noindex, page_type, category_type, updated_at")
+    .select("id, slug, locale, is_published, robots_noindex, page_type, category_type, updated_at")
     .eq("website_id", website.id)
     .eq("is_published", true)
     .or(
@@ -185,11 +185,12 @@ async function readDbProductLikeUrls(siteBaseUrl) {
   return (pages ?? [])
     .filter((page) => typeof page.slug === "string" && page.slug.length > 0)
     .map((page) => ({
-      url: `${siteBaseUrl}/${page.slug.replace(/^\/+/, "")}`,
+      url: `${siteBaseUrl}${publicPathForPageSlug(page, website)}`,
       source: "db:website_pages",
       db: {
         table: "website_pages",
         id: page.id,
+        locale: page.locale,
         is_published: page.is_published,
         robots_noindex: page.robots_noindex,
         page_type: page.page_type,
@@ -197,6 +198,19 @@ async function readDbProductLikeUrls(siteBaseUrl) {
         updated_at: page.updated_at,
       },
     }));
+}
+
+function publicPathForPageSlug(page, website) {
+  const slug = page.slug.replace(/^\/+/, "");
+  const locale = typeof page.locale === "string" ? page.locale : "";
+  const defaultLocale = website.default_locale || "es-CO";
+  if (!locale || locale === defaultLocale) return `/${slug}`;
+
+  const localeLanguage = locale.split("-")[0]?.toLowerCase();
+  const defaultLanguage = defaultLocale.split("-")[0]?.toLowerCase();
+  if (!localeLanguage || localeLanguage === defaultLanguage) return `/${slug}`;
+
+  return `/${localeLanguage}/${slug}`;
 }
 
 async function auditUrl(candidate) {


### PR DESCRIPTION
## Summary

Follow-up to #604. Production improved from `p0=9` to `p0=4`, and the remaining P0s are English `/packages/*` aliases leaking into the default sitemap/DB audit path.

This PR keeps localized `website_pages` aliases out of default-locale sitemap generation and updates the product indexability audit to evaluate non-default DB pages at their public localized path, e.g. `/en/packages/...` instead of `/packages/...`.

## Changes

- Filter `getAllPageSlugs` and `getIndexablePageSlugs` to default-locale pages for sitemap generation.
- Keep `null` locale and default-locale pages eligible.
- Map DB-discovered non-default product-like pages to their localized public URL in `audit-product-indexing-gate.mjs`.
- Preserve no-secret logging and read-only audit behavior.

## Validation

Run from clean hotfix worktree `/private/tmp/bukeer-indexing-main-hotfix`:

```bash
npm test -- --runTestsByPath __tests__/middleware/product-fallback-routing.test.ts __tests__/app/product-static-landing-fallback.test.tsx __tests__/lib/seo/sitemap.test.ts __tests__/middleware/locale-site-route.test.ts --runInBand
npm run typecheck -- --pretty false
DOTENV_CONFIG_PATH=/Users/yeisongomez/Documents/Proyectos/Bukeer/bukeer-studio/.env.local NODE_OPTIONS='-r dotenv/config' npm run build:worker
```

Results:

- focused Jest: PASS, 4 suites / 26 tests
- typecheck: PASS
- OpenNext worker build: PASS

Post-#604 live gate before this PR:

- `status=FAIL`
- `total=66`
- `pass=42`
- `p0=4`
- `p1=0`
- `p2=20`

Evidence artifact:

`artifacts/seo/product-indexing-gate/2026-05-31T00-42-27-926Z-product-indexing-gate.md`