### PR TITLE
sync(seo): carry ColombiaTours indexability fixes to dev

### DIFF
--- a/__tests__/app/product-static-landing-fallback.test.tsx
+++ b/__tests__/app/product-static-landing-fallback.test.tsx
@@ -15,6 +15,12 @@ const mockGetProductPage = jest.fn();
 const mockGetPageBySlug = jest.fn();
 const mockGetProductSlugRedirect = jest.fn();
 const mockGetDestinations = jest.fn();
+const mockResolvePublicMetadataLocale = jest.fn(async () => ({
+  resolvedLocale: "es-CO",
+  defaultLocale: "es-CO",
+  resolvedLanguage: "es",
+  localizedPathname: "/paquetes/cartagena-medellin",
+}));
 const mockStaticPage = jest.fn((props: unknown) =>
   React.createElement("div", { "data-testid": "static-page", props }),
 );
@@ -66,11 +72,8 @@ jest.mock("@/lib/seo/public-metadata", () => ({
   buildLocaleAwareAlternateLanguages: (baseUrl: string, pathname: string) => ({
     "es-CO": `${baseUrl}${pathname}`,
   }),
-  resolvePublicMetadataLocale: jest.fn(async () => ({
-    resolvedLocale: "es-CO",
-    defaultLocale: "es-CO",
-    resolvedLanguage: "es",
-  })),
+  resolvePublicMetadataLocale: (...args: unknown[]) =>
+    mockResolvePublicMetadataLocale(...args),
 }));
 
 jest.mock("@/lib/seo/locale-routing", () => ({
@@ -134,6 +137,12 @@ describe("product static landing fallback", () => {
     mockGetProductPage.mockResolvedValue(null);
     mockGetProductSlugRedirect.mockResolvedValue(null);
     mockGetDestinations.mockResolvedValue([]);
+    mockResolvePublicMetadataLocale.mockResolvedValue({
+      resolvedLocale: "es-CO",
+      defaultLocale: "es-CO",
+      resolvedLanguage: "es",
+      localizedPathname: "/paquetes/cartagena-medellin",
+    });
   });
 
   it("serves a published package landing as indexable metadata when the product RPC misses", async () => {
@@ -172,6 +181,48 @@ describe("product static landing fallback", () => {
         }),
       }),
     );
+  });
+
+  it("serves a localized package landing from its DB slug without preserving the locale prefix", async () => {
+    mockResolvePublicMetadataLocale.mockResolvedValue({
+      resolvedLocale: "en-US",
+      defaultLocale: "es-CO",
+      resolvedLanguage: "en",
+      localizedPathname: "/en/packages/cartagena-medellin",
+    });
+    mockGetPageBySlug.mockResolvedValue(
+      makePublishedLanding("packages/cartagena-medellin"),
+    );
+
+    const metadata = await generatePackageMetadata({
+      params: Promise.resolve({
+        subdomain: "colombiatours",
+        slug: "cartagena-medellin",
+      }),
+    });
+    const element = await PackageSlugPage({
+      params: Promise.resolve({
+        subdomain: "colombiatours",
+        slug: "cartagena-medellin",
+      }),
+    });
+
+    expect(metadata.robots).toBeUndefined();
+    expect(metadata.alternates?.canonical).toBe(
+      "https://colombiatours.travel/en/packages/cartagena-medellin",
+    );
+    expect(mockGetPageBySlug).toHaveBeenCalledWith(
+      "web-colombiatours",
+      "packages/cartagena-medellin",
+      "en-US",
+    );
+    expect(mockGetPageBySlug).not.toHaveBeenCalledWith(
+      "web-colombiatours",
+      "en/packages/cartagena-medellin",
+      "en-US",
+    );
+    expect(mockNotFound).not.toHaveBeenCalled();
+    expect(React.isValidElement(element)).toBe(true);
   });
 
   it("serves a published activity landing as indexable metadata when the product RPC misses", async () => {

--- a/__tests__/app/product-static-landing-fallback.test.tsx
+++ b/__tests__/app/product-static-landing-fallback.test.tsx
@@ -55,6 +55,7 @@ jest.mock("@/lib/supabase/get-pages", () => ({
   getDestinations: (...args: unknown[]) => mockGetDestinations(...args),
   getLocalizedProductOverlay: jest.fn(),
   getPageBySlug: (...args: unknown[]) => mockGetPageBySlug(...args),
+  getPageBySlugForLocale: (...args: unknown[]) => mockGetPageBySlug(...args),
   getProductPage: (...args: unknown[]) => mockGetProductPage(...args),
   getProductSlugRedirect: (...args: unknown[]) =>
     mockGetProductSlugRedirect(...args),
@@ -72,8 +73,7 @@ jest.mock("@/lib/seo/public-metadata", () => ({
   buildLocaleAwareAlternateLanguages: (baseUrl: string, pathname: string) => ({
     "es-CO": `${baseUrl}${pathname}`,
   }),
-  resolvePublicMetadataLocale: (...args: unknown[]) =>
-    mockResolvePublicMetadataLocale(...args),
+  resolvePublicMetadataLocale: () => mockResolvePublicMetadataLocale(),
 }));
 
 jest.mock("@/lib/seo/locale-routing", () => ({
@@ -168,8 +168,9 @@ describe("product static landing fallback", () => {
       "https://colombiatours.travel/paquetes/cartagena-medellin",
     );
     expect(mockGetPageBySlug).toHaveBeenCalledWith(
-      "colombiatours",
+      "web-colombiatours",
       "paquetes/cartagena-medellin",
+      "es-CO",
     );
     expect(mockNotFound).not.toHaveBeenCalled();
     expect(React.isValidElement(element)).toBe(true);

--- a/app/site/[subdomain]/paquetes/[slug]/page.tsx
+++ b/app/site/[subdomain]/paquetes/[slug]/page.tsx
@@ -10,7 +10,7 @@ import {
   getCategoryProducts,
   getDestinations,
   getLocalizedProductOverlay,
-  getPageBySlug,
+  getPageBySlugForLocale,
   getProductPage,
   getProductSlugRedirect,
 } from "@/lib/supabase/get-pages";
@@ -57,6 +57,21 @@ function looksLikeLegacyId(value: string): boolean {
       value,
     )
   );
+}
+
+function localizedStaticPackageSlug(
+  slug: string,
+  localizedPathname?: string | null,
+): string | null {
+  if (!localizedPathname) return `paquetes/${slug}`;
+  const path = localizedPathname.replace(/^\/+|\/+$/g, "");
+  if (!path || path === `paquetes/${slug}`) return `paquetes/${slug}`;
+  const rawParts = path.split("/");
+  const parts = /^[a-z]{2}(?:-[a-z]{2})?$/i.test(rawParts[0] || "")
+    ? rawParts.slice(1)
+    : rawParts;
+  if (parts.length < 2 || parts[parts.length - 1] !== slug) return null;
+  return parts.join("/");
 }
 
 async function resolveLegacyPackageSlug(
@@ -106,8 +121,20 @@ export async function generateMetadata({
     locale: localeContext.resolvedLocale,
   });
   if (!productPage?.product) {
-    const fallbackLanding = await getPageBySlug(subdomain, `paquetes/${slug}`);
+    const staticSlug = localizedStaticPackageSlug(
+      slug,
+      localeContext.localizedPathname,
+    );
+    const fallbackLanding = staticSlug
+      ? await getPageBySlugForLocale(
+          String(website.id),
+          staticSlug,
+          localeContext.resolvedLocale,
+        )
+      : null;
     if (fallbackLanding?.is_published) {
+      const canonicalPathname =
+        localeContext.localizedPathname || `/${staticSlug}`;
       const title = normalizePublicMetadataTitle(
         fallbackLanding.seo_title || fallbackLanding.title,
         siteName,
@@ -136,7 +163,7 @@ export async function generateMetadata({
           ...(ogImage && { images: [ogImage] }),
         },
         alternates: {
-          canonical: `${baseUrl}/paquetes/${slug}`,
+          canonical: `${baseUrl}${canonicalPathname}`,
           languages: buildLocaleAwareAlternateLanguages(
             baseUrl,
             `/paquetes/${slug}`,
@@ -299,18 +326,13 @@ export default async function PackageSlugPage({ params }: PackagePageProps) {
     locale: resolvedLocale,
   });
   if (!productPage?.product) {
-    const redirectedSlug = website.account_id
-      ? await getProductSlugRedirect(
-          String(website.account_id),
-          "package",
-          slug,
-        )
+    const staticSlug = localizedStaticPackageSlug(
+      slug,
+      localeContext.localizedPathname,
+    );
+    const fallbackLanding = staticSlug
+      ? await getPageBySlugForLocale(String(website.id), staticSlug, resolvedLocale)
       : null;
-    if (redirectedSlug) {
-      permanentRedirect(`/site/${subdomain}/paquetes/${redirectedSlug}`);
-    }
-
-    const fallbackLanding = await getPageBySlug(subdomain, `paquetes/${slug}`);
     if (fallbackLanding?.is_published) {
       const isCustomDomain = inferIsCustomDomainWebsite(website);
       const websiteForRender = {
@@ -330,6 +352,16 @@ export default async function PackageSlugPage({ params }: PackagePageProps) {
       );
     }
 
+    const redirectedSlug = website.account_id
+      ? await getProductSlugRedirect(
+          String(website.account_id),
+          "package",
+          slug,
+        )
+      : null;
+    if (redirectedSlug) {
+      permanentRedirect(`/site/${subdomain}/paquetes/${redirectedSlug}`);
+    }
     notFound();
   }
 

--- a/lib/supabase/get-pages.ts
+++ b/lib/supabase/get-pages.ts
@@ -1890,7 +1890,7 @@ export async function getAllPageSlugs(subdomain: string): Promise<string[]> {
     // Get website first
     const { data: websiteData, error: websiteError } = await supabase
       .from("websites")
-      .select("id")
+      .select("id, default_locale")
       .eq("subdomain", subdomain)
       .eq("status", "published")
       .is("deleted_at", null)
@@ -1903,7 +1903,7 @@ export async function getAllPageSlugs(subdomain: string): Promise<string[]> {
     // Get all published pages
     const { data, error } = await supabase
       .from("website_pages")
-      .select("slug")
+      .select("slug, locale")
       .eq("website_id", websiteData.id)
       .eq("is_published", true);
 
@@ -1912,7 +1912,10 @@ export async function getAllPageSlugs(subdomain: string): Promise<string[]> {
       return [];
     }
 
-    return data.map((p) => p.slug);
+    const defaultLocale = websiteData.default_locale || "es-CO";
+    return data
+      .filter((p) => isDefaultLocalePage(p.locale, defaultLocale))
+      .map((p) => p.slug);
   } catch (e) {
     console.error("[getAllPageSlugs] Exception:", e);
     return [];
@@ -1929,7 +1932,7 @@ export async function getIndexablePageSlugs(
   try {
     const { data: websiteData, error: websiteError } = await supabase
       .from("websites")
-      .select("id")
+      .select("id, default_locale")
       .eq("subdomain", subdomain)
       .eq("status", "published")
       .is("deleted_at", null)
@@ -1941,7 +1944,7 @@ export async function getIndexablePageSlugs(
 
     const { data, error } = await supabase
       .from("website_pages")
-      .select("slug, robots_noindex")
+      .select("slug, robots_noindex, locale")
       .eq("website_id", websiteData.id)
       .eq("is_published", true);
 
@@ -1950,11 +1953,24 @@ export async function getIndexablePageSlugs(
       return [];
     }
 
-    return data.filter((p) => !p.robots_noindex).map((p) => p.slug);
+    const defaultLocale = websiteData.default_locale || "es-CO";
+    return data
+      .filter((p) => !p.robots_noindex)
+      .filter((p) => isDefaultLocalePage(p.locale, defaultLocale))
+      .map((p) => p.slug);
   } catch (e) {
     console.error("[getIndexablePageSlugs] Exception:", e);
     return [];
   }
+}
+
+function isDefaultLocalePage(
+  locale: string | null | undefined,
+  defaultLocale: string,
+): boolean {
+  if (!locale) return true;
+  if (locale === defaultLocale) return true;
+  return locale.split("-")[0]?.toLowerCase() === defaultLocale.split("-")[0]?.toLowerCase();
 }
 
 /**

--- a/scripts/seo/audit-product-indexing-gate.mjs
+++ b/scripts/seo/audit-product-indexing-gate.mjs
@@ -13,6 +13,16 @@ const PRODUCT_PREFIXES = [
   "/packages/",
   "/activities/",
 ];
+const LOCALIZED_LISTING_PATHS = [
+  "/en/packages",
+  "/en/activities",
+  "/fr/forfaits",
+  "/fr/activites",
+  "/de/pakete",
+  "/de/aktivitaten",
+  "/pt-br/pacotes",
+  "/pt-br/atividades",
+];
 
 const args = parseArgs(process.argv.slice(2));
 const baseUrl = normalizeBaseUrl(args.baseUrl ?? DEFAULT_BASE_URL);
@@ -34,7 +44,13 @@ async function main() {
   const sitemapUrls = await readSitemapProductUrls(baseUrl);
   for (const url of sitemapUrls) addSource(urls, url, "sitemap");
 
-  for (const listingPath of ["/paquetes", "/actividades", "/packages", "/activities"]) {
+  for (const listingPath of [
+    "/paquetes",
+    "/actividades",
+    "/packages",
+    "/activities",
+    ...LOCALIZED_LISTING_PATHS,
+  ]) {
     const listingUrls = await readListingProductUrls(`${baseUrl}${listingPath}`);
     for (const url of listingUrls) addSource(urls, url, `listing:${listingPath}`);
   }
@@ -42,9 +58,8 @@ async function main() {
   if (includeDb) {
     const dbUrls = await readDbProductLikeUrls(baseUrl);
     for (const row of dbUrls) {
-      addSource(urls, row.url, row.source);
-      const current = urls.get(row.url);
-      current.db = row.db;
+      const current = addSource(urls, row.url, row.source);
+      if (current) current.db = row.db;
     }
   }
 
@@ -124,12 +139,13 @@ function normalizeBaseUrl(input) {
 }
 
 function addSource(map, url, source) {
-  if (!isProductLikeUrl(url)) return;
+  if (!isProductLikeUrl(url)) return null;
   const normalized = normalizeUrl(url);
-  if (!normalized) return;
+  if (!normalized) return null;
   const row = map.get(normalized) ?? { url: normalized, sources: [] };
   if (!row.sources.includes(source)) row.sources.push(source);
   map.set(normalized, row);
+  return row;
 }
 
 async function readSitemapProductUrls(siteBaseUrl) {
@@ -468,10 +484,20 @@ function normalizeUrl(value, origin = baseUrl) {
 function isProductLikeUrl(value) {
   try {
     const pathname = new URL(value, baseUrl).pathname;
-    return PRODUCT_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+    return PRODUCT_PREFIXES.some((prefix) =>
+      stripLocalePrefix(pathname).startsWith(prefix),
+    );
   } catch {
     return false;
   }
+}
+
+function stripLocalePrefix(pathname) {
+  const segments = pathname.split("/").filter(Boolean);
+  if (/^[a-z]{2}(?:-[a-z]{2})?$/i.test(segments[0] || "")) {
+    return `/${segments.slice(1).join("/")}`;
+  }
+  return pathname;
 }
 
 function matchFirst(value, pattern) {

--- a/scripts/seo/audit-product-indexing-gate.mjs
+++ b/scripts/seo/audit-product-indexing-gate.mjs
@@ -167,7 +167,7 @@ async function readDbProductLikeUrls(siteBaseUrl) {
   const host = new URL(siteBaseUrl).hostname;
   const { data: website } = await client
     .from("websites")
-    .select("id, subdomain, custom_domain")
+    .select("id, subdomain, custom_domain, default_locale")
     .or(`custom_domain.eq.${host},subdomain.eq.${host.split(".")[0]}`)
     .maybeSingle();
 
@@ -175,7 +175,7 @@ async function readDbProductLikeUrls(siteBaseUrl) {
 
   const { data: pages } = await client
     .from("website_pages")
-    .select("id, slug, is_published, robots_noindex, page_type, category_type, updated_at")
+    .select("id, slug, locale, is_published, robots_noindex, page_type, category_type, updated_at")
     .eq("website_id", website.id)
     .eq("is_published", true)
     .or(
@@ -185,11 +185,12 @@ async function readDbProductLikeUrls(siteBaseUrl) {
   return (pages ?? [])
     .filter((page) => typeof page.slug === "string" && page.slug.length > 0)
     .map((page) => ({
-      url: `${siteBaseUrl}/${page.slug.replace(/^\/+/, "")}`,
+      url: `${siteBaseUrl}${publicPathForPageSlug(page, website)}`,
       source: "db:website_pages",
       db: {
         table: "website_pages",
         id: page.id,
+        locale: page.locale,
         is_published: page.is_published,
         robots_noindex: page.robots_noindex,
         page_type: page.page_type,
@@ -197,6 +198,19 @@ async function readDbProductLikeUrls(siteBaseUrl) {
         updated_at: page.updated_at,
       },
     }));
+}
+
+function publicPathForPageSlug(page, website) {
+  const slug = page.slug.replace(/^\/+/, "");
+  const locale = typeof page.locale === "string" ? page.locale : "";
+  const defaultLocale = website.default_locale || "es-CO";
+  if (!locale || locale === defaultLocale) return `/${slug}`;
+
+  const localeLanguage = locale.split("-")[0]?.toLowerCase();
+  const defaultLanguage = defaultLocale.split("-")[0]?.toLowerCase();
+  if (!localeLanguage || localeLanguage === defaultLanguage) return `/${slug}`;
+
+  return `/${localeLanguage}/${slug}`;
 }
 
 async function auditUrl(candidate) {


### PR DESCRIPTION
## Summary
- syncs the production ColombiaTours indexability fixes from main back into dev
- keeps localized product aliases out of the default sitemap
- preserves localized static package landings as indexable pages
- keeps the product indexing gate covering locale-prefixed product/activity URLs

## Verification
- node --check scripts/seo/audit-product-indexing-gate.mjs
- node node_modules/jest/bin/jest.js __tests__/app/product-static-landing-fallback.test.tsx --runInBand
- Production live gate after main deploy: PASS total=66 pass=46 p0=0 p1=0 p2=20