### PR TITLE
fix(seo): index localized static package landings

### DIFF
--- a/__tests__/app/product-static-landing-fallback.test.tsx
+++ b/__tests__/app/product-static-landing-fallback.test.tsx
@@ -15,6 +15,12 @@ const mockGetProductPage = jest.fn();
 const mockGetPageBySlug = jest.fn();
 const mockGetProductSlugRedirect = jest.fn();
 const mockGetDestinations = jest.fn();
+const mockResolvePublicMetadataLocale = jest.fn(async () => ({
+  resolvedLocale: "es-CO",
+  defaultLocale: "es-CO",
+  resolvedLanguage: "es",
+  localizedPathname: "/paquetes/cartagena-medellin",
+}));
 const mockStaticPage = jest.fn((props: unknown) =>
   React.createElement("div", { "data-testid": "static-page", props }),
 );
@@ -67,11 +73,8 @@ jest.mock("@/lib/seo/public-metadata", () => ({
   buildLocaleAwareAlternateLanguages: (baseUrl: string, pathname: string) => ({
     "es-CO": `${baseUrl}${pathname}`,
   }),
-  resolvePublicMetadataLocale: jest.fn(async () => ({
-    resolvedLocale: "es-CO",
-    defaultLocale: "es-CO",
-    resolvedLanguage: "es",
-  })),
+  resolvePublicMetadataLocale: (...args: unknown[]) =>
+    mockResolvePublicMetadataLocale(...args),
 }));
 
 jest.mock("@/lib/seo/locale-routing", () => ({
@@ -135,6 +138,12 @@ describe("product static landing fallback", () => {
     mockGetProductPage.mockResolvedValue(null);
     mockGetProductSlugRedirect.mockResolvedValue(null);
     mockGetDestinations.mockResolvedValue([]);
+    mockResolvePublicMetadataLocale.mockResolvedValue({
+      resolvedLocale: "es-CO",
+      defaultLocale: "es-CO",
+      resolvedLanguage: "es",
+      localizedPathname: "/paquetes/cartagena-medellin",
+    });
   });
 
   it("serves a published package landing as indexable metadata when the product RPC misses", async () => {
@@ -174,6 +183,48 @@ describe("product static landing fallback", () => {
         }),
       }),
     );
+  });
+
+  it("serves a localized package landing from its DB slug without preserving the locale prefix", async () => {
+    mockResolvePublicMetadataLocale.mockResolvedValue({
+      resolvedLocale: "en-US",
+      defaultLocale: "es-CO",
+      resolvedLanguage: "en",
+      localizedPathname: "/en/packages/cartagena-medellin",
+    });
+    mockGetPageBySlug.mockResolvedValue(
+      makePublishedLanding("packages/cartagena-medellin"),
+    );
+
+    const metadata = await generatePackageMetadata({
+      params: Promise.resolve({
+        subdomain: "colombiatours",
+        slug: "cartagena-medellin",
+      }),
+    });
+    const element = await PackageSlugPage({
+      params: Promise.resolve({
+        subdomain: "colombiatours",
+        slug: "cartagena-medellin",
+      }),
+    });
+
+    expect(metadata.robots).toBeUndefined();
+    expect(metadata.alternates?.canonical).toBe(
+      "https://colombiatours.travel/en/packages/cartagena-medellin",
+    );
+    expect(mockGetPageBySlug).toHaveBeenCalledWith(
+      "web-colombiatours",
+      "packages/cartagena-medellin",
+      "en-US",
+    );
+    expect(mockGetPageBySlug).not.toHaveBeenCalledWith(
+      "web-colombiatours",
+      "en/packages/cartagena-medellin",
+      "en-US",
+    );
+    expect(mockNotFound).not.toHaveBeenCalled();
+    expect(React.isValidElement(element)).toBe(true);
   });
 
   it("serves a published activity landing as indexable metadata when the product RPC misses", async () => {

--- a/app/site/[subdomain]/paquetes/[slug]/page.tsx
+++ b/app/site/[subdomain]/paquetes/[slug]/page.tsx
@@ -66,9 +66,12 @@ function localizedStaticPackageSlug(
   if (!localizedPathname) return `paquetes/${slug}`;
   const path = localizedPathname.replace(/^\/+|\/+$/g, "");
   if (!path || path === `paquetes/${slug}`) return `paquetes/${slug}`;
-  const parts = path.split("/");
+  const rawParts = path.split("/");
+  const parts = /^[a-z]{2}(?:-[a-z]{2})?$/i.test(rawParts[0] || "")
+    ? rawParts.slice(1)
+    : rawParts;
   if (parts.length < 2 || parts[parts.length - 1] !== slug) return null;
-  return path;
+  return parts.join("/");
 }
 
 async function resolveLegacyPackageSlug(

--- a/scripts/seo/audit-product-indexing-gate.mjs
+++ b/scripts/seo/audit-product-indexing-gate.mjs
@@ -13,6 +13,16 @@ const PRODUCT_PREFIXES = [
   "/packages/",
   "/activities/",
 ];
+const LOCALIZED_LISTING_PATHS = [
+  "/en/packages",
+  "/en/activities",
+  "/fr/forfaits",
+  "/fr/activites",
+  "/de/pakete",
+  "/de/aktivitaten",
+  "/pt-br/pacotes",
+  "/pt-br/atividades",
+];
 
 const args = parseArgs(process.argv.slice(2));
 const baseUrl = normalizeBaseUrl(args.baseUrl ?? DEFAULT_BASE_URL);
@@ -34,7 +44,13 @@ async function main() {
   const sitemapUrls = await readSitemapProductUrls(baseUrl);
   for (const url of sitemapUrls) addSource(urls, url, "sitemap");
 
-  for (const listingPath of ["/paquetes", "/actividades", "/packages", "/activities"]) {
+  for (const listingPath of [
+    "/paquetes",
+    "/actividades",
+    "/packages",
+    "/activities",
+    ...LOCALIZED_LISTING_PATHS,
+  ]) {
     const listingUrls = await readListingProductUrls(`${baseUrl}${listingPath}`);
     for (const url of listingUrls) addSource(urls, url, `listing:${listingPath}`);
   }
@@ -42,9 +58,8 @@ async function main() {
   if (includeDb) {
     const dbUrls = await readDbProductLikeUrls(baseUrl);
     for (const row of dbUrls) {
-      addSource(urls, row.url, row.source);
-      const current = urls.get(row.url);
-      current.db = row.db;
+      const current = addSource(urls, row.url, row.source);
+      if (current) current.db = row.db;
     }
   }
 
@@ -124,12 +139,13 @@ function normalizeBaseUrl(input) {
 }
 
 function addSource(map, url, source) {
-  if (!isProductLikeUrl(url)) return;
+  if (!isProductLikeUrl(url)) return null;
   const normalized = normalizeUrl(url);
-  if (!normalized) return;
+  if (!normalized) return null;
   const row = map.get(normalized) ?? { url: normalized, sources: [] };
   if (!row.sources.includes(source)) row.sources.push(source);
   map.set(normalized, row);
+  return row;
 }
 
 async function readSitemapProductUrls(siteBaseUrl) {
@@ -468,10 +484,20 @@ function normalizeUrl(value, origin = baseUrl) {
 function isProductLikeUrl(value) {
   try {
     const pathname = new URL(value, baseUrl).pathname;
-    return PRODUCT_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+    return PRODUCT_PREFIXES.some((prefix) =>
+      stripLocalePrefix(pathname).startsWith(prefix),
+    );
   } catch {
     return false;
   }
+}
+
+function stripLocalePrefix(pathname) {
+  const segments = pathname.split("/").filter(Boolean);
+  if (/^[a-z]{2}(?:-[a-z]{2})?$/i.test(segments[0] || "")) {
+    return `/${segments.slice(1).join("/")}`;
+  }
+  return pathname;
 }
 
 function matchFirst(value, pattern) {


### PR DESCRIPTION
## Summary
- fixes localized static package fallback so /en/packages/<slug> resolves DB slug packages/<slug> instead of en/packages/<slug>
- expands product indexing gate to include locale-prefixed product/activity URLs
- fixes the gate auditor DB metadata attachment on normalized URLs

## Verification
- node --check scripts/seo/audit-product-indexing-gate.mjs
- NODE_PATH=/Users/yeisongomez/Documents/Proyectos/Bukeer/bukeer-studio/node_modules node /Users/yeisongomez/Documents/Proyectos/Bukeer/bukeer-studio/node_modules/jest/bin/jest.js __tests__/app/product-static-landing-fallback.test.tsx --runInBand

## Current live evidence before this PR
- #605 deploy is green
- direct curl shows /en/packages/* currently returns HTTP 200 but includes Next 404/noindex metadata; this PR addresses that remaining localized static fallback blocker