### PR TITLE
fix(test): avoid spread in localized package mock

### DIFF
--- a/__tests__/app/product-static-landing-fallback.test.tsx
+++ b/__tests__/app/product-static-landing-fallback.test.tsx
@@ -73,8 +73,7 @@ jest.mock("@/lib/seo/public-metadata", () => ({
   buildLocaleAwareAlternateLanguages: (baseUrl: string, pathname: string) => ({
     "es-CO": `${baseUrl}${pathname}`,
   }),
-  resolvePublicMetadataLocale: (...args: unknown[]) =>
-    mockResolvePublicMetadataLocale(...args),
+  resolvePublicMetadataLocale: () => mockResolvePublicMetadataLocale(),
 }));
 
 jest.mock("@/lib/seo/locale-routing", () => ({


### PR DESCRIPTION
## Summary
- fixes the typecheck failure introduced by the localized static package fallback test
- removes the unknown[] spread from the mocked resolvePublicMetadataLocale implementation

## Verification
- NODE_PATH=/Users/yeisongomez/Documents/Proyectos/Bukeer/bukeer-studio/node_modules node /Users/yeisongomez/Documents/Proyectos/Bukeer/bukeer-studio/node_modules/jest/bin/jest.js __tests__/app/product-static-landing-fallback.test.tsx --runInBand