### PR TITLE
security: read public account currency via SECURITY DEFINER RPC (drop raw anon accounts SELECT)

### DIFF
--- a/app/domain/[host]/[[...slug]]/page.tsx
+++ b/app/domain/[host]/[[...slug]]/page.tsx
@@ -79,10 +79,10 @@ async function getWebsiteByCustomDomain(customDomain: string): Promise<WebsiteDa
 
   const websiteData = website as unknown as WebsiteData;
   if (websiteData.account_id && websiteData.content.account) {
+    // Column-scoped public read (no PII) via SECURITY DEFINER RPC instead of a
+    // raw anon SELECT on `accounts` (lets us drop the broad anon RLS policy).
     const { data: accountCurrency } = await supabase
-      .from('accounts')
-      .select('primary_currency, enabled_currencies, currency')
-      .eq('id', websiteData.account_id)
+      .rpc('get_public_account_currency', { p_account_id: websiteData.account_id })
       .maybeSingle();
 
     if (accountCurrency) {

--- a/lib/supabase/get-website.ts
+++ b/lib/supabase/get-website.ts
@@ -208,10 +208,10 @@ async function hydrateWebsiteAnalyticsColumns(
 async function getAccountCurrencyColumns(
   accountId: string,
 ): Promise<AccountCurrencyColumns | null> {
+  // Column-scoped public read (no PII). Uses the SECURITY DEFINER RPC instead of
+  // a raw anon SELECT on `accounts`, so the broad anon RLS policy can be dropped.
   const { data, error } = await supabase
-    .from("accounts")
-    .select("primary_currency, enabled_currencies, currency")
-    .eq("id", accountId)
+    .rpc("get_public_account_currency", { p_account_id: accountId })
     .maybeSingle();
 
   if (error || !data) {


### PR DESCRIPTION
## Qué
El render del sitio público (`lib/supabase/get-website.ts` + `app/domain/[host]`) leía `accounts` con la clave **anon** (`.from('accounts').select('primary_currency, enabled_currencies, currency')`). Eso obligaba a una policy RLS amplia `accounts_select_anon USING(true)` en la DB (anon podía leer cualquier fila de `accounts`, no solo moneda).

Este PR reemplaza esas 2 lecturas por la RPC **column-scoped** `get_public_account_currency(account_id)` (SECURITY DEFINER, **ya desplegada en prod**), que devuelve **solo** las 3 columnas de moneda — sin PII (mail/phone/settings).

## Por qué
Cierra el último residual del hardening RLS de tablas core (`accounts`/`user_roles`/`roles`) hecho en bukeer-flutter. Una vez que esto despliegue, se puede **dropear la policy `accounts_select_anon`** (migración preparada y gateada en bukeer-flutter).

## Notas
- Sin cambio de comportamiento: la RPC devuelve los mismos campos (`primary_currency`, `enabled_currencies`, `currency`); el código downstream queda igual.
- Cliente público no tipado → sin cambios de tipos; `tsc --noEmit` limpio en los archivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)