### PR TITLE
chore: add Weppa Node container workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,21 @@ artifacts
 *.log
 Dockerfile*
 docker-compose*.yml
+
+# Large local/audit assets are not needed for a Node runtime image.
+/*.png
+/*.jpg
+/*.jpeg
+/*.webp
+/*.html
+qa-screenshots
+eval-screenshots
+evidence
+output
+memory
+reports
+docs/audits
+docs/growth-sessions
+themes/references
+_elementor-research
+growth-os-infografias

--- a/.github/workflows/weppa-node-container.yml
+++ b/.github/workflows/weppa-node-container.yml
@@ -1,0 +1,74 @@
+name: Build Weppa Node container
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: GHCR image tag to publish
+        required: true
+        default: staging
+      source_ref:
+        description: Git ref to build
+        required: true
+        default: dev
+
+concurrency:
+  group: weppa-node-container-${{ github.event.inputs.image_tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.source_ref }}
+
+      - name: Resolve image revision
+        id: revision
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/weppa-cloud/booker-studio:${{ github.event.inputs.image_tag }}
+            ghcr.io/weppa-cloud/booker-studio:${{ steps.revision.outputs.sha }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ steps.revision.outputs.sha }}
+            weppa.cloud/runtime=node-nextjs
+          build-args: |
+            NEXT_PUBLIC_SUPABASE_URL=${{ secrets.SUPABASE_URL || 'https://example.supabase.co' }}
+            NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
+            NEXT_PUBLIC_API_BASE_URL=https://insforge.weppa.co
+            NEXT_PUBLIC_BASE_URL=https://booker-studio-staging.bukeer.k8s.weppa.co
+            NEXT_PUBLIC_URL=https://booker-studio-staging.bukeer.k8s.weppa.co
+            NEXT_PUBLIC_MAIN_DOMAIN=bukeer.com
+
+      - name: Summary
+        run: |
+          {
+            echo "Published:"
+            echo "- ghcr.io/weppa-cloud/booker-studio:${{ github.event.inputs.image_tag }}"
+            echo "- ghcr.io/weppa-cloud/booker-studio:${{ steps.revision.outputs.sha }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+FROM node:22-bookworm-slim AS deps
+
+WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1
+
+COPY package.json package-lock.json ./
+COPY packages ./packages
+RUN npm ci
+
+FROM node:22-bookworm-slim AS builder
+
+WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV NODE_ENV=production
+
+ARG NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY=placeholder-anon-key
+ARG NEXT_PUBLIC_API_BASE_URL=https://insforge.weppa.co
+ARG NEXT_PUBLIC_BASE_URL=http://localhost:3000
+ARG NEXT_PUBLIC_URL=http://localhost:3000
+ARG NEXT_PUBLIC_MAIN_DOMAIN=bukeer.com
+
+ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
+ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
+ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
+ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
+ENV NEXT_PUBLIC_URL=$NEXT_PUBLIC_URL
+ENV NEXT_PUBLIC_MAIN_DOMAIN=$NEXT_PUBLIC_MAIN_DOMAIN
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+RUN npm prune --omit=dev
+
+FROM node:22-bookworm-slim AS runner
+
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV HOSTNAME=0.0.0.0
+ENV PORT=3000
+
+RUN useradd --system --uid 1001 nextjs
+
+COPY --from=builder --chown=nextjs:nextjs /app/package.json ./package.json
+COPY --from=builder --chown=nextjs:nextjs /app/next.config.ts ./next.config.ts
+COPY --from=builder --chown=nextjs:nextjs /app/public ./public
+COPY --from=builder --chown=nextjs:nextjs /app/.next ./.next
+COPY --from=builder --chown=nextjs:nextjs /app/node_modules ./node_modules
+
+USER nextjs
+EXPOSE 3000
+
+CMD ["npm", "start"]


### PR DESCRIPTION
Adds the minimal Node 22 Dockerfile and manual GHCR workflow needed for the Weppa Node App Runtime staging pilot.\n\nScope:\n- Dockerfile for the Next.js web app runtime on port 3000.\n- Manual workflow_dispatch publishing ghcr.io/weppa-cloud/booker-studio:<tag>.\n- .dockerignore exclusions to keep large local/audit assets out of the container context.\n\nThis PR targets main because GitHub only exposes new workflow_dispatch workflows after the workflow file exists on the default branch.